### PR TITLE
chore(#12): IpcCommand validation + MessageCache gc 改善

### DIFF
--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -340,6 +340,19 @@ where
 
         tracing::debug!("Received command: {:?}", command);
 
+        // dispatcher 前に共通の入力バリデーションを通す。空文字 / 過長 ID 等を弾く。
+        if let Err(reason) = command.validate() {
+            send_server_message(
+                &writer,
+                ServerMessage::Response(IpcResponse::Error {
+                    code: 400,
+                    message: format!("invalid command: {reason}"),
+                }),
+            )
+            .await?;
+            continue;
+        }
+
         match command {
             IpcCommand::Subscribe { events } => {
                 // 既存リレーがあれば停止してから再起動

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -86,3 +86,138 @@ pub enum IpcCommand {
     /// イベント購読解除
     Unsubscribe { subscription_id: String },
 }
+
+impl IpcCommand {
+    /// 入力バリデーション。dispatcher が処理に入る前に呼ばれ、Err なら
+    /// 不正コマンドとして即座に Error 応答を返す。
+    ///
+    /// 主なチェック:
+    /// - 識別子の空文字 (project_id / peer_id / file_id 等)
+    /// - 過大な長さ (DoS 防止: 1 KiB を超える文字列はカット)
+    /// - PublishUpdate.file_paths は空でないこと、上限 1024 件
+    pub fn validate(&self) -> Result<(), String> {
+        const MAX_ID_LEN: usize = 1024;
+        const MAX_PATHS_PER_PUBLISH: usize = 1024;
+
+        let check_id = |label: &str, s: &str| -> Result<(), String> {
+            if s.trim().is_empty() {
+                Err(format!("{label} must not be empty"))
+            } else if s.len() > MAX_ID_LEN {
+                Err(format!("{label} too long ({} > {MAX_ID_LEN})", s.len()))
+            } else {
+                Ok(())
+            }
+        };
+
+        match self {
+            Self::Ping
+            | Self::Shutdown
+            | Self::Status
+            | Self::NetworkStatus
+            | Self::ProjectList => Ok(()),
+
+            Self::ProjectOpen { project_id, .. }
+            | Self::ProjectClose { project_id }
+            | Self::ProjectGet { project_id }
+            | Self::ProjectCreateInvite { project_id, .. }
+            | Self::PeerList { project_id }
+            | Self::ProjectUpdate { project_id, .. } => check_id("project_id", project_id),
+
+            Self::ProjectJoin { invite_token, .. } => check_id("invite_token", invite_token),
+
+            Self::PeerConnect {
+                project_id,
+                peer_id,
+            } => {
+                check_id("project_id", project_id)?;
+                check_id("peer_id", peer_id)
+            }
+            Self::PeerDisconnect { peer_id } => check_id("peer_id", peer_id),
+
+            Self::TransferRequest {
+                project_id,
+                file_id,
+                peer_id,
+            } => {
+                check_id("project_id", project_id)?;
+                check_id("file_id", file_id)?;
+                check_id("peer_id", peer_id)
+            }
+            Self::TransferList { project_id } => {
+                if let Some(p) = project_id {
+                    check_id("project_id", p)?;
+                }
+                Ok(())
+            }
+            Self::TransferCancel { transfer_id } => check_id("transfer_id", transfer_id),
+
+            Self::PublishUpdate {
+                project_id,
+                file_paths,
+            } => {
+                check_id("project_id", project_id)?;
+                if file_paths.is_empty() {
+                    return Err("file_paths must not be empty".into());
+                }
+                if file_paths.len() > MAX_PATHS_PER_PUBLISH {
+                    return Err(format!(
+                        "too many file_paths ({} > {MAX_PATHS_PER_PUBLISH})",
+                        file_paths.len()
+                    ));
+                }
+                Ok(())
+            }
+
+            Self::Subscribe { .. } => Ok(()),
+            Self::Unsubscribe { subscription_id } => check_id("subscription_id", subscription_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+
+    #[test]
+    fn empty_project_id_rejected() {
+        let cmd = IpcCommand::ProjectClose {
+            project_id: "".into(),
+        };
+        assert!(cmd.validate().is_err());
+    }
+
+    #[test]
+    fn whitespace_only_id_rejected() {
+        let cmd = IpcCommand::PeerDisconnect {
+            peer_id: "   ".into(),
+        };
+        assert!(cmd.validate().is_err());
+    }
+
+    #[test]
+    fn long_id_rejected() {
+        let cmd = IpcCommand::ProjectClose {
+            project_id: "x".repeat(2048),
+        };
+        assert!(cmd.validate().is_err());
+    }
+
+    #[test]
+    fn empty_publish_paths_rejected() {
+        let cmd = IpcCommand::PublishUpdate {
+            project_id: "p".into(),
+            file_paths: vec![],
+        };
+        assert!(cmd.validate().is_err());
+    }
+
+    #[test]
+    fn happy_path_passes() {
+        let cmd = IpcCommand::TransferRequest {
+            project_id: "p".into(),
+            file_id: "f".into(),
+            peer_id: "x".into(),
+        };
+        cmd.validate().unwrap();
+    }
+}

--- a/synergos-net/src/gossip/node.rs
+++ b/synergos-net/src/gossip/node.rs
@@ -38,15 +38,50 @@ impl MessageCache {
     }
 
     fn gc(&self) {
-        // 最も古い 25% を削除
-        let target = self.max_size / 4;
-        let mut entries: Vec<_> = self
-            .seen
-            .iter()
-            .map(|e| (e.key().clone(), *e.value()))
-            .collect();
-        entries.sort_by_key(|(_, t)| *t);
-        for (key, _) in entries.into_iter().take(target) {
+        // 最も古い 25% を削除する。
+        // 旧実装は Vec 全体を sort していて O(n log n)。max-heap で
+        // 「最古 k 件」のみ保持することで O(n log k) に短縮する。
+        let target = (self.max_size / 4).max(1);
+        if self.seen.len() <= target {
+            self.seen.clear();
+            return;
+        }
+        // MessageId は Ord 未実装なので Instant だけで順序付けする wrapper。
+        // (top = 最大時刻 = 最新) で max-heap を作り、走査中に top より古い
+        // ものが来たら swap することで結果的に heap には「最古 target 件」が残る。
+        use std::cmp::Ordering;
+        use std::collections::BinaryHeap;
+        struct ByTime(Instant, MessageId);
+        impl PartialEq for ByTime {
+            fn eq(&self, o: &Self) -> bool {
+                self.0 == o.0
+            }
+        }
+        impl Eq for ByTime {}
+        impl Ord for ByTime {
+            fn cmp(&self, o: &Self) -> Ordering {
+                self.0.cmp(&o.0)
+            }
+        }
+        impl PartialOrd for ByTime {
+            fn partial_cmp(&self, o: &Self) -> Option<Ordering> {
+                Some(self.cmp(o))
+            }
+        }
+
+        let mut oldest: BinaryHeap<ByTime> = BinaryHeap::with_capacity(target + 1);
+        for entry in self.seen.iter() {
+            let t = *entry.value();
+            if oldest.len() < target {
+                oldest.push(ByTime(t, entry.key().clone()));
+            } else if let Some(top) = oldest.peek() {
+                if t < top.0 {
+                    oldest.pop();
+                    oldest.push(ByTime(t, entry.key().clone()));
+                }
+            }
+        }
+        for ByTime(_t, key) in oldest {
             self.seen.remove(&key);
         }
     }


### PR DESCRIPTION
Refs: #12

## 完了

- [x] `IpcCommand::validate()` 追加 + dispatcher 統合 (空文字 / 過長 ID / 空 paths を弾く、code 400 で即拒絶)
- [x] `MessageCache::gc` を O(n log n) → O(n log k) に書き換え (BinaryHeap)
- [x] validate の単体テスト 5 件追加

39/39 tests pass。

## 残 (#12)

- DHT FIND_NODE / Route Migration / 実ファイル転送配線 / S1 QUIC 認証 / Conflicts GUI / Settings GUI / DashMap TOCTOU / DoH DNSSEC / redact_path helper / peer_id.short() 全箇所適用