### PR TITLE
chore(#12): SyncMode FromStr + now_ms 統一 + CatalogConfig + validate

### DIFF
--- a/synergos-core/src/conflict/mod.rs
+++ b/synergos-core/src/conflict/mod.rs
@@ -5,8 +5,6 @@
 //!
 //! 旧 ars-plugin-synergos から synergos-core に移植。Ars 依存を除去。
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use dashmap::DashMap;
 use synergos_net::chain::{ChainBlock, FileChain};
 use synergos_net::types::{Blake3Hash, FileId, PeerId};
@@ -80,12 +78,7 @@ pub enum ConflictError {
 
 // ── 実装 ──
 
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
+use synergos_net::types::now_ms;
 
 /// コンフリクト管理サービス
 pub struct ConflictManager {

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -61,6 +61,9 @@ impl Daemon {
     pub async fn new(config: DaemonConfig) -> anyhow::Result<Self> {
         // ── 設定ファイルの読み込み（任意） ──
         let net_config = load_net_config(config.config_path.as_deref())?;
+        net_config
+            .validate()
+            .map_err(|e| anyhow::anyhow!("invalid net config: {e}"))?;
         let net_config = Arc::new(net_config);
 
         // ── ローカル識別子（永続化は別途：TODO） ──

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -9,7 +9,6 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -166,12 +165,7 @@ pub trait FileSharing: Send + Sync {
 
 // ── 実装 ──
 
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
+use synergos_net::types::now_ms;
 
 /// ファイル転送制御サービス
 pub struct Exchange {

--- a/synergos-core/src/project.rs
+++ b/synergos-core/src/project.rs
@@ -37,13 +37,20 @@ impl SyncMode {
             Self::Selective { .. } => "selective",
         }
     }
+}
 
-    pub fn from_str(s: &str) -> Self {
-        match s {
+/// `"manual".parse::<SyncMode>()` などの標準イディオムを使えるよう
+/// `std::str::FromStr` を実装する。未知の入力は `Full` にフォールバック
+/// (既定動作互換)。エラーは返さないので `Infallible`。
+impl std::str::FromStr for SyncMode {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
             "manual" => Self::Manual,
             "selective" => Self::Selective { patterns: vec![] },
             _ => Self::Full,
-        }
+        })
     }
 }
 
@@ -338,7 +345,7 @@ impl ProjectConfiguration for ProjectManager {
                     settings.description = desc;
                 }
                 if let Some(mode) = patch.sync_mode {
-                    settings.sync_mode = SyncMode::from_str(&mode);
+                    settings.sync_mode = mode.parse().unwrap();
                 }
                 if let Some(max) = patch.max_peers {
                     settings.max_peers = max;

--- a/synergos-net/src/catalog/manager.rs
+++ b/synergos-net/src/catalog/manager.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use dashmap::DashMap;
 use tokio::sync::RwLock;
 
@@ -247,12 +245,7 @@ impl CatalogManager {
     }
 }
 
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
+use crate::types::now_ms;
 
 #[cfg(test)]
 mod tests {

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -12,6 +12,28 @@ pub struct NetConfig {
     pub speed_test: SpeedTestConfig,
     pub peer_selection: PeerSelectionConfig,
     pub monitor: MonitorConfig,
+    /// CatalogManager のチューニング (マジックナンバー解消、後方互換のため
+    /// `#[serde(default)]` で旧 config からも読める)。
+    #[serde(default)]
+    pub catalog: CatalogConfig,
+}
+
+/// CatalogManager のチューニングパラメータ。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogConfig {
+    /// 1 チャンクあたりの最大ファイル数 (default: 256)
+    pub chunk_max_files: usize,
+    /// FileChain の最大保持深度 (default: 10)
+    pub chain_max_depth: usize,
+}
+
+impl Default for CatalogConfig {
+    fn default() -> Self {
+        Self {
+            chunk_max_files: 256,
+            chain_max_depth: 10,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,6 +124,21 @@ pub struct StreamAllocationConfig {
     pub small_ratio: u8,
 }
 
+impl StreamAllocationConfig {
+    /// 3 つの比率の合計が 100 になっているかを検証する。
+    /// 合計が 100 でないと帯域配分計算が壊れる。
+    pub fn validate(&self) -> Result<(), String> {
+        let sum = self.large_ratio as u16 + self.medium_ratio as u16 + self.small_ratio as u16;
+        if sum != 100 {
+            return Err(format!(
+                "stream_allocation ratios must sum to 100 (got {sum}: large={}, medium={}, small={})",
+                self.large_ratio, self.medium_ratio, self.small_ratio
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpeedTestConfig {
     /// スピードテストを有効にするか
@@ -187,6 +224,16 @@ impl Default for NetConfig {
                 history_size: 3600,
                 graph_sample_interval_secs: 1,
             },
+            catalog: CatalogConfig::default(),
         }
+    }
+}
+
+impl NetConfig {
+    /// 設定全体の妥当性を検証する。Daemon 起動時に呼ばれる。
+    /// 個別の知識は各サブ struct の `validate()` に委譲する。
+    pub fn validate(&self) -> Result<(), String> {
+        self.stream_allocation.validate()?;
+        Ok(())
     }
 }

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -75,7 +75,11 @@ impl SynergosNet {
     ) -> Self {
         let dht = DhtNode::new(local_peer_id.clone(), config.dht.clone());
         let gossip = GossipNode::new(local_peer_id, config.gossipsub.clone());
-        let catalog = CatalogManager::new(project_id, 256, 10);
+        let catalog = CatalogManager::new(
+            project_id,
+            config.catalog.chunk_max_files,
+            config.catalog.chain_max_depth,
+        );
         let ledger = TransferLedger::new();
         let quic = Arc::new(QuicManager::new(config.quic.clone()));
         let tunnel = Arc::new(TunnelManager::new(&config.tunnel));

--- a/synergos-net/src/types.rs
+++ b/synergos-net/src/types.rs
@@ -215,3 +215,14 @@ impl FileSizeClass {
         }
     }
 }
+
+/// UNIX epoch からの経過時間を milliseconds で返す共通ユーティリティ。
+/// `conflict` / `exchange` / `catalog` で個別定義されていた重複を解消する。
+///
+/// 時計が epoch より前に設定されている等の異常状態では 0 を返す。
+pub fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}


### PR DESCRIPTION
Refs: #12 (PR #5 引き継ぎ品質改善 続き)

PR #13 後に残っていた品質改善 4 項目を処理。

## 完了

- [x] `SyncMode` の inherent `from_str` を `std::str::FromStr` 実装に置換
- [x] `now_ms()` を synergos-net::types に統一 (3 箇所重複を撤去)
- [x] `NetConfig` に `CatalogConfig` を追加 (chunk_max_files / chain_max_depth マジックナンバー解消)
- [x] `StreamAllocationConfig::validate()` + `NetConfig::validate()` 経由で Daemon 起動時に fail-fast

## 残

- [ ] `IpcCommand` 入力バリデーション関数 (project_id 空文字検査など) — 別 PR
- [ ] peer_id.short() の他所への波及 (presence など)
- [ ] 大物: DHT FIND_NODE / S1 QUIC 認証 / 実ファイル転送配線 / Conflicts GUI / Settings GUI