### PR TITLE
Add comprehensive test suites and improve code formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,27 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
-  build:
-    runs-on: windows-latest
-    name: Build (Windows)
-
+  fmt:
+    runs-on: ubuntu-latest
+    name: Rustfmt
     steps:
       - uses: actions/checkout@v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
+  clippy:
+    runs-on: ubuntu-latest
+    name: Clippy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - name: Cache cargo registry & build
         uses: actions/cache@v4
         with:
@@ -28,9 +39,34 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: windows-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: clippy-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            windows-cargo-
+            clippy-cargo-
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: Test (${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-cargo-
       - name: Build workspace
-        run: cargo build --workspace
+        run: cargo build --workspace --all-targets
+      - name: Run tests
+        run: cargo test --workspace --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 name = "ars-plugin-synergos"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
+ "pretty_assertions",
  "serde",
  "synergos-ipc",
  "thiserror 2.0.18",
@@ -286,6 +288,12 @@ checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-broadcast"
@@ -525,12 +533,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -835,12 +837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,33 +939,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,16 +959,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +966,12 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1089,31 +1054,6 @@ checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1395,12 +1335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1424,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2933,16 +2878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +2938,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -3550,6 +3495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3592,6 +3546,12 @@ dependencies = [
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -3686,21 +3646,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3730,15 +3705,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3882,16 +3848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,20 +3915,24 @@ name = "synergos-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "blake3",
  "clap",
  "crc32fast",
  "dashmap",
- "libc",
+ "pretty_assertions",
  "serde",
+ "serial_test",
  "synergos-ipc",
  "synergos-net",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
 ]
 
@@ -3980,8 +3940,10 @@ dependencies = [
 name = "synergos-gui"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "eframe",
  "egui",
+ "pretty_assertions",
  "serde",
  "synergos-ipc",
  "thiserror 2.0.18",
@@ -3994,8 +3956,12 @@ dependencies = [
 name = "synergos-ipc"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
+ "pretty_assertions",
  "rmp-serde",
  "serde",
+ "serial_test",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4005,23 +3971,22 @@ dependencies = [
 name = "synergos-net"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "blake3",
  "bytes",
  "crc32fast",
  "dashmap",
- "ed25519-dalek",
- "hex",
  "hickory-resolver",
+ "pretty_assertions",
  "prost",
  "prost-build",
  "prost-types",
  "quinn",
- "rand 0.8.5",
  "rcgen",
- "rmp-serde",
  "rustls 0.23.37",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4375,6 +4340,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5501,6 +5487,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +951,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +996,16 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1054,6 +1103,31 @@ checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1333,6 +1407,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -2878,6 +2958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,6 +3773,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,6 +3806,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3848,6 +3958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +4041,7 @@ dependencies = [
  "clap",
  "crc32fast",
  "dashmap",
+ "libc",
  "pretty_assertions",
  "serde",
  "serial_test",
@@ -3977,13 +4098,17 @@ dependencies = [
  "bytes",
  "crc32fast",
  "dashmap",
+ "ed25519-dalek",
+ "hex",
  "hickory-resolver",
  "pretty_assertions",
  "prost",
  "prost-build",
  "prost-types",
  "quinn",
+ "rand 0.8.5",
  "rcgen",
+ "rmp-serde",
  "rustls 0.23.37",
  "serde",
  "tempfile",

--- a/ars-plugin-synergos/Cargo.toml
+++ b/ars-plugin-synergos/Cargo.toml
@@ -20,3 +20,8 @@ tracing = "0.1"
 
 # Error handling
 thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+pretty_assertions = "1"
+assert_matches = "1"

--- a/synergos-core/Cargo.toml
+++ b/synergos-core/Cargo.toml
@@ -41,3 +41,11 @@ anyhow = "1"
 # Unix peer credential check (SO_PEERCRED via libc::geteuid)
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+tempfile = "3"
+pretty_assertions = "1"
+assert_matches = "1"
+serial_test = "3"
+tracing-test = "0.2"

--- a/synergos-core/src/cli.rs
+++ b/synergos-core/src/cli.rs
@@ -156,16 +156,12 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Stop => {
             tracing::info!("Stopping Synergos core daemon...");
             let mut client = synergos_ipc::IpcClient::connect().await?;
-            client
-                .send(synergos_ipc::IpcCommand::Shutdown)
-                .await?;
+            client.send(synergos_ipc::IpcCommand::Shutdown).await?;
             println!("Daemon stopped.");
         }
         Command::Status => {
             let mut client = synergos_ipc::IpcClient::connect().await?;
-            let resp = client
-                .send(synergos_ipc::IpcCommand::Status)
-                .await?;
+            let resp = client.send(synergos_ipc::IpcCommand::Status).await?;
             match resp {
                 synergos_ipc::IpcResponse::Status(status) => {
                     println!("Synergos Core Daemon");
@@ -182,14 +178,15 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Transfer(cmd) => handle_transfer(cmd).await?,
         Command::Network => {
             let mut client = synergos_ipc::IpcClient::connect().await?;
-            let resp = client
-                .send(synergos_ipc::IpcCommand::NetworkStatus)
-                .await?;
+            let resp = client.send(synergos_ipc::IpcCommand::NetworkStatus).await?;
             match resp {
                 synergos_ipc::IpcResponse::NetworkStatus(info) => {
                     println!("Network Status");
                     println!("  Route:       {}", info.primary_route);
-                    println!("  Connections: {}/{}", info.active_connections, info.max_connections);
+                    println!(
+                        "  Connections: {}/{}",
+                        info.active_connections, info.max_connections
+                    );
                     println!("  Bandwidth:   {} bps", info.total_bandwidth_bps);
                     println!("  Latency:     {} ms", info.avg_latency_ms);
                 }
@@ -215,16 +212,12 @@ async fn handle_project(cmd: ProjectCommand) -> anyhow::Result<()> {
         }
         ProjectCommand::Close { id } => {
             client
-                .send(synergos_ipc::IpcCommand::ProjectClose {
-                    project_id: id,
-                })
+                .send(synergos_ipc::IpcCommand::ProjectClose { project_id: id })
                 .await?;
             println!("Project closed.");
         }
         ProjectCommand::List => {
-            let resp = client
-                .send(synergos_ipc::IpcCommand::ProjectList)
-                .await?;
+            let resp = client.send(synergos_ipc::IpcCommand::ProjectList).await?;
             if let synergos_ipc::IpcResponse::ProjectList(projects) = resp {
                 if projects.is_empty() {
                     println!("No active projects.");
@@ -248,7 +241,14 @@ async fn handle_project(cmd: ProjectCommand) -> anyhow::Result<()> {
                     println!("  Path:        {}", d.root_path);
                     println!("  Description: {}", d.description);
                     println!("  Sync mode:   {}", d.sync_mode);
-                    println!("  Max peers:   {}", if d.max_peers == 0 { "unlimited".to_string() } else { d.max_peers.to_string() });
+                    println!(
+                        "  Max peers:   {}",
+                        if d.max_peers == 0 {
+                            "unlimited".to_string()
+                        } else {
+                            d.max_peers.to_string()
+                        }
+                    );
                     println!("  Peers:       {}", d.peer_count);
                     println!("  Transfers:   {}", d.active_transfers);
                     if !d.connected_peer_ids.is_empty() {

--- a/synergos-core/src/conflict/mod.rs
+++ b/synergos-core/src/conflict/mod.rs
@@ -132,19 +132,16 @@ impl ConflictManager {
         }
 
         // 分岐点を特定: remote_block の prev_hash がチェーン内に存在するか探す
-        let (ancestor_hash, ancestor_version) =
-            if let Some(prev) = &remote_block.prev_hash {
-                // ローカルチェーンの中から一致するブロックを探す
-                let found = local_chain
-                    .blocks_iter()
-                    .find(|b| &b.hash == prev);
-                match found {
-                    Some(b) => (Some(b.hash.clone()), b.version),
-                    None => (None, 0),
-                }
-            } else {
-                (None, 0)
-            };
+        let (ancestor_hash, ancestor_version) = if let Some(prev) = &remote_block.prev_hash {
+            // ローカルチェーンの中から一致するブロックを探す
+            let found = local_chain.blocks_iter().find(|b| &b.hash == prev);
+            match found {
+                Some(b) => (Some(b.hash.clone()), b.version),
+                None => (None, 0),
+            }
+        } else {
+            (None, 0)
+        };
 
         let local_version = local_chain
             .blocks_iter()
@@ -208,11 +205,7 @@ impl ConflictManager {
                 entry.state = ConflictState::Resolved { resolution };
                 let resolved = entry.clone();
 
-                tracing::info!(
-                    "Conflict resolved for file {}: {:?}",
-                    file_id,
-                    resolution
-                );
+                tracing::info!("Conflict resolved for file {}: {:?}", file_id, resolution);
 
                 Ok(resolved)
             }

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -198,7 +198,11 @@ impl Daemon {
             if transfer.state == crate::exchange::TransferState::Running
                 || transfer.state == crate::exchange::TransferState::Queued
             {
-                let _ = self.ctx.exchange.cancel_transfer(&transfer.transfer_id).await;
+                let _ = self
+                    .ctx
+                    .exchange
+                    .cancel_transfer(&transfer.transfer_id)
+                    .await;
             }
         }
 

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -8,14 +8,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 
 use synergos_net::{
-    config::NetConfig,
-    conduit::Conduit,
-    dht::DhtNode,
-    gossip::GossipNode,
-    mesh::Mesh,
-    quic::QuicManager,
-    tunnel::TunnelManager,
-    types::PeerId,
+    conduit::Conduit, config::NetConfig, dht::DhtNode, gossip::GossipNode, mesh::Mesh,
+    quic::QuicManager, tunnel::TunnelManager, types::PeerId,
 };
 
 use crate::conflict::ConflictManager;
@@ -72,10 +66,7 @@ impl Daemon {
         let local_peer_id = PeerId::generate();
 
         // ── ネットワーク基盤コンポーネント ──
-        let dht = Arc::new(DhtNode::new(
-            local_peer_id.clone(),
-            net_config.dht.clone(),
-        ));
+        let dht = Arc::new(DhtNode::new(local_peer_id.clone(), net_config.dht.clone()));
         let gossip = Arc::new(GossipNode::new(
             local_peer_id.clone(),
             net_config.gossipsub.clone(),
@@ -103,8 +94,10 @@ impl Daemon {
 
         // ── サービスレイヤ ──
         let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
-        let project_manager =
-            Arc::new(ProjectManager::with_gossip(event_bus.clone(), Some(gossip.clone())));
+        let project_manager = Arc::new(ProjectManager::with_gossip(
+            event_bus.clone(),
+            Some(gossip.clone()),
+        ));
         let exchange = Arc::new(Exchange::with_network(
             event_bus.clone(),
             local_peer_id.clone(),
@@ -226,10 +219,7 @@ fn load_net_config(path: Option<&std::path::Path>) -> anyhow::Result<NetConfig> 
             Ok(cfg)
         }
         Some(p) => {
-            tracing::warn!(
-                "Config file not found at {}; using defaults",
-                p.display()
-            );
+            tracing::warn!("Config file not found at {}; using defaults", p.display());
             Ok(NetConfig::default())
         }
         None => Ok(NetConfig::default()),

--- a/synergos-core/src/event_bus.rs
+++ b/synergos-core/src/event_bus.rs
@@ -53,13 +53,10 @@ impl CoreEventBus {
     /// 初回購読時にチャンネルが自動作成される。
     pub fn subscribe<E: CoreEvent>(&self) -> broadcast::Receiver<E> {
         let type_id = TypeId::of::<E>();
-        let entry = self
-            .channels
-            .entry(type_id)
-            .or_insert_with(|| {
-                let (tx, _) = broadcast::channel::<E>(CHANNEL_CAPACITY);
-                Box::new(tx)
-            });
+        let entry = self.channels.entry(type_id).or_insert_with(|| {
+            let (tx, _) = broadcast::channel::<E>(CHANNEL_CAPACITY);
+            Box::new(tx)
+        });
         entry
             .downcast_ref::<broadcast::Sender<E>>()
             .expect("type mismatch in EventBus")
@@ -167,3 +164,107 @@ impl CoreEvent for NetworkStatusEvent {
 
 /// EventBus の共有参照型
 pub type SharedEventBus = Arc<CoreEventBus>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use pretty_assertions::assert_eq;
+    use tokio::sync::broadcast::error::TryRecvError;
+
+    // テスト用の独立したイベント型（他テストとの TypeId 衝突を避けるためここだけで定義）
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct AlphaEvent(u32);
+    impl CoreEvent for AlphaEvent {
+        fn event_name() -> &'static str {
+            "alpha"
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct BetaEvent(String);
+    impl CoreEvent for BetaEvent {
+        fn event_name() -> &'static str {
+            "beta"
+        }
+    }
+
+    /// T-EB-01: emit_without_subscriber_is_noop — 受信者ゼロでも emit がパニックしない
+    #[test]
+    fn emit_without_subscriber_is_noop() {
+        let bus = CoreEventBus::new();
+        // チャンネル未作成状態で emit → 何も起きない
+        bus.emit(AlphaEvent(1));
+        bus.emit(BetaEvent("x".into()));
+        // パニックしなければ OK
+    }
+
+    /// T-EB-02: subscribe_then_emit_delivers — 購読 → 発行 → 受信できる
+    #[tokio::test(flavor = "current_thread")]
+    async fn subscribe_then_emit_delivers() {
+        let bus = CoreEventBus::new();
+        let mut rx = bus.subscribe::<AlphaEvent>();
+
+        bus.emit(AlphaEvent(42));
+
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got, AlphaEvent(42));
+    }
+
+    /// T-EB-03: multiple_subscribers_all_receive — 複数受信者にブロードキャストされる
+    #[tokio::test(flavor = "current_thread")]
+    async fn multiple_subscribers_all_receive() {
+        let bus = CoreEventBus::new();
+        let mut rx1 = bus.subscribe::<AlphaEvent>();
+        let mut rx2 = bus.subscribe::<AlphaEvent>();
+        let mut rx3 = bus.subscribe::<AlphaEvent>();
+
+        bus.emit(AlphaEvent(7));
+
+        assert_eq!(rx1.recv().await.unwrap(), AlphaEvent(7));
+        assert_eq!(rx2.recv().await.unwrap(), AlphaEvent(7));
+        assert_eq!(rx3.recv().await.unwrap(), AlphaEvent(7));
+    }
+
+    /// T-EB-04: type_isolation — 型が違うイベントは混線しない
+    #[tokio::test(flavor = "current_thread")]
+    async fn type_isolation() {
+        let bus = CoreEventBus::new();
+        let mut alpha_rx = bus.subscribe::<AlphaEvent>();
+        let mut beta_rx = bus.subscribe::<BetaEvent>();
+
+        bus.emit(AlphaEvent(100));
+        bus.emit(BetaEvent("hello".into()));
+
+        assert_eq!(alpha_rx.recv().await.unwrap(), AlphaEvent(100));
+        assert_eq!(beta_rx.recv().await.unwrap(), BetaEvent("hello".into()));
+
+        // 交差受信していないことを確認
+        assert_matches!(alpha_rx.try_recv(), Err(TryRecvError::Empty));
+        assert_matches!(beta_rx.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    /// T-EB-05: late_subscriber_misses_old_events — 発行後に購読した受信者は過去分を受け取らない
+    #[tokio::test(flavor = "current_thread")]
+    async fn late_subscriber_misses_old_events() {
+        let bus = CoreEventBus::new();
+
+        // 早期購読者は受信できるが…
+        let mut early = bus.subscribe::<AlphaEvent>();
+        bus.emit(AlphaEvent(1));
+
+        // 後から購読した受信者は過去の 1 を受け取らない
+        let mut late = bus.subscribe::<AlphaEvent>();
+
+        // 新しい発行は両方受け取る
+        bus.emit(AlphaEvent(2));
+
+        assert_eq!(early.recv().await.unwrap(), AlphaEvent(1));
+        assert_eq!(early.recv().await.unwrap(), AlphaEvent(2));
+
+        assert_eq!(late.recv().await.unwrap(), AlphaEvent(2));
+        // late がもう受信できる値を持っていないことを確認
+        assert_matches!(late.try_recv(), Err(TryRecvError::Empty));
+    }
+}

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -13,11 +13,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use synergos_net::chain::{LedgerEntryState, OfferEntry, TransferLedger, WantEntry, LedgerAction};
+use synergos_net::chain::{LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry};
 use synergos_net::gossip::{GossipMessage, GossipNode};
 use synergos_net::types::{Blake3Hash, FileId, PeerId, TopicId, TransferId};
 
-use crate::event_bus::{SharedEventBus, TransferProgressEvent, TransferCompletedEvent};
+use crate::event_bus::{SharedEventBus, TransferCompletedEvent, TransferProgressEvent};
 
 // ── 型定義 ──
 
@@ -271,12 +271,7 @@ impl Exchange {
     }
 
     /// Gossipsub 経由で CatalogUpdate をブロードキャスト
-    fn broadcast_catalog_update(
-        &self,
-        project_id: &str,
-        root_crc: u32,
-        update_count: u64,
-    ) {
+    fn broadcast_catalog_update(&self, project_id: &str, root_crc: u32, update_count: u64) {
         if let Some(gossip) = &self.gossip {
             let topic = TopicId::project(project_id);
             gossip.publish(
@@ -517,11 +512,7 @@ impl FileSharing for Exchange {
 
         // Gossipsub で CatalogUpdate をブロードキャスト
         if let Some(first) = notifications.first() {
-            self.broadcast_catalog_update(
-                &first.project_id,
-                total_crc,
-                notifications.len() as u64,
-            );
+            self.broadcast_catalog_update(&first.project_id, total_crc, notifications.len() as u64);
         }
 
         Ok(())
@@ -553,11 +544,8 @@ impl FileSharing for Exchange {
 
                 // TransferLedger で Want をキャンセル
                 if transfer.direction == TransferDirection::Receive {
-                    self.ledger.cancel_want(
-                        &transfer.file_id,
-                        0,
-                        &self.local_peer_id,
-                    );
+                    self.ledger
+                        .cancel_want(&transfer.file_id, 0, &self.local_peer_id);
                 }
 
                 Ok(())

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -211,9 +211,7 @@ impl Exchange {
     pub fn gc_finished_transfers(&self) -> usize {
         let mut removed = 0;
         self.transfers.retain(|_, t| match &t.state {
-            TransferState::Completed
-            | TransferState::Cancelled
-            | TransferState::Failed(_) => {
+            TransferState::Completed | TransferState::Cancelled | TransferState::Failed(_) => {
                 removed += 1;
                 false
             }
@@ -301,11 +299,8 @@ impl Exchange {
             });
 
             // TransferLedger で fulfilled をマーク
-            self.ledger.mark_fulfilled(
-                &transfer.file_id,
-                transfer.version,
-                &transfer.peer_id,
-            );
+            self.ledger
+                .mark_fulfilled(&transfer.file_id, transfer.version, &transfer.peer_id);
         }
     }
 

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -921,11 +921,7 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
                     .iter()
                     .filter(|p| p.rtt_ms.is_some())
                     .count() as u32;
-                if count > 0 {
-                    total_rtt / count
-                } else {
-                    0
-                }
+                total_rtt.checked_div(count).unwrap_or(0)
             };
 
             let primary_route = connected_peers

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -107,7 +107,7 @@ impl IpcServer {
                         Err(e) => {
                             tracing::error!("Accept error: {}", e);
                             // 指数バックオフ (最大 1s)
-                            backoff_ms = (backoff_ms * 2).max(10).min(1000);
+                            backoff_ms = (backoff_ms * 2).clamp(10, 1000);
                             tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                         }
                     }
@@ -170,7 +170,7 @@ impl IpcServer {
                         Ok(n) => n,
                         Err(e) => {
                             tracing::error!("failed to create next pipe instance: {e}");
-                            backoff_ms = (backoff_ms * 2).max(10).min(1000);
+                            backoff_ms = (backoff_ms * 2).clamp(10, 1000);
                             tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                             continue;
                         }
@@ -187,7 +187,7 @@ impl IpcServer {
                 }
                 Err(e) => {
                     tracing::error!("Named pipe accept error: {e}");
-                    backoff_ms = (backoff_ms * 2).max(10).min(1000);
+                    backoff_ms = (backoff_ms * 2).clamp(10, 1000);
                     tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                 }
             }
@@ -268,7 +268,6 @@ where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
     W: tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
-
     // Subscribe 起動時にここへタスクハンドルを保持。Unsubscribe / 切断時に abort。
     let mut event_relay: Option<tokio::task::JoinHandle<()>> = None;
 
@@ -333,10 +332,7 @@ where
     Ok(())
 }
 
-async fn send_server_message<W>(
-    writer: &Arc<Mutex<W>>,
-    msg: ServerMessage,
-) -> Result<(), IpcError>
+async fn send_server_message<W>(writer: &Arc<Mutex<W>>, msg: ServerMessage) -> Result<(), IpcError>
 where
     W: tokio::io::AsyncWrite + Unpin,
 {
@@ -346,11 +342,8 @@ where
 
 /// EventBus → クライアントへ IpcEvent を中継する per-client タスク。
 /// `filter` に合致しないイベントはスキップ。
-async fn relay_events<W>(
-    ctx: Arc<ServiceContext>,
-    writer: Arc<Mutex<W>>,
-    filters: Vec<EventFilter>,
-) where
+async fn relay_events<W>(ctx: Arc<ServiceContext>, writer: Arc<Mutex<W>>, filters: Vec<EventFilter>)
+where
     W: tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     // `filter_event` に渡す際に参照渡しにしたいので slice で借用する形に。

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -201,28 +201,24 @@ type SharedWriter = Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>;
 
 /// 接続元 UID が自プロセス UID と一致するか確認する。
 ///
-/// 非 Unix や UCred 非対応プラットフォームでは許容する (Windows は別経路)。
+/// `std::os::unix::net::UCred::uid()` は現在 nightly 限定の unstable API
+/// なので libc 直接呼び出しで実装する:
+/// - Linux: `getsockopt(SO_PEERCRED)` → `struct ucred { pid, uid, gid }`
+/// - macOS / iOS / FreeBSD: `getpeereid(fd, &uid, &gid)`
+/// - それ以外の Unix は uid 取得を諦めて許容 (ベストエフォート)。
 #[cfg(unix)]
 fn verify_peer_uid(stream: &tokio::net::UnixStream) -> Result<(), String> {
     use std::os::unix::io::AsRawFd;
-    // SAFETY: `stream` は生きている UnixStream。借用期間内でのみ fd を触る。
-    // std の UnixStream::peer_cred を借りるために unsafe FromRawFd + ManuallyDrop パターン。
     let fd = stream.as_raw_fd();
-    let std_stream = unsafe {
-        use std::os::unix::io::FromRawFd;
-        std::mem::ManuallyDrop::new(std::os::unix::net::UnixStream::from_raw_fd(fd))
-    };
-    let cred = match std_stream.peer_cred() {
-        Ok(c) => c,
+
+    let peer_uid = match peer_uid_of_fd(fd) {
+        Ok(u) => u,
         Err(e) => {
-            // peer_cred が取れない OS (macOS 等旧バージョン) は allow (ベストエフォート)
             tracing::debug!("peer_cred unavailable, skipping uid check: {e}");
             return Ok(());
         }
     };
-    let peer_uid = cred.uid();
-    // 自プロセス UID
-    // SAFETY: libc call with no side effects; always succeeds.
+    // SAFETY: libc::geteuid is side-effect-free and always succeeds.
     let self_uid = unsafe { libc::geteuid() };
     if peer_uid != self_uid {
         return Err(format!(
@@ -230,6 +226,63 @@ fn verify_peer_uid(stream: &tokio::net::UnixStream) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn peer_uid_of_fd(fd: std::os::unix::io::RawFd) -> std::io::Result<libc::uid_t> {
+    // SAFETY: libc::ucred は POD。getsockopt が成功した場合のみ書き込まれる。
+    unsafe {
+        let mut cred: libc::ucred = std::mem::zeroed();
+        let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        let ret = libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut cred as *mut _ as *mut libc::c_void,
+            &mut len,
+        );
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(cred.uid)
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+))]
+fn peer_uid_of_fd(fd: std::os::unix::io::RawFd) -> std::io::Result<libc::uid_t> {
+    // SAFETY: getpeereid fills uid/gid when the call succeeds.
+    unsafe {
+        let mut uid: libc::uid_t = 0;
+        let mut gid: libc::gid_t = 0;
+        let ret = libc::getpeereid(fd, &mut uid, &mut gid);
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(uid)
+    }
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))
+))]
+fn peer_uid_of_fd(_fd: std::os::unix::io::RawFd) -> std::io::Result<libc::uid_t> {
+    // illumos / solaris / hermit など未対応 Unix はベストエフォートで自プロセス UID を返す。
+    // SAFETY: geteuid is side-effect-free.
+    unsafe { Ok(libc::geteuid()) }
 }
 
 /// Windows Named Pipe 接続のハンドリング。Unix 版と共通の dispatch/relay

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -539,9 +539,7 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
             let transfers = ctx.exchange.list_transfers(None).await;
             let active_transfers = transfers
                 .iter()
-                .filter(|t| {
-                    t.state == TransferState::Running || t.state == TransferState::Queued
-                })
+                .filter(|t| t.state == TransferState::Running || t.state == TransferState::Queued)
                 .count();
 
             let peers = ctx.presence.list_nodes(None).await;
@@ -561,7 +559,6 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
         }
 
         // ── プロジェクト管理 ──
-
         IpcCommand::ProjectOpen {
             project_id,
             root_path,
@@ -659,7 +656,6 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
         },
 
         // ── ピア管理 ──
-
         IpcCommand::PeerList { project_id } => {
             let nodes = ctx.presence.list_nodes(Some(&project_id)).await;
             let peers: Vec<PeerInfo> = nodes
@@ -713,7 +709,6 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
         }
 
         // ── ファイル転送 ──
-
         IpcCommand::TransferRequest {
             project_id,
             file_id,
@@ -759,11 +754,7 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
         }
 
         IpcCommand::TransferCancel { transfer_id } => {
-            match ctx
-                .exchange
-                .cancel_transfer(&TransferId(transfer_id))
-                .await
-            {
+            match ctx.exchange.cancel_transfer(&TransferId(transfer_id)).await {
                 Ok(()) => IpcResponse::Ok,
                 Err(e) => IpcResponse::Error {
                     code: 3,
@@ -868,7 +859,6 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
         }
 
         // ── モニタリング ──
-
         IpcCommand::NetworkStatus => {
             let peers = ctx.presence.list_nodes(None).await;
             let connected_peers: Vec<_> = peers
@@ -880,15 +870,16 @@ async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcRespo
             let avg_latency = if connected_peers.is_empty() {
                 0
             } else {
-                let total_rtt: u32 = connected_peers
-                    .iter()
-                    .filter_map(|p| p.rtt_ms)
-                    .sum();
+                let total_rtt: u32 = connected_peers.iter().filter_map(|p| p.rtt_ms).sum();
                 let count = connected_peers
                     .iter()
                     .filter(|p| p.rtt_ms.is_some())
                     .count() as u32;
-                if count > 0 { total_rtt / count } else { 0 }
+                if count > 0 {
+                    total_rtt / count
+                } else {
+                    0
+                }
             };
 
             let primary_route = connected_peers

--- a/synergos-core/src/presence/mod.rs
+++ b/synergos-core/src/presence/mod.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use synergos_net::dht::{DhtNode, PeerRecord};
-use synergos_net::gossip::{GossipMessage, GossipNode, PeerActivityStatus, ActivityState};
+use synergos_net::gossip::{ActivityState, GossipMessage, GossipNode, PeerActivityStatus};
 use synergos_net::types::{PeerId, Route, TopicId};
 
 use crate::event_bus::{PeerConnectedEvent, PeerDisconnectedEvent, SharedEventBus};

--- a/synergos-core/src/project.rs
+++ b/synergos-core/src/project.rs
@@ -448,10 +448,7 @@ impl ProjectConfiguration for ProjectManager {
             return Ok(project_id);
         }
 
-        tracing::info!(
-            "Joining project {} via invite (path redacted)",
-            project_id
-        );
+        tracing::info!("Joining project {} via invite (path redacted)", project_id);
 
         // リモートからのプロジェクト設定取得は Gossipsub 経由で非同期に行われる
         self.open_project(project_id.clone(), root_path, None)

--- a/synergos-core/src/project.rs
+++ b/synergos-core/src/project.rs
@@ -260,11 +260,7 @@ impl ProjectConfiguration for ProjectManager {
             return Err(ProjectError::AlreadyExists(project_id));
         }
 
-        tracing::info!(
-            "Opening project: {} at {}",
-            project_id,
-            root_path.display()
-        );
+        tracing::info!("Opening project: {} at {}", project_id, root_path.display());
 
         let settings = ProjectSettings {
             display_name: display_name.unwrap_or_else(|| project_id.clone()),
@@ -301,11 +297,12 @@ impl ProjectConfiguration for ProjectManager {
 
                 // EventBus にプロジェクトクローズを通知（Presence/Exchange が購読して処理）
                 for peer_id in &project.connected_peer_ids {
-                    self.event_bus.emit(crate::event_bus::PeerDisconnectedEvent {
-                        project_id: project_id.to_string(),
-                        peer_id: peer_id.clone(),
-                        reason: "project closed".to_string(),
-                    });
+                    self.event_bus
+                        .emit(crate::event_bus::PeerDisconnectedEvent {
+                            project_id: project_id.to_string(),
+                            peer_id: peer_id.clone(),
+                            reason: "project closed".to_string(),
+                        });
                 }
 
                 Ok(())
@@ -457,7 +454,8 @@ impl ProjectConfiguration for ProjectManager {
         );
 
         // リモートからのプロジェクト設定取得は Gossipsub 経由で非同期に行われる
-        self.open_project(project_id.clone(), root_path, None).await?;
+        self.open_project(project_id.clone(), root_path, None)
+            .await?;
 
         Ok(project_id)
     }

--- a/synergos-gui/Cargo.toml
+++ b/synergos-gui/Cargo.toml
@@ -28,3 +28,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Error handling
 thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+pretty_assertions = "1"
+assert_matches = "1"

--- a/synergos-gui/src/connection.rs
+++ b/synergos-gui/src/connection.rs
@@ -126,9 +126,7 @@ impl CoreConnection {
 
     /// 転送一覧をリフレッシュ
     pub fn refresh_transfers(&self) {
-        let resp = self.send_command(IpcCommand::TransferList {
-            project_id: None,
-        });
+        let resp = self.send_command(IpcCommand::TransferList { project_id: None });
         if let Some(synergos_ipc::IpcResponse::TransferList(transfers)) = resp {
             let mut cache = self.cache.lock().unwrap();
             cache.transfers = transfers;

--- a/synergos-gui/src/ui/overview.rs
+++ b/synergos-gui/src/ui/overview.rs
@@ -28,7 +28,10 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection, inputs: &mut UiInput
                     ui.end_row();
 
                     ui.label("Active Peers:");
-                    ui.label(format!("{}/{}", net.active_connections, net.max_connections));
+                    ui.label(format!(
+                        "{}/{}",
+                        net.active_connections, net.max_connections
+                    ));
                     ui.end_row();
 
                     ui.label("Bandwidth:");
@@ -122,22 +125,16 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection, inputs: &mut UiInput
                     ui.horizontal(|ui| {
                         if ui.button("Invite").clicked() {
                             inputs.selected_project_id = p.project_id.clone();
-                            let expires =
-                                inputs.invite_expires_secs.trim().parse::<u64>().ok();
+                            let expires = inputs.invite_expires_secs.trim().parse::<u64>().ok();
                             match connection.create_invite(&p.project_id, expires) {
                                 Some((token, _exp)) => {
                                     inputs.last_invite_token = Some(token);
                                     inputs.invite_error = None;
-                                    inputs.set_ok(format!(
-                                        "invite created for {}",
-                                        p.project_id
-                                    ));
+                                    inputs.set_ok(format!("invite created for {}", p.project_id));
                                 }
                                 None => {
-                                    inputs.invite_error = Some(format!(
-                                        "invite failed for {}",
-                                        p.project_id
-                                    ));
+                                    inputs.invite_error =
+                                        Some(format!("invite failed for {}", p.project_id));
                                     inputs.set_err("invite failed");
                                 }
                             }

--- a/synergos-gui/src/ui/transfers.rs
+++ b/synergos-gui/src/ui/transfers.rs
@@ -74,7 +74,11 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection, inputs: &mut UiInput
 
             for t in &transfers {
                 // 方向アイコン
-                let dir_icon = if t.direction == "upload" { "↑" } else { "↓" };
+                let dir_icon = if t.direction == "upload" {
+                    "↑"
+                } else {
+                    "↓"
+                };
                 ui.label(dir_icon);
 
                 ui.label(&t.file_name);
@@ -85,8 +89,8 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection, inputs: &mut UiInput
                 } else {
                     0.0
                 };
-                let bar = egui::ProgressBar::new(progress)
-                    .text(format!("{:.0}%", progress * 100.0));
+                let bar =
+                    egui::ProgressBar::new(progress).text(format!("{:.0}%", progress * 100.0));
                 ui.add_sized([120.0, 16.0], bar);
 
                 ui.label(format_speed(t.speed_bps));

--- a/synergos-ipc/Cargo.toml
+++ b/synergos-ipc/Cargo.toml
@@ -17,3 +17,10 @@ thiserror = "2"
 
 # Logging
 tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["io-util", "net", "sync", "macros", "rt", "rt-multi-thread", "test-util", "time"] }
+tempfile = "3"
+pretty_assertions = "1"
+assert_matches = "1"
+serial_test = "3"

--- a/synergos-ipc/src/client.rs
+++ b/synergos-ipc/src/client.rs
@@ -131,10 +131,7 @@ impl IpcClient {
 
     /// イベントを受信する
     pub async fn recv_event(&mut self) -> Result<IpcEvent, IpcError> {
-        self.event_rx
-            .recv()
-            .await
-            .ok_or(IpcError::ConnectionClosed)
+        self.event_rx.recv().await.ok_or(IpcError::ConnectionClosed)
     }
 
     /// デーモンが稼働中かチェック

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -11,7 +11,6 @@ use crate::event::EventFilter;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum IpcCommand {
     // ── デーモン制御 ──
-
     /// 疎通確認
     Ping,
     /// デーモン停止
@@ -20,7 +19,6 @@ pub enum IpcCommand {
     Status,
 
     // ── プロジェクト管理 ──
-
     /// プロジェクトを開く（ネットワーク参加）
     ProjectOpen {
         project_id: String,
@@ -29,15 +27,11 @@ pub enum IpcCommand {
         display_name: Option<String>,
     },
     /// プロジェクトを閉じる（ネットワーク離脱）
-    ProjectClose {
-        project_id: String,
-    },
+    ProjectClose { project_id: String },
     /// 管理中のプロジェクト一覧
     ProjectList,
     /// プロジェクトの詳細情報を取得
-    ProjectGet {
-        project_id: String,
-    },
+    ProjectGet { project_id: String },
     /// プロジェクト設定を更新
     ProjectUpdate {
         project_id: String,
@@ -60,23 +54,14 @@ pub enum IpcCommand {
     },
 
     // ── ピア管理 ──
-
     /// 接続中のピア一覧
-    PeerList {
-        project_id: String,
-    },
+    PeerList { project_id: String },
     /// 指定ピアに接続
-    PeerConnect {
-        project_id: String,
-        peer_id: String,
-    },
+    PeerConnect { project_id: String, peer_id: String },
     /// 指定ピアを切断
-    PeerDisconnect {
-        peer_id: String,
-    },
+    PeerDisconnect { peer_id: String },
 
     // ── ファイル転送 ──
-
     /// ファイル転送リクエスト
     TransferRequest {
         project_id: String,
@@ -84,13 +69,9 @@ pub enum IpcCommand {
         peer_id: String,
     },
     /// アクティブ転送一覧
-    TransferList {
-        project_id: Option<String>,
-    },
+    TransferList { project_id: Option<String> },
     /// 転送をキャンセル
-    TransferCancel {
-        transfer_id: String,
-    },
+    TransferCancel { transfer_id: String },
     /// ファイル更新を公開
     PublishUpdate {
         project_id: String,
@@ -98,15 +79,10 @@ pub enum IpcCommand {
     },
 
     // ── モニタリング ──
-
     /// ネットワーク状態取得
     NetworkStatus,
     /// イベント購読開始
-    Subscribe {
-        events: Vec<EventFilter>,
-    },
+    Subscribe { events: Vec<EventFilter> },
     /// イベント購読解除
-    Unsubscribe {
-        subscription_id: String,
-    },
+    Unsubscribe { subscription_id: String },
 }

--- a/synergos-ipc/src/response.rs
+++ b/synergos-ipc/src/response.rs
@@ -11,10 +11,7 @@ pub enum IpcResponse {
     Ok,
 
     /// エラー
-    Error {
-        code: u32,
-        message: String,
-    },
+    Error { code: u32, message: String },
 
     /// Ping 応答
     Pong,
@@ -44,9 +41,7 @@ pub enum IpcResponse {
     NetworkStatus(NetworkStatusInfo),
 
     /// イベント購読完了
-    Subscribed {
-        subscription_id: String,
-    },
+    Subscribed { subscription_id: String },
 }
 
 /// デーモン状態

--- a/synergos-ipc/src/transport.rs
+++ b/synergos-ipc/src/transport.rs
@@ -55,9 +55,10 @@ pub enum ServerMessage {
 pub fn socket_path() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
-        let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
-            .unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(runtime_dir).join("synergos").join("synergos.sock")
+        let runtime_dir = std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/tmp".to_string());
+        PathBuf::from(runtime_dir)
+            .join("synergos")
+            .join("synergos.sock")
     }
 
     #[cfg(target_os = "macos")]
@@ -144,5 +145,236 @@ impl IpcTransport {
         }
         let message = rmp_serde::from_slice(&payload)?;
         Ok(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::IpcCommand;
+    use crate::event::{EventCategory, EventFilter, IpcEvent};
+    use crate::response::{DaemonStatus, IpcResponse};
+    use assert_matches::assert_matches;
+    use pretty_assertions::assert_eq;
+    use serde::{Deserialize, Serialize};
+    use std::path::PathBuf;
+    use tokio::io::{duplex, AsyncWriteExt};
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct Sample {
+        id: u32,
+        name: String,
+    }
+
+    /// T-IPC-01: write_read_roundtrip — write_message で書き込んだものが read_message で読み戻せる
+    #[tokio::test]
+    async fn write_read_roundtrip() {
+        let (mut a, mut b) = duplex(4096);
+        let sent = Sample {
+            id: 42,
+            name: "hello".to_string(),
+        };
+
+        IpcTransport::write_message(&mut a, &sent).await.unwrap();
+        let received: Sample = IpcTransport::read_message(&mut b).await.unwrap();
+
+        assert_eq!(sent, received);
+    }
+
+    /// T-IPC-02: read_eof_returns_connection_closed — 書き込み側が閉じると ConnectionClosed が返る
+    #[tokio::test]
+    async fn read_eof_returns_connection_closed() {
+        let (a, mut b) = duplex(64);
+        drop(a);
+
+        let result: Result<Sample, _> = IpcTransport::read_message(&mut b).await;
+
+        assert_matches!(result, Err(IpcError::ConnectionClosed));
+    }
+
+    /// T-IPC-03: message_too_large_write — 書き込み時の上限超過チェック
+    #[tokio::test]
+    async fn message_too_large_write() {
+        // 16 MiB + α のデータ（MessagePack エンコード後に MAX を超える）
+        let big: Vec<u8> = vec![0u8; (MAX_MESSAGE_SIZE as usize) + 1024];
+
+        // duplex バッファは小さいが、サイズ判定で事前に弾かれるため実書き込みは起きない
+        let (mut a, _b) = duplex(64);
+        let result = IpcTransport::write_message(&mut a, &big).await;
+
+        assert_matches!(result, Err(IpcError::MessageTooLarge { .. }));
+    }
+
+    /// T-IPC-04: message_too_large_read — 巨大なヘッダ長が届いたときに MessageTooLarge で弾く
+    #[tokio::test]
+    async fn message_too_large_read() {
+        let (mut a, mut b) = duplex(64);
+
+        // MAX + 1 のヘッダのみ書き込む（payload は届けない）
+        let oversized = (MAX_MESSAGE_SIZE + 1).to_le_bytes();
+        a.write_all(&oversized).await.unwrap();
+        a.flush().await.unwrap();
+        drop(a);
+
+        let result: Result<Sample, _> = IpcTransport::read_message(&mut b).await;
+
+        assert_matches!(
+            result,
+            Err(IpcError::MessageTooLarge { size, max })
+                if size == MAX_MESSAGE_SIZE + 1 && max == MAX_MESSAGE_SIZE
+        );
+    }
+
+    /// T-IPC-05: partial_header_eof — 4 byte ヘッダ未満で EOF → ConnectionClosed
+    #[tokio::test]
+    async fn partial_header_eof() {
+        let (mut a, mut b) = duplex(64);
+        a.write_all(&[0x01, 0x02]).await.unwrap(); // 2 byte だけ
+        a.flush().await.unwrap();
+        drop(a);
+
+        let result: Result<Sample, _> = IpcTransport::read_message(&mut b).await;
+
+        assert_matches!(result, Err(IpcError::ConnectionClosed));
+    }
+
+    /// T-IPC-06: multiple_messages_streamed — 同じストリームで複数メッセージが順に読める
+    #[tokio::test]
+    async fn multiple_messages_streamed() {
+        let (mut a, mut b) = duplex(8192);
+
+        let m1 = Sample {
+            id: 1,
+            name: "one".to_string(),
+        };
+        let m2 = Sample {
+            id: 2,
+            name: "two".to_string(),
+        };
+        let m3 = Sample {
+            id: 3,
+            name: "three".to_string(),
+        };
+
+        IpcTransport::write_message(&mut a, &m1).await.unwrap();
+        IpcTransport::write_message(&mut a, &m2).await.unwrap();
+        IpcTransport::write_message(&mut a, &m3).await.unwrap();
+
+        let r1: Sample = IpcTransport::read_message(&mut b).await.unwrap();
+        let r2: Sample = IpcTransport::read_message(&mut b).await.unwrap();
+        let r3: Sample = IpcTransport::read_message(&mut b).await.unwrap();
+
+        assert_eq!((m1, m2, m3), (r1, r2, r3));
+    }
+
+    /// T-IPC-07: socket_path_linux_uses_xdg_runtime_dir — XDG_RUNTIME_DIR を反映
+    ///
+    /// 環境変数を書き換えるため `serial_test` で直列実行。
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial]
+    #[test]
+    fn socket_path_linux_uses_xdg_runtime_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let original = std::env::var("XDG_RUNTIME_DIR").ok();
+
+        // SAFETY: serial_test で直列化されているため他テストと競合しない
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", tmp.path());
+        }
+
+        let path = socket_path();
+        assert_eq!(path, tmp.path().join("synergos").join("synergos.sock"));
+
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+    }
+
+    /// T-IPC-07b: socket_path_linux_fallback_tmp — XDG_RUNTIME_DIR 未設定時は /tmp
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial]
+    #[test]
+    fn socket_path_linux_fallback_tmp() {
+        let original = std::env::var("XDG_RUNTIME_DIR").ok();
+
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
+
+        let path = socket_path();
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp").join("synergos").join("synergos.sock")
+        );
+
+        unsafe {
+            if let Some(v) = original {
+                std::env::set_var("XDG_RUNTIME_DIR", v);
+            }
+        }
+    }
+
+    /// T-IPC-08: command_response_event_serde_full — 主要な IPC 型の往復シリアライズ
+    #[tokio::test]
+    async fn command_response_event_serde_full() {
+        // IpcCommand::ProjectOpen
+        let cmd = IpcCommand::ProjectOpen {
+            project_id: "proj-1".to_string(),
+            root_path: PathBuf::from("/tmp/proj"),
+            display_name: Some("My Project".to_string()),
+        };
+        let (mut a, mut b) = duplex(8192);
+        IpcTransport::write_message(&mut a, &cmd).await.unwrap();
+        let decoded: IpcCommand = IpcTransport::read_message(&mut b).await.unwrap();
+        assert_matches!(
+            decoded,
+            IpcCommand::ProjectOpen { ref project_id, ref display_name, .. }
+                if project_id == "proj-1" && display_name.as_deref() == Some("My Project")
+        );
+
+        // IpcResponse::Status
+        let resp = IpcResponse::Status(DaemonStatus {
+            pid: 12345,
+            started_at: 1_700_000_000,
+            project_count: 2,
+            active_connections: 3,
+            active_transfers: 4,
+        });
+        let (mut a, mut b) = duplex(8192);
+        IpcTransport::write_message(&mut a, &resp).await.unwrap();
+        let decoded: IpcResponse = IpcTransport::read_message(&mut b).await.unwrap();
+        assert_matches!(
+            decoded,
+            IpcResponse::Status(s) if s.pid == 12345 && s.active_transfers == 4
+        );
+
+        // IpcEvent::ConflictDetected
+        let ev = IpcEvent::ConflictDetected {
+            project_id: "proj-1".to_string(),
+            file_id: "f-1".to_string(),
+            file_path: "/a/b.txt".to_string(),
+            involved_peers: vec!["peer-a".to_string(), "peer-b".to_string()],
+        };
+        let (mut a, mut b) = duplex(8192);
+        IpcTransport::write_message(&mut a, &ev).await.unwrap();
+        let decoded: IpcEvent = IpcTransport::read_message(&mut b).await.unwrap();
+        assert_matches!(
+            decoded,
+            IpcEvent::ConflictDetected { ref involved_peers, .. } if involved_peers.len() == 2
+        );
+
+        // EventFilter (全バリアント)
+        let filters = vec![
+            EventFilter::All,
+            EventFilter::Project("p".to_string()),
+            EventFilter::Category(EventCategory::Transfer),
+        ];
+        let (mut a, mut b) = duplex(8192);
+        IpcTransport::write_message(&mut a, &filters).await.unwrap();
+        let decoded: Vec<EventFilter> = IpcTransport::read_message(&mut b).await.unwrap();
+        assert_eq!(decoded.len(), 3);
     }
 }

--- a/synergos-ipc/src/transport.rs
+++ b/synergos-ipc/src/transport.rs
@@ -36,7 +36,7 @@ pub enum IpcError {
 }
 
 /// 最大メッセージサイズ (1 MiB) — DoS 対策のため小さめに設定
-pub const MAX_MESSAGE_SIZE: u32 = 1 * 1024 * 1024;
+pub const MAX_MESSAGE_SIZE: u32 = 1024 * 1024;
 
 /// 1 回の read で確保するチャンクサイズ上限（ピーク確保量制限）
 const READ_CHUNK: usize = 64 * 1024;

--- a/synergos-net/Cargo.toml
+++ b/synergos-net/Cargo.toml
@@ -41,3 +41,9 @@ rcgen = "0.13"
 
 [build-dependencies]
 prost-build = "0.13"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+tempfile = "3"
+pretty_assertions = "1"
+assert_matches = "1"

--- a/synergos-net/src/catalog/manager.rs
+++ b/synergos-net/src/catalog/manager.rs
@@ -62,8 +62,10 @@ impl CatalogManager {
         }
 
         // チェーンを初期化
-        self.chains
-            .insert(file_id.clone(), FileChain::new(file_id.clone(), self.chain_max_depth));
+        self.chains.insert(
+            file_id.clone(),
+            FileChain::new(file_id.clone(), self.chain_max_depth),
+        );
         self.file_to_chunk.insert(file_id.clone(), chunk_id.clone());
 
         // カタログ CRC を更新
@@ -76,10 +78,9 @@ impl CatalogManager {
     /// ファイル更新をチェーンに記録 + カタログ CRC 更新
     pub async fn record_update(&self, file_id: &FileId, block: ChainBlock) -> Result<()> {
         // 1. FileChain にブロック追加
-        let mut chain = self
-            .chains
-            .get_mut(file_id)
-            .ok_or_else(|| SynergosNetError::PeerNotFound(format!("File not found: {}", file_id)))?;
+        let mut chain = self.chains.get_mut(file_id).ok_or_else(|| {
+            SynergosNetError::PeerNotFound(format!("File not found: {}", file_id))
+        })?;
         chain.append(block)?;
 
         // 2. FileEntry の CRC を更新
@@ -167,7 +168,10 @@ impl CatalogManager {
     }
 
     /// ファイルのチェーンを取得
-    pub fn get_chain(&self, file_id: &FileId) -> Option<dashmap::mapref::one::Ref<'_, FileId, FileChain>> {
+    pub fn get_chain(
+        &self,
+        file_id: &FileId,
+    ) -> Option<dashmap::mapref::one::Ref<'_, FileId, FileChain>> {
         self.chains.get(file_id)
     }
 

--- a/synergos-net/src/chain/file_chain.rs
+++ b/synergos-net/src/chain/file_chain.rs
@@ -109,9 +109,7 @@ impl ChainBlock {
         let mut clone = self.clone();
         clone.compute_hash();
         if clone.hash != self.hash {
-            return Err(SynergosNetError::Gossip(
-                "ChainBlock hash mismatch".into(),
-            ));
+            return Err(SynergosNetError::Gossip("ChainBlock hash mismatch".into()));
         }
         identity::verify(
             &self.author_public_key,

--- a/synergos-net/src/chain/file_chain.rs
+++ b/synergos-net/src/chain/file_chain.rs
@@ -44,13 +44,21 @@ impl ChainBlock {
                 hasher.update(patch.as_bytes());
                 hasher.update(&result_crc.to_le_bytes());
             }
-            ChainPayload::BinaryCid { cid, file_size, crc } => {
+            ChainPayload::BinaryCid {
+                cid,
+                file_size,
+                crc,
+            } => {
                 hasher.update(b"binary_cid");
                 hasher.update(cid.0.as_bytes());
                 hasher.update(&file_size.to_le_bytes());
                 hasher.update(&crc.to_le_bytes());
             }
-            ChainPayload::FullSnapshot { cid, file_size, crc } => {
+            ChainPayload::FullSnapshot {
+                cid,
+                file_size,
+                crc,
+            } => {
                 hasher.update(b"full_snapshot");
                 hasher.update(cid.0.as_bytes());
                 hasher.update(&file_size.to_le_bytes());
@@ -124,22 +132,11 @@ impl ChainBlock {
 #[derive(Debug, Clone)]
 pub enum ChainPayload {
     /// テキストファイルの差分（unified diff）
-    TextDiff {
-        patch: String,
-        result_crc: u32,
-    },
+    TextDiff { patch: String, result_crc: u32 },
     /// バイナリファイルの IPFS CID 参照
-    BinaryCid {
-        cid: Cid,
-        file_size: u64,
-        crc: u32,
-    },
+    BinaryCid { cid: Cid, file_size: u64, crc: u32 },
     /// フルスナップショット（初回 or 定期ベースライン）
-    FullSnapshot {
-        cid: Cid,
-        file_size: u64,
-        crc: u32,
-    },
+    FullSnapshot { cid: Cid, file_size: u64, crc: u32 },
 }
 
 /// ファイルごとの更新チェーン
@@ -223,12 +220,10 @@ impl FileChain {
     /// 2 つのチェーンの共通祖先を見つける
     pub fn find_common_ancestor(&self, remote_chain: &FileChain) -> Option<&ChainBlock> {
         // ローカルのブロックを逆順に走査し、リモートにも存在するものを探す
-        for local_block in self.blocks.iter().rev() {
-            if remote_chain.find_block(&local_block.hash).is_some() {
-                return Some(local_block);
-            }
-        }
-        None
+        self.blocks
+            .iter()
+            .rev()
+            .find(|local_block| remote_chain.find_block(&local_block.hash).is_some())
     }
 }
 

--- a/synergos-net/src/conduit/mod.rs
+++ b/synergos-net/src/conduit/mod.rs
@@ -13,7 +13,7 @@ use crate::error::{Result, SynergosNetError};
 use crate::mesh::{Mesh, ProbeResult};
 use crate::quic::{QuicConnectionInfo, QuicManager};
 use crate::tunnel::{TunnelManager, TunnelState};
-use crate::types::{ConnectionState, PeerId, PeerEndpoint, Route, RouteKind};
+use crate::types::{ConnectionState, PeerEndpoint, PeerId, Route, RouteKind};
 
 /// 経路検出結果
 #[derive(Debug, Clone)]
@@ -203,9 +203,7 @@ impl Conduit {
 
     /// 指定ピアの接続状態を取得
     pub fn get_peer_state(&self, peer_id: &PeerId) -> Option<ConnectionState> {
-        self.peers
-            .get(peer_id)
-            .map(|entry| entry.state.clone())
+        self.peers.get(peer_id).map(|entry| entry.state.clone())
     }
 
     /// Route Migration: より高優先度の経路が利用可能になった場合に切り替え
@@ -296,9 +294,9 @@ impl Conduit {
         let (ipv6, tunnel) = tokio::join!(ipv6_probe, tunnel_probe);
 
         let recommended = match (ipv6.reachable, tunnel.available) {
-            (true, _) => RouteKind::Direct,   // IPv6 最優先
+            (true, _) => RouteKind::Direct,     // IPv6 最優先
             (false, true) => RouteKind::Tunnel, // Tunnel フォールバック
-            (false, false) => RouteKind::Relay,  // WebSocket リレー
+            (false, false) => RouteKind::Relay, // WebSocket リレー
         };
 
         DetectionResult {
@@ -334,20 +332,18 @@ impl Conduit {
     }
 
     /// 経路の優先度順に接続を試行
-    async fn try_connect_routes(
-        &self,
-        peer_id: &PeerId,
-        routes: &[Route],
-    ) -> Result<RouteKind> {
+    async fn try_connect_routes(&self, peer_id: &PeerId, routes: &[Route]) -> Result<RouteKind> {
         // 1. IPv6 Direct を試行
         for route in routes {
             if let Route::Direct { addr, fqdn } = route {
-                let server_name = fqdn
-                    .as_deref()
-                    .unwrap_or("synergos");
+                let server_name = fqdn.as_deref().unwrap_or("synergos");
                 match self
                     .quic
-                    .connect(peer_id.clone(), std::net::SocketAddr::V6(*addr), server_name)
+                    .connect(
+                        peer_id.clone(),
+                        std::net::SocketAddr::V6(*addr),
+                        server_name,
+                    )
                     .await
                 {
                     Ok(()) => return Ok(RouteKind::Direct),

--- a/synergos-net/src/dht/routing.rs
+++ b/synergos-net/src/dht/routing.rs
@@ -114,11 +114,8 @@ impl RoutingTable {
 
     /// 指定 NodeId に最も近い k 個のノードを返す
     pub fn closest(&self, target: &NodeId, count: usize) -> Vec<&BucketEntry> {
-        let mut all_entries: Vec<&BucketEntry> = self
-            .buckets
-            .iter()
-            .flat_map(|b| b.entries.iter())
-            .collect();
+        let mut all_entries: Vec<&BucketEntry> =
+            self.buckets.iter().flat_map(|b| b.entries.iter()).collect();
 
         all_entries.sort_by(|a, b| {
             let dist_a = target.xor_distance(&a.node_id);

--- a/synergos-net/src/gossip/node.rs
+++ b/synergos-net/src/gossip/node.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 use dashmap::DashMap;
 use tokio::sync::broadcast;
 
-use super::message::*;
 use super::message::canonical_bytes;
+use super::message::*;
 use crate::config::GossipsubConfig;
 use crate::identity::Identity;
 use crate::types::{MessageId, PeerId, TopicId};

--- a/synergos-net/src/gossip/node.rs
+++ b/synergos-net/src/gossip/node.rs
@@ -119,7 +119,7 @@ impl GossipNode {
 
     /// Topic を購読（プロジェクト参加時）
     pub fn subscribe(&self, topic: TopicId) {
-        self.mesh.entry(topic).or_insert_with(Vec::new);
+        self.mesh.entry(topic).or_default();
     }
 
     /// Topic から退出

--- a/synergos-net/src/identity.rs
+++ b/synergos-net/src/identity.rs
@@ -132,20 +132,19 @@ impl Identity {
                 return PathBuf::from(state).join("synergos").join("identity.key");
             }
             if let Ok(home) = std::env::var("HOME") {
-                return PathBuf::from(home)
-                    .join(".local/state/synergos/identity.key");
+                return PathBuf::from(home).join(".local/state/synergos/identity.key");
             }
-            return PathBuf::from("/tmp/synergos-identity.key");
+            PathBuf::from("/tmp/synergos-identity.key")
         }
 
         #[cfg(target_os = "macos")]
         {
             let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-            return PathBuf::from(home)
+            PathBuf::from(home)
                 .join("Library")
                 .join("Application Support")
                 .join("Synergos")
-                .join("identity.key");
+                .join("identity.key")
         }
 
         #[cfg(target_os = "windows")]
@@ -154,7 +153,7 @@ impl Identity {
                 .ok()
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from("."));
-            return base.join("Synergos").join("identity.key");
+            base.join("Synergos").join("identity.key")
         }
     }
 }
@@ -179,10 +178,10 @@ pub fn verify(
     message: &[u8],
     signature: &[u8; 64],
 ) -> Result<(), IdentityError> {
-    let vk = VerifyingKey::from_bytes(public_key)
-        .map_err(|_| IdentityError::VerifyFailed)?;
+    let vk = VerifyingKey::from_bytes(public_key).map_err(|_| IdentityError::VerifyFailed)?;
     let sig = Signature::from_bytes(signature);
-    vk.verify(message, &sig).map_err(|_| IdentityError::VerifyFailed)
+    vk.verify(message, &sig)
+        .map_err(|_| IdentityError::VerifyFailed)
 }
 
 #[cfg(test)]
@@ -206,10 +205,7 @@ mod tests {
 
     #[test]
     fn load_or_generate_persists_same_peer_id() {
-        let tmp = std::env::temp_dir().join(format!(
-            "synergos-id-{}.key",
-            uuid::Uuid::new_v4()
-        ));
+        let tmp = std::env::temp_dir().join(format!("synergos-id-{}.key", uuid::Uuid::new_v4()));
         let a = Identity::load_or_generate(&tmp).unwrap();
         let pid_a = a.peer_id().clone();
         drop(a);

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -26,7 +26,9 @@ pub use config::NetConfig;
 pub use dht::DhtNode;
 pub use error::{Result, SynergosNetError};
 pub use gossip::{GossipMessage, GossipNode};
-pub use identity::{peer_id_from_public_bytes, verify as verify_signature, Identity, IdentityError};
+pub use identity::{
+    peer_id_from_public_bytes, verify as verify_signature, Identity, IdentityError,
+};
 pub use mesh::Mesh;
 pub use quic::{CalibratedParams, ConnectionCalibrator, QuicManager, SpeedTestResult};
 pub use tunnel::{TunnelManager, TunnelState};

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -28,7 +28,7 @@ pub use error::{Result, SynergosNetError};
 pub use gossip::{GossipMessage, GossipNode};
 pub use identity::{peer_id_from_public_bytes, verify as verify_signature, Identity, IdentityError};
 pub use mesh::Mesh;
-pub use quic::{QuicManager, SpeedTestResult, CalibratedParams, ConnectionCalibrator};
+pub use quic::{CalibratedParams, ConnectionCalibrator, QuicManager, SpeedTestResult};
 pub use tunnel::{TunnelManager, TunnelState};
 pub use types::*;
 

--- a/synergos-net/src/mesh/mod.rs
+++ b/synergos-net/src/mesh/mod.rs
@@ -280,12 +280,11 @@ impl Mesh {
 
     /// 期限切れの TURN セッションをクリーンアップ
     pub fn cleanup_expired_sessions(&self) {
-        self.turn_sessions.retain(|_, session| {
-            match session.expires_at {
+        self.turn_sessions
+            .retain(|_, session| match session.expires_at {
                 Some(exp) => Instant::now() < exp,
                 None => true,
-            }
-        });
+            });
     }
 
     /// アクティブな TURN セッション一覧を取得
@@ -308,10 +307,8 @@ impl Mesh {
         use hickory_resolver::config::{ResolverConfig, ResolverOpts};
         use hickory_resolver::TokioAsyncResolver;
 
-        let resolver = TokioAsyncResolver::tokio(
-            ResolverConfig::cloudflare_https(),
-            ResolverOpts::default(),
-        );
+        let resolver =
+            TokioAsyncResolver::tokio(ResolverConfig::cloudflare_https(), ResolverOpts::default());
 
         let response = resolver
             .ipv6_lookup(fqdn)
@@ -329,10 +326,8 @@ impl Mesh {
         use hickory_resolver::config::{ResolverConfig, ResolverOpts};
         use hickory_resolver::TokioAsyncResolver;
 
-        let resolver = TokioAsyncResolver::tokio(
-            ResolverConfig::default(),
-            ResolverOpts::default(),
-        );
+        let resolver =
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
 
         let response = resolver
             .ipv6_lookup(fqdn)

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -360,10 +360,8 @@ impl QuicManager {
                 _server_name: &rustls::pki_types::ServerName<'_>,
                 _ocsp: &[u8],
                 _now: rustls::pki_types::UnixTime,
-            ) -> std::result::Result<
-                rustls::client::danger::ServerCertVerified,
-                rustls::Error,
-            > {
+            ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error>
+            {
                 Ok(rustls::client::danger::ServerCertVerified::assertion())
             }
             fn verify_tls12_signature(
@@ -371,10 +369,8 @@ impl QuicManager {
                 _message: &[u8],
                 _cert: &rustls::pki_types::CertificateDer<'_>,
                 _dss: &rustls::DigitallySignedStruct,
-            ) -> std::result::Result<
-                rustls::client::danger::HandshakeSignatureValid,
-                rustls::Error,
-            > {
+            ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+            {
                 Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
             }
             fn verify_tls13_signature(
@@ -382,10 +378,8 @@ impl QuicManager {
                 _message: &[u8],
                 _cert: &rustls::pki_types::CertificateDer<'_>,
                 _dss: &rustls::DigitallySignedStruct,
-            ) -> std::result::Result<
-                rustls::client::danger::HandshakeSignatureValid,
-                rustls::Error,
-            > {
+            ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+            {
                 Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
             }
             fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -236,11 +236,7 @@ impl QuicManager {
             .await
             .map_err(|e| SynergosNetError::Quic(format!("Failed to open stream: {}", e)))?;
 
-        tracing::debug!(
-            "Opened {:?} stream to peer {}",
-            stream_type,
-            peer_id
-        );
+        tracing::debug!("Opened {:?} stream to peer {}", stream_type, peer_id);
 
         // ストリーム数を更新
         drop(entry);
@@ -267,13 +263,15 @@ impl QuicManager {
 
     /// コネクション情報を取得
     pub fn get_connection(&self, peer_id: &PeerId) -> Option<QuicConnectionInfo> {
-        self.connections.get(peer_id).map(|entry| QuicConnectionInfo {
-            peer_id: entry.peer_id.clone(),
-            remote_addr: entry.remote_addr,
-            active_streams: entry.active_streams,
-            state: entry.state.clone(),
-            rtt_ms: entry.rtt_ms,
-        })
+        self.connections
+            .get(peer_id)
+            .map(|entry| QuicConnectionInfo {
+                peer_id: entry.peer_id.clone(),
+                remote_addr: entry.remote_addr,
+                active_streams: entry.active_streams,
+                state: entry.state.clone(),
+                rtt_ms: entry.rtt_ms,
+            })
     }
 
     /// 全接続の情報を取得
@@ -440,11 +438,10 @@ impl QuicManager {
                 .unwrap_or_else(|_| quinn::IdleTimeout::from(quinn::VarInt::from_u32(30_000))),
         ));
 
-        let mut server_config =
-            quinn::ServerConfig::with_crypto(Arc::new(
-                quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)
-                    .map_err(|e| SynergosNetError::Quic(format!("QUIC config error: {}", e)))?,
-            ));
+        let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(
+            quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)
+                .map_err(|e| SynergosNetError::Quic(format!("QUIC config error: {}", e)))?,
+        ));
         server_config.transport_config(Arc::new(transport));
 
         Ok(server_config)

--- a/synergos-net/src/transfer/mod.rs
+++ b/synergos-net/src/transfer/mod.rs
@@ -63,11 +63,7 @@ pub struct TransferFooter {
 ///
 /// ヘッダの `total_hash` / `total_size` / `chunk_count` は呼び出し側が
 /// 事前に計算して渡す。(ローカルで `hash_file` を事前実行する想定)
-pub async fn send_stream<R, W>(
-    mut reader: R,
-    mut writer: W,
-    header: TransferHeader,
-) -> Result<()>
+pub async fn send_stream<R, W>(mut reader: R, mut writer: W, header: TransferHeader) -> Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -112,10 +108,7 @@ where
 
 /// 受信側: `reader` (QUIC bidi の recv side) から読み、検証しながら `out_path`
 /// へ書く。完了時にヘッダと一致する全体ハッシュを返す。
-pub async fn receive_stream<R>(
-    mut reader: R,
-    out_path: &Path,
-) -> Result<TransferHeader>
+pub async fn receive_stream<R>(mut reader: R, out_path: &Path) -> Result<TransferHeader>
 where
     R: AsyncRead + Unpin,
 {
@@ -181,9 +174,7 @@ where
                 return Ok(header);
             }
             FrameKind::Header(_) => {
-                return Err(SynergosNetError::Transfer(
-                    "duplicate header frame".into(),
-                ));
+                return Err(SynergosNetError::Transfer("duplicate header frame".into()));
             }
         }
     }
@@ -207,9 +198,13 @@ pub async fn hash_file(path: &Path) -> Result<(Blake3Hash, u64, u64)> {
     let chunk_count = if total == 0 {
         0
     } else {
-        (total + CHUNK_SIZE as u64 - 1) / CHUNK_SIZE as u64
+        total.div_ceil(CHUNK_SIZE as u64)
     };
-    Ok((Blake3Hash(*hasher.finalize().as_bytes()), total, chunk_count))
+    Ok((
+        Blake3Hash(*hasher.finalize().as_bytes()),
+        total,
+        chunk_count,
+    ))
 }
 
 // ---- 内部 I/O ----
@@ -256,8 +251,10 @@ mod tests {
     #[tokio::test]
     async fn roundtrip_small_file() {
         // 10 KiB のランダムデータをメモリ上の双方向パイプで送受信する。
-        let tmp_src = std::env::temp_dir().join(format!("synergos-tx-src-{}", uuid::Uuid::new_v4()));
-        let tmp_dst = std::env::temp_dir().join(format!("synergos-tx-dst-{}", uuid::Uuid::new_v4()));
+        let tmp_src =
+            std::env::temp_dir().join(format!("synergos-tx-src-{}", uuid::Uuid::new_v4()));
+        let tmp_dst =
+            std::env::temp_dir().join(format!("synergos-tx-dst-{}", uuid::Uuid::new_v4()));
         let data = vec![42u8; 10 * 1024];
         tokio::fs::write(&tmp_src, &data).await.unwrap();
 
@@ -276,9 +273,8 @@ mod tests {
 
         let (tx, rx) = duplex(64 * 1024);
         let src_reader = tokio::fs::File::open(&tmp_src).await.unwrap();
-        let send_task = tokio::spawn(async move {
-            send_stream(src_reader, tx, header.clone()).await
-        });
+        let send_task =
+            tokio::spawn(async move { send_stream(src_reader, tx, header.clone()).await });
         let dst_path = tmp_dst.clone();
         let recv_task = tokio::spawn(async move { receive_stream(rx, &dst_path).await });
 
@@ -314,7 +310,9 @@ mod tests {
             chunk_count: 1,
             total_hash: Blake3Hash(*blake3::hash(b"hello").as_bytes()),
         };
-        write_frame(&mut tx, &FrameKind::Header(header)).await.unwrap();
+        write_frame(&mut tx, &FrameKind::Header(header))
+            .await
+            .unwrap();
 
         // データは "hello" だが hash は "WORLD" 版にすり替える (改竄)。
         let bad = ChunkFrame {

--- a/synergos-net/src/tunnel/mod.rs
+++ b/synergos-net/src/tunnel/mod.rs
@@ -18,14 +18,9 @@ pub enum TunnelState {
     /// 起動中
     Starting,
     /// 稼働中
-    Active {
-        tunnel_id: String,
-        uptime_secs: u64,
-    },
+    Active { tunnel_id: String, uptime_secs: u64 },
     /// エラー
-    Error {
-        message: String,
-    },
+    Error { message: String },
 }
 
 /// Tunnel ヘルスチェック結果
@@ -110,7 +105,11 @@ impl TunnelManager {
                     tunnel_id: tunnel_id.clone(),
                     uptime_secs: 0,
                 };
-                tracing::info!("Tunnel active: id={}, hostname={}", tunnel_id, self.hostname);
+                tracing::info!(
+                    "Tunnel active: id={}, hostname={}",
+                    tunnel_id,
+                    self.hostname
+                );
                 Ok(tunnel_id)
             }
             Err(e) => {
@@ -206,9 +205,7 @@ impl TunnelManager {
 
         // cloudflared tunnel run を起動
         let mut cmd = tokio::process::Command::new("cloudflared");
-        cmd.arg("tunnel")
-            .arg("--no-autoupdate")
-            .arg("run");
+        cmd.arg("tunnel").arg("--no-autoupdate").arg("run");
 
         if !self.config.hostname.is_empty() {
             cmd.arg("--hostname").arg(&self.config.hostname);

--- a/synergos-net/src/tunnel/mod.rs
+++ b/synergos-net/src/tunnel/mod.rs
@@ -238,8 +238,8 @@ fn is_valid_hostname(s: &str) -> bool {
         return false;
     }
     // 連続したドットや先頭/末尾の `.` / `-` を弾く
-    if bytes.first().map_or(true, |&b| !b.is_ascii_alphanumeric())
-        || bytes.last().map_or(true, |&b| !b.is_ascii_alphanumeric())
+    if bytes.first().is_none_or(|&b| !b.is_ascii_alphanumeric())
+        || bytes.last().is_none_or(|&b| !b.is_ascii_alphanumeric())
     {
         return false;
     }

--- a/synergos-net/src/types.rs
+++ b/synergos-net/src/types.rs
@@ -36,8 +36,8 @@ impl NodeId {
     /// 2つの NodeId 間の XOR 距離を計算（Kademlia）
     pub fn xor_distance(&self, other: &NodeId) -> [u8; 32] {
         let mut distance = [0u8; 32];
-        for i in 0..32 {
-            distance[i] = self.0[i] ^ other.0[i];
+        for (i, d) in distance.iter_mut().enumerate() {
+            *d = self.0[i] ^ other.0[i];
         }
         distance
     }
@@ -141,15 +141,9 @@ pub enum Route {
         fqdn: Option<String>,
     },
     /// Cloudflare Tunnel 経由
-    Tunnel {
-        tunnel_id: String,
-        hostname: String,
-    },
+    Tunnel { tunnel_id: String, hostname: String },
     /// WebSocket リレー（フォールバック）
-    Relay {
-        server_url: String,
-        room_id: String,
-    },
+    Relay { server_url: String, room_id: String },
 }
 
 /// 経路種別（簡易判別用）


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage to core IPC and event bus modules, improves code formatting consistency across the codebase, and updates CI/CD workflows to enforce code quality standards.

## Key Changes

### Test Coverage
- **IPC Transport Tests** (`synergos-ipc/src/transport.rs`): Added 8 comprehensive tests covering:
  - Message serialization/deserialization roundtrips
  - Connection closure handling
  - Message size validation (both write and read paths)
  - Partial header EOF scenarios
  - Multiple message streaming
  - Socket path resolution on Linux (with XDG_RUNTIME_DIR fallback)
  - Full serialization of IpcCommand, IpcResponse, and IpcEvent types

- **Event Bus Tests** (`synergos-core/src/event_bus.rs`): Added 5 tests covering:
  - Emission without subscribers (no-op behavior)
  - Subscribe-then-emit delivery
  - Multi-subscriber broadcasting
  - Type isolation between different event types
  - Late subscriber behavior (missing old events)

### Code Formatting & Style
- Reformatted multi-line expressions for consistency across multiple files:
  - `synergos-ipc/src/transport.rs`: Improved socket path construction formatting
  - `synergos-core/src/event_bus.rs`: Simplified entry insertion pattern
  - `synergos-ipc/src/command.rs`: Removed unnecessary blank lines between enum variants
  - `synergos-net/src/chain/file_chain.rs`: Improved pattern matching formatting
  - `synergos-core/src/cli.rs`: Simplified method chaining
  - `synergos-net/src/quic/mod.rs`: Improved map closure formatting
  - `synergos-core/src/conflict/mod.rs`: Simplified conditional logic
  - `synergos-net/src/conduit/mod.rs`: Fixed import ordering and alignment
  - `synergos-net/src/types.rs`: Improved XOR distance calculation loop
  - Multiple other files: General formatting improvements for readability

### CI/CD Improvements
- **Updated `.github/workflows/ci.yml`**:
  - Split monolithic build job into separate `fmt`, `clippy`, and `test` jobs
  - Added Rustfmt checking with `--check` flag
  - Added Clippy linting with `-D warnings` enforcement
  - Implemented matrix testing across Ubuntu, macOS, and Windows
  - Improved caching strategy with OS-specific cache keys
  - Added `--all-targets` flag to build and test commands

### Dependencies
- Added dev-dependencies across all crates:
  - `tokio` with comprehensive feature flags for async testing
  - `tempfile` for temporary file/directory handling in tests
  - `pretty_assertions` for better assertion output
  - `assert_matches` for pattern matching assertions
  - `serial_test` for serialized test execution (environment variable safety)
  - `tracing-test` for logging assertions (synergos-core)

## Notable Implementation Details
- Tests use `tokio::io::duplex` for in-memory stream testing without actual socket I/O
- Environment variable tests use `serial_test` to prevent race conditions
- Event bus tests define local event types to avoid TypeId collisions with other tests
- Socket path tests verify both XDG_RUNTIME_DIR usage and /tmp fallback behavior
- IPC tests validate serialization of complex nested types (commands, responses, events)

https://claude.ai/code/session_018nvtwv3vjkS43iCDc5R9Mi