### PR TITLE
feat(#12,#9,#13): S1 QUIC auth + DHT FIND_NODE + real transfer + 60 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,38 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-targets
 
+  coverage:
+    runs-on: ubuntu-latest
+    name: Coverage (llvm-cov)
+    # cargo-llvm-cov は Linux でしか手軽に動かないので ubuntu-only。
+    # CI ブロックはしないが、PR レビューで目安になる。
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: cargo install --locked cargo-llvm-cov
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: coverage-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            coverage-cargo-
+      - name: Generate lcov report
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
+
   audit:
     runs-on: ubuntu-latest
     name: Security audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1047,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,12 +1544,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1564,6 +1633,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2361,6 +2431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2554,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,10 +2573,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2801,6 +2906,15 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3436,6 +3550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3680,6 +3803,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4043,6 +4176,7 @@ dependencies = [
  "dashmap",
  "libc",
  "pretty_assertions",
+ "quinn",
  "serde",
  "serial_test",
  "synergos-ipc",
@@ -4099,6 +4233,7 @@ dependencies = [
  "crc32fast",
  "dashmap",
  "ed25519-dalek",
+ "futures",
  "hex",
  "hickory-resolver",
  "pretty_assertions",
@@ -4111,11 +4246,13 @@ dependencies = [
  "rmp-serde",
  "rustls 0.23.37",
  "serde",
+ "serde_bytes",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -4221,10 +4358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4232,6 +4371,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-skia"
@@ -5571,6 +5720,23 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "xcursor"

--- a/synergos-core/Cargo.toml
+++ b/synergos-core/Cargo.toml
@@ -17,6 +17,9 @@ synergos-ipc = { path = "../synergos-ipc" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 
+# QUIC (for transfer stream handling)
+quinn = "0.11"
+
 # Crypto / Hash
 blake3 = "1"
 

--- a/synergos-core/src/cli.rs
+++ b/synergos-core/src/cli.rs
@@ -6,7 +6,7 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-use crate::daemon::Daemon;
+use crate::daemon::{Daemon, DaemonConfig};
 
 /// Synergos Core Daemon
 #[derive(Parser)]
@@ -146,7 +146,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Command::Start { config } => {
             tracing::info!("Starting Synergos core daemon...");
-            let daemon_config = crate::daemon::DaemonConfig {
+            let daemon_config = DaemonConfig {
                 config_path: config,
                 ..Default::default()
             };

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -199,6 +199,14 @@ impl Daemon {
             self.ctx.shutdown_tx.subscribe(),
         );
 
+        // Gossip サブスクライバ: FileWant / FileOffer を Exchange に配線する。
+        // これで Synergos 既存の gossip チャネルだけで自動更新がドライブする。
+        let gossip_sub_task = spawn_gossip_subscriber(
+            self.net.gossip.clone(),
+            self.ctx.clone(),
+            self.ctx.shutdown_tx.subscribe(),
+        );
+
         // IPC サーバーを実行（シャットダウンまでブロック）
         ipc_server.run().await?;
 
@@ -207,6 +215,7 @@ impl Daemon {
         cleanup_task.abort();
         heartbeat_task.abort();
         quic_accept_task.abort();
+        gossip_sub_task.abort();
 
         // グレースフルシャットダウン
         self.shutdown().await?;
@@ -423,6 +432,47 @@ async fn dispatch_peer_streams(
             }
         });
     }
+}
+
+/// Gossip メッセージサブスクライバ。`GossipNode::receiver()` で購読し、
+/// `FileWant` / `FileOffer` を `Exchange::handle_file_want` /
+/// `handle_file_offer` に流す。
+///
+/// これにより「誰かがファイル A を Want した」→「A を持っている自分が
+/// gossip 経由で気付く」→「QUIC の `TXFR` ストリームを開いて実データを
+/// 送る」という完全な自動更新チェーンが Synergos 既存の gossip + ledger +
+/// conduit 経路だけで成立する。IPC からの直接コマンドには依存しない。
+fn spawn_gossip_subscriber(
+    gossip: Arc<GossipNode>,
+    ctx: Arc<ServiceContext>,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    let mut rx = gossip.receiver();
+    tokio::spawn(async move {
+        use synergos_net::gossip::GossipMessage;
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => break,
+                msg = rx.recv() => {
+                    match msg {
+                        Ok((_topic, GossipMessage::FileWant { requester, file_id, version })) => {
+                            ctx.exchange.handle_file_want(requester, file_id, version);
+                        }
+                        Ok((_topic, GossipMessage::FileOffer { sender, file_id, version, size, crc, content_hash: _ })) => {
+                            ctx.exchange.handle_file_offer(sender, file_id, version, size, crc);
+                        }
+                        Ok(_) => {
+                            // CatalogUpdate / PeerStatus / ConflictAlert は別系統で処理
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!("gossip subscriber lagged; dropped {n} messages");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }
+        }
+    })
 }
 
 /// Gossipsub ハートビート

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -8,8 +8,16 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 
 use synergos_net::{
-    conduit::Conduit, config::NetConfig, dht::DhtNode, gossip::GossipNode, mesh::Mesh,
-    quic::QuicManager, tunnel::TunnelManager, types::PeerId,
+    conduit::Conduit,
+    config::NetConfig,
+    dht::{handle_dht_stream, DhtNode, DHT_STREAM_MAGIC},
+    gossip::GossipNode,
+    identity::Identity,
+    mesh::Mesh,
+    quic::QuicManager,
+    transfer::TRANSFER_STREAM_MAGIC,
+    tunnel::TunnelManager,
+    types::PeerId,
 };
 
 use crate::conflict::ConflictManager;
@@ -41,6 +49,7 @@ impl Default for DaemonConfig {
 /// ネットワーク基盤のハンドル群（Daemon が保持して寿命を合わせる）
 pub struct NetworkHandles {
     pub local_peer_id: PeerId,
+    pub identity: Arc<Identity>,
     pub net_config: Arc<NetConfig>,
     pub dht: Arc<DhtNode>,
     pub gossip: Arc<GossipNode>,
@@ -66,8 +75,12 @@ impl Daemon {
             .map_err(|e| anyhow::anyhow!("invalid net config: {e}"))?;
         let net_config = Arc::new(net_config);
 
-        // ── ローカル識別子（永続化は別途：TODO） ──
-        let local_peer_id = PeerId::generate();
+        // ── ローカル識別子（ed25519 キー + BLAKE3 派生 PeerId を永続化） ──
+        let identity = Arc::new(
+            Identity::load_or_generate(&Identity::default_path())
+                .map_err(|e| anyhow::anyhow!("identity init failed: {e}"))?,
+        );
+        let local_peer_id = identity.peer_id().clone();
 
         // ── ネットワーク基盤コンポーネント ──
         let dht = Arc::new(DhtNode::new(local_peer_id.clone(), net_config.dht.clone()));
@@ -75,7 +88,7 @@ impl Daemon {
             local_peer_id.clone(),
             net_config.gossipsub.clone(),
         ));
-        let quic = Arc::new(QuicManager::new(net_config.quic.clone()));
+        let quic = Arc::new(QuicManager::new(net_config.quic.clone(), identity.clone()));
         let tunnel = Arc::new(TunnelManager::new(&net_config.tunnel));
         let mesh = Arc::new(Mesh::new(net_config.mesh.clone()));
         let conduit = Arc::new(Conduit::new(
@@ -87,6 +100,7 @@ impl Daemon {
 
         let net = Arc::new(NetworkHandles {
             local_peer_id: local_peer_id.clone(),
+            identity,
             net_config,
             dht: dht.clone(),
             gossip: gossip.clone(),
@@ -102,11 +116,24 @@ impl Daemon {
             event_bus.clone(),
             Some(gossip.clone()),
         ));
-        let exchange = Arc::new(Exchange::with_network(
+        let mut exchange_inner = Exchange::with_network(
             event_bus.clone(),
             local_peer_id.clone(),
             Some(gossip.clone()),
-        ));
+        );
+        // QUIC と受信先レゾルバを注入する。
+        // リゾルバは ProjectManager からプロジェクトルートを引いて FileId を
+        // 相対パスとして連結する (実運用では file_id に path 情報を持たせる
+        // 必要あり — 暫定で FileId をそのまま相対パスとして扱う)。
+        {
+            let pm = project_manager.clone();
+            let resolver: crate::exchange::OutPathResolver = Arc::new(move |project_id, file_id| {
+                let root = pm.project_root(project_id)?;
+                Some(root.join(file_id.0.clone()))
+            });
+            exchange_inner.attach_quic(net.quic.clone(), resolver);
+        }
+        let exchange = Arc::new(exchange_inner);
         let presence = Arc::new(PresenceService::with_network(
             event_bus.clone(),
             Some(dht.clone()),
@@ -164,6 +191,13 @@ impl Daemon {
             self.ctx.shutdown_tx.subscribe(),
         );
 
+        // QUIC 着信ストリームディスパッチャ (DHT / Transfer を magic で振り分け)
+        let quic_accept_task = spawn_quic_accept_loop(
+            self.net.clone(),
+            self.ctx.clone(),
+            self.ctx.shutdown_tx.subscribe(),
+        );
+
         // IPC サーバーを実行（シャットダウンまでブロック）
         ipc_server.run().await?;
 
@@ -171,6 +205,7 @@ impl Daemon {
         signal_task.abort();
         cleanup_task.abort();
         heartbeat_task.abort();
+        quic_accept_task.abort();
 
         // グレースフルシャットダウン
         self.shutdown().await?;
@@ -281,6 +316,90 @@ fn spawn_periodic_cleanup(
             }
         }
     })
+}
+
+/// QUIC 着信ストリームを受け付け、magic バイトで DHT / Transfer にディスパッチする。
+///
+/// 今のところ `QuicManager::accept` で受け取った Connection から `accept_bi()` を
+/// ループで拾い、1 bidi ストリームごとに:
+///   1. 先頭 4 byte を読んで magic を判定
+///   2. DHT なら `handle_dht_stream` に委譲
+///   3. Transfer なら `Exchange::handle_incoming_transfer` に委譲
+fn spawn_quic_accept_loop(
+    net: Arc<NetworkHandles>,
+    ctx: Arc<ServiceContext>,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => break,
+                accepted = net.quic.accept() => {
+                    match accepted {
+                        Ok(Some(acc)) => {
+                            let dht = net.dht.clone();
+                            let exchange = ctx.exchange.clone();
+                            let sender = acc.peer_id.clone();
+                            let connection = acc.connection;
+                            tokio::spawn(async move {
+                                dispatch_peer_streams(connection, sender, dht, exchange).await;
+                            });
+                        }
+                        Ok(None) => {
+                            tracing::debug!("quic accept returned None (endpoint closed); exiting loop");
+                            break;
+                        }
+                        Err(e) => {
+                            tracing::warn!("quic accept error: {e}");
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// 1 つの QUIC コネクションから bidi ストリームをループで受け、先頭 magic で
+/// DHT / Transfer に振り分ける。コネクションが閉じられたらループを抜ける。
+async fn dispatch_peer_streams(
+    connection: quinn::Connection,
+    sender: PeerId,
+    dht: Arc<DhtNode>,
+    exchange: Arc<crate::exchange::Exchange>,
+) {
+    loop {
+        let (send, mut recv) = match connection.accept_bi().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::debug!("connection {} closed: {e}", sender.short());
+                return;
+            }
+        };
+
+        let mut magic = [0u8; 4];
+        if let Err(e) = recv.read_exact(&mut magic).await {
+            tracing::debug!("stream magic read failed from {}: {e}", sender.short());
+            continue;
+        }
+
+        let dht = dht.clone();
+        let exchange = exchange.clone();
+        let sender_cloned = sender.clone();
+        tokio::spawn(async move {
+            if &magic == DHT_STREAM_MAGIC {
+                if let Err(e) = handle_dht_stream(dht, send, recv).await {
+                    tracing::debug!("DHT stream handler error: {e}");
+                }
+            } else if &magic == TRANSFER_STREAM_MAGIC {
+                if let Err(e) = exchange.handle_incoming_transfer(recv, sender_cloned).await {
+                    tracing::debug!("Transfer stream handler error: {e}");
+                }
+            } else {
+                tracing::debug!("unknown stream magic {:?}", magic);
+            }
+        });
+    }
 }
 
 /// Gossipsub ハートビート

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -309,6 +309,28 @@ fn spawn_periodic_cleanup(
                             ctx.presence.update_bandwidth(&info.peer_id, bw);
                         }
                     }
+
+                    // Route Migration: 各接続済みピアに対して try_migrate_route を呼び、
+                    // より高優先度の経路が開通していれば切り替える (S-route)。
+                    // QUIC のアクティブリストを元にするのでオフラインピアは触らない。
+                    for info in net.quic.list_connections() {
+                        match net.conduit.try_migrate_route(&info.peer_id).await {
+                            Ok(Some(new_route)) => {
+                                tracing::debug!(
+                                    "route migrated for {}: {:?}",
+                                    info.peer_id.short(),
+                                    new_route
+                                );
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                tracing::debug!(
+                                    "route migration attempt for {} failed: {e}",
+                                    info.peer_id.short()
+                                );
+                            }
+                        }
+                    }
                 }
                 _ = shutdown_rx.recv() => {
                     break;

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -127,10 +127,11 @@ impl Daemon {
         // 必要あり — 暫定で FileId をそのまま相対パスとして扱う)。
         {
             let pm = project_manager.clone();
-            let resolver: crate::exchange::OutPathResolver = Arc::new(move |project_id, file_id| {
-                let root = pm.project_root(project_id)?;
-                Some(root.join(file_id.0.clone()))
-            });
+            let resolver: crate::exchange::OutPathResolver =
+                Arc::new(move |project_id, file_id| {
+                    let root = pm.project_root(project_id)?;
+                    Some(root.join(file_id.0.clone()))
+                });
             exchange_inner.attach_quic(net.quic.clone(), resolver);
         }
         let exchange = Arc::new(exchange_inner);

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -229,6 +229,17 @@ pub trait FileSharing: Send + Sync {
 
 use synergos_net::types::now_ms;
 
+/// ローカルが「送信可能 (Offer 済)」として保持するファイルの記録。
+/// FileWant を受けたときに即座に送信を起動するのに必要な項目。
+#[derive(Debug, Clone)]
+pub struct SharedFileRecord {
+    pub project_id: String,
+    pub file_path: PathBuf,
+    pub file_size: u64,
+    pub crc: u32,
+    pub version: u64,
+}
+
 /// ファイル転送制御サービス
 pub struct Exchange {
     event_bus: SharedEventBus,
@@ -242,6 +253,9 @@ pub struct Exchange {
     quic: Option<Arc<QuicManager>>,
     /// 受信時に保存先パスを解決するレゾルバ
     out_path_resolver: Option<OutPathResolver>,
+    /// ローカルが share_file / publish_updates で登録したファイル
+    /// (FileWant 受信時に send_and_share を起動する材料にする)
+    shared_files: DashMap<FileId, SharedFileRecord>,
     /// ローカルピアID
     local_peer_id: PeerId,
 }
@@ -265,6 +279,7 @@ impl Exchange {
             gossip,
             quic: None,
             out_path_resolver: None,
+            shared_files: DashMap::new(),
             local_peer_id,
         }
     }
@@ -472,6 +487,104 @@ impl Exchange {
         Ok(())
     }
 
+    /// Gossip で `FileWant` を受信したときのハンドラ。
+    /// 自ノードが該当ファイルを `share_file` / `publish_updates` 経由で
+    /// 登録済 (= `shared_files` にある) 場合、要求ピアに対して QUIC で
+    /// 実データをプッシュする (Synergos 既存の共有ルート経由)。
+    ///
+    /// 既に該当 peer へ同じバージョンを送ったことがあれば ledger の
+    /// `mark_fulfilled` でスキップされる想定。
+    pub fn handle_file_want(self: &Arc<Self>, requester: PeerId, file_id: FileId, version: u64) {
+        if requester == self.local_peer_id {
+            return; // 自分の Want は無視
+        }
+        let record = match self.shared_files.get(&file_id) {
+            Some(r) => r.value().clone(),
+            None => {
+                tracing::debug!(
+                    "handle_file_want: no local offer for {} (requester={})",
+                    file_id,
+                    requester.short()
+                );
+                return;
+            }
+        };
+        // 要求バージョン 0 = 任意の最新、それ以外は一致するバージョンのみ
+        if version != 0 && version != record.version {
+            tracing::debug!(
+                "handle_file_want: version mismatch (want v{version}, have v{})",
+                record.version
+            );
+            return;
+        }
+        if self.quic.is_none() {
+            tracing::debug!("handle_file_want: QUIC not attached, cannot auto-send");
+            return;
+        }
+
+        let ex = self.clone();
+        let req = ShareRequest {
+            project_id: record.project_id.clone(),
+            file_id: file_id.clone(),
+            file_path: record.file_path.clone(),
+            file_size: record.file_size,
+            checksum: synergos_net::types::Blake3Hash::default(),
+            priority: TransferPriority::Interactive,
+            target_peer: Some(requester.clone()),
+            version: record.version,
+        };
+        tokio::spawn(async move {
+            tracing::info!(
+                "auto-sending {} v{} to {} via FileWant",
+                file_id,
+                record.version,
+                requester.short()
+            );
+            if let Err(e) = share_and_send(ex, req).await {
+                tracing::warn!("auto-send via FileWant failed: {e}");
+            }
+        });
+    }
+
+    /// Gossip で `FileOffer` を受信したときのハンドラ。
+    /// リモートの Offer を TransferLedger に登録し、自分の保留 Want と
+    /// マッチしたらログを出す (実受信は相手側が開く QUIC ストリームを
+    /// Daemon のディスパッチャが handle_incoming_transfer に流すので
+    /// ここで別途 fetch を起動する必要はない)。
+    pub fn handle_file_offer(
+        &self,
+        sender: PeerId,
+        file_id: FileId,
+        version: u64,
+        file_size: u64,
+        crc: u32,
+    ) {
+        if sender == self.local_peer_id {
+            return;
+        }
+        let offer = OfferEntry {
+            sender: sender.clone(),
+            file_id: file_id.clone(),
+            version,
+            file_size,
+            crc,
+            offered_at: now_ms(),
+            state: LedgerEntryState::Pending,
+        };
+        let actions = self.ledger.register_offer(offer);
+        for action in actions {
+            if let LedgerAction::Match { sender, file_size } = action {
+                tracing::info!(
+                    "FileOffer matched a pending Want: sender={}, size={}",
+                    sender.short(),
+                    file_size
+                );
+                // 相手 (sender) が我々の FileWant を受けて QUIC push する。
+                // こちら側は Daemon の accept ループが自動で受信する。
+            }
+        }
+    }
+
     /// 転送を失敗状態に遷移
     fn fail_transfer(&self, transfer_id: &TransferId, reason: String) {
         if let Some(mut entry) = self.transfers.get_mut(transfer_id) {
@@ -645,6 +758,18 @@ impl FileSharing for Exchange {
         let actions = self.ledger.register_offer(offer);
         tracing::debug!("Ledger offer registered, actions: {}", actions.len());
 
+        // FileWant 到着時に即転送起動できるよう、path とメタを保存
+        self.shared_files.insert(
+            request.file_id.clone(),
+            SharedFileRecord {
+                project_id: request.project_id.clone(),
+                file_path: request.file_path.clone(),
+                file_size: request.file_size,
+                crc: crc32fast::hash(&request.checksum.0),
+                version: request.version,
+            },
+        );
+
         // Gossipsub で FileOffer をブロードキャスト
         self.broadcast_offer(
             &request.project_id,
@@ -742,7 +867,7 @@ impl FileSharing for Exchange {
                 notif.version
             );
 
-            // TransferLedger に各ファ��ルの Offer を登録
+            // TransferLedger に各ファイルの Offer を登録
             let offer = OfferEntry {
                 sender: self.local_peer_id.clone(),
                 file_id: notif.file_id.clone(),
@@ -753,6 +878,18 @@ impl FileSharing for Exchange {
                 state: LedgerEntryState::Pending,
             };
             self.ledger.register_offer(offer);
+
+            // 受信した FileWant に自動応答するため shared_files にも登録
+            self.shared_files.insert(
+                notif.file_id.clone(),
+                SharedFileRecord {
+                    project_id: notif.project_id.clone(),
+                    file_path: notif.file_path.clone(),
+                    file_size: notif.file_size,
+                    crc: notif.crc,
+                    version: notif.version,
+                },
+            );
 
             // Gossipsub で FileOffer をブロードキャスト
             self.broadcast_offer(

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -23,8 +23,7 @@ use crate::event_bus::{SharedEventBus, TransferCompletedEvent, TransferProgressE
 /// 受信側で転送の保存先を解決するためのレゾルバ。`(project_id, file_id)` から
 /// 最終的な書き込み先 `PathBuf` を返す。通常は ProjectManager 経由で
 /// プロジェクトルート + 相対パスを組み立てる想定。
-pub type OutPathResolver =
-    Arc<dyn Fn(&str, &FileId) -> Option<PathBuf> + Send + Sync + 'static>;
+pub type OutPathResolver = Arc<dyn Fn(&str, &FileId) -> Option<PathBuf> + Send + Sync + 'static>;
 
 /// QUIC 送信を進行しつつ 128KiB ごとに読み込んだ累積バイトを
 /// `tokio::sync::mpsc` で投げ出す `AsyncRead` ラッパ。
@@ -375,7 +374,12 @@ impl Exchange {
 
         // bidi ストリームを開く
         let (send, _recv) = quic
-            .open_stream(&target_peer, StreamType::Data { transfer_id: transfer_id.clone() })
+            .open_stream(
+                &target_peer,
+                StreamType::Data {
+                    transfer_id: transfer_id.clone(),
+                },
+            )
             .await
             .map_err(|e| FileSharingError::NetworkError(format!("open_stream: {e}")))?;
 
@@ -581,7 +585,10 @@ pub async fn spawn_send_after_share(
     };
     let _ = version; // 既存の ActiveTransfer.version に既に載っている
 
-    if let Err(e) = exchange.execute_send(transfer_id, target, path, header).await {
+    if let Err(e) = exchange
+        .execute_send(transfer_id, target, path, header)
+        .await
+    {
         tracing::warn!("execute_send failed: {e}");
     }
 }

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -14,9 +14,72 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use synergos_net::chain::{LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry};
 use synergos_net::gossip::{GossipMessage, GossipNode};
+use synergos_net::quic::{QuicManager, StreamType};
+use synergos_net::transfer::{receive_over_quic, send_over_quic, TransferHeader};
 use synergos_net::types::{Blake3Hash, FileId, PeerId, TopicId, TransferId};
 
 use crate::event_bus::{SharedEventBus, TransferCompletedEvent, TransferProgressEvent};
+
+/// 受信側で転送の保存先を解決するためのレゾルバ。`(project_id, file_id)` から
+/// 最終的な書き込み先 `PathBuf` を返す。通常は ProjectManager 経由で
+/// プロジェクトルート + 相対パスを組み立てる想定。
+pub type OutPathResolver =
+    Arc<dyn Fn(&str, &FileId) -> Option<PathBuf> + Send + Sync + 'static>;
+
+/// QUIC 送信を進行しつつ 128KiB ごとに読み込んだ累積バイトを
+/// `tokio::sync::mpsc` で投げ出す `AsyncRead` ラッパ。
+///
+/// 送信側の進捗イベントは「source から何 byte 読んだか」で近似する。
+/// QUIC 層の ACK は quinn からは直接取れないので read-side 近似で
+/// 十分 (受信完了は相手のストリームが EOF を返すので区別可能)。
+struct ProgressReader<R> {
+    inner: R,
+    emitted: u64,
+    next_emit_at: u64,
+    tx: tokio::sync::mpsc::Sender<u64>,
+}
+
+impl<R> ProgressReader<R>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    fn wrap(inner: R) -> (Self, tokio::sync::mpsc::Receiver<u64>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        (
+            Self {
+                inner,
+                emitted: 0,
+                next_emit_at: 128 * 1024,
+                tx,
+            },
+            rx,
+        )
+    }
+}
+
+impl<R> tokio::io::AsyncRead for ProgressReader<R>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let poll = std::pin::Pin::new(&mut self.inner).poll_read(cx, buf);
+        let after = buf.filled().len();
+        let delta = (after - before) as u64;
+        if delta > 0 {
+            self.emitted += delta;
+            if self.emitted >= self.next_emit_at {
+                let _ = self.tx.try_send(self.emitted);
+                self.next_emit_at += 128 * 1024;
+            }
+        }
+        poll
+    }
+}
 
 // ── 型定義 ──
 
@@ -176,6 +239,10 @@ pub struct Exchange {
     ledger: Arc<TransferLedger>,
     /// Gossipsub ノード（オプション: ネットワーク初期化後にセット）
     gossip: Option<Arc<GossipNode>>,
+    /// QUIC ハンドル (注入済みなら share_file で実転送を起動する)
+    quic: Option<Arc<QuicManager>>,
+    /// 受信時に保存先パスを解決するレゾルバ
+    out_path_resolver: Option<OutPathResolver>,
     /// ローカルピアID
     local_peer_id: PeerId,
 }
@@ -197,8 +264,17 @@ impl Exchange {
             transfers: DashMap::new(),
             ledger: Arc::new(TransferLedger::new()),
             gossip,
+            quic: None,
+            out_path_resolver: None,
             local_peer_id,
         }
+    }
+
+    /// QUIC 送受を行うためのハンドルと、受信先解決用リゾルバを注入する。
+    /// `with_network` の後に呼んで有効化する。
+    pub fn attach_quic(&mut self, quic: Arc<QuicManager>, resolver: OutPathResolver) {
+        self.quic = Some(quic);
+        self.out_path_resolver = Some(resolver);
     }
 
     /// 完了済み/キャンセル済み転送をテーブルから除去
@@ -278,6 +354,127 @@ impl Exchange {
         }
     }
 
+    /// 実ファイル転送を起動する (送信側)。QUIC + 指定ピアが揃っている前提。
+    /// `reader` は非同期ファイルハンドル。`header.total_hash` は呼び出し元で
+    /// `transfer::hash_file` 等により事前計算する。
+    ///
+    /// 進捗は 128KiB ごとに `TransferProgressEvent` を emit する。完了時に
+    /// `complete_transfer` を呼ぶ。失敗時は ActiveTransfer を Failed へ遷移。
+    pub async fn execute_send(
+        self: &Arc<Self>,
+        transfer_id: TransferId,
+        target_peer: PeerId,
+        source_path: PathBuf,
+        header: TransferHeader,
+    ) -> Result<(), FileSharingError> {
+        let quic = self
+            .quic
+            .as_ref()
+            .ok_or_else(|| FileSharingError::NetworkError("QUIC not attached".into()))?
+            .clone();
+
+        // bidi ストリームを開く
+        let (send, _recv) = quic
+            .open_stream(&target_peer, StreamType::Data { transfer_id: transfer_id.clone() })
+            .await
+            .map_err(|e| FileSharingError::NetworkError(format!("open_stream: {e}")))?;
+
+        // 進捗報告用ラッパ reader
+        let file = tokio::fs::File::open(&source_path).await?;
+        let total_size = header.total_size;
+        let (reader, mut progress_rx) = ProgressReader::wrap(file);
+
+        let exchange = self.clone();
+        let xfer_id_for_progress = transfer_id.clone();
+        let progress_task = tokio::spawn(async move {
+            let start = std::time::Instant::now();
+            while let Some(bytes) = progress_rx.recv().await {
+                let elapsed_ms = start.elapsed().as_millis().max(1) as u64;
+                let speed = (bytes * 1000) / elapsed_ms;
+                exchange.update_progress(&xfer_id_for_progress, bytes, speed);
+                if bytes >= total_size {
+                    break;
+                }
+            }
+        });
+
+        let result = send_over_quic(send, reader, header).await;
+        progress_task.abort();
+
+        match result {
+            Ok(()) => {
+                self.complete_transfer(&transfer_id);
+                Ok(())
+            }
+            Err(e) => {
+                self.fail_transfer(&transfer_id, format!("{e}"));
+                Err(FileSharingError::NetworkError(format!("{e}")))
+            }
+        }
+    }
+
+    /// 実ファイル転送を起動する (受信側)。Daemon のストリームディスパッチャが
+    /// マジック `TXFR` を確認した後の `recv` を渡す。
+    /// `out_path_resolver` が解決した絶対パスへ書き込み、完了時に
+    /// `complete_transfer` を呼ぶ。
+    pub async fn handle_incoming_transfer(
+        self: &Arc<Self>,
+        recv: quinn::RecvStream,
+        sender: PeerId,
+    ) -> Result<(), FileSharingError> {
+        let resolver = self.out_path_resolver.clone().ok_or_else(|| {
+            FileSharingError::NetworkError("out_path_resolver not attached".into())
+        })?;
+
+        // 先にヘッダを覗き見するため、一時バッファに受信せず receive_over_quic を
+        // 呼んで Header → Body → Footer を完結させる。保存先はヘッダから決める。
+        // 保存先を決めるために「ヘッダだけ先読み」したいが、receive_stream が
+        // 内部で一気通貫するので、tmp ファイルに書いたあと移動する。
+        let tmp_path =
+            std::env::temp_dir().join(format!("synergos-incoming-{}", uuid::Uuid::new_v4()));
+        let header = receive_over_quic(recv, &tmp_path)
+            .await
+            .map_err(|e| FileSharingError::NetworkError(format!("{e}")))?;
+
+        let file_id = FileId(header.file_id.clone());
+        let final_path = resolver(&header.project_id, &file_id)
+            .ok_or_else(|| FileSharingError::FileNotFound(header.file_id.clone()))?;
+        if let Some(parent) = final_path.parent() {
+            tokio::fs::create_dir_all(parent).await.ok();
+        }
+        tokio::fs::rename(&tmp_path, &final_path).await?;
+
+        // この転送に対応する ActiveTransfer を作り直して complete_transfer する
+        let transfer_id = TransferId(header.transfer_id.clone());
+        let transfer = ActiveTransfer {
+            transfer_id: transfer_id.clone(),
+            project_id: header.project_id.clone(),
+            file_id,
+            file_name: final_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| header.file_id.clone()),
+            file_size: header.total_size,
+            bytes_transferred: header.total_size,
+            speed_bps: 0,
+            direction: TransferDirection::Receive,
+            peer_id: sender,
+            state: TransferState::Running,
+            priority: TransferPriority::Interactive,
+            version: 1,
+        };
+        self.transfers.insert(transfer_id.clone(), transfer);
+        self.complete_transfer(&transfer_id);
+        Ok(())
+    }
+
+    /// 転送を失敗状態に遷移
+    fn fail_transfer(&self, transfer_id: &TransferId, reason: String) {
+        if let Some(mut entry) = self.transfers.get_mut(transfer_id) {
+            entry.state = TransferState::Failed(reason);
+        }
+    }
+
     /// 転送完了を処理
     pub fn complete_transfer(&self, transfer_id: &TransferId) {
         if let Some(mut entry) = self.transfers.get_mut(transfer_id) {
@@ -323,6 +520,69 @@ impl Exchange {
                 speed_bps,
             });
         }
+    }
+}
+
+/// share_file + 実転送を一括で実行する `Arc<Exchange>` 用ヘルパ。
+/// 通常の FileSharing trait 経由ではなく、ここを経由することで
+/// QUIC 経由の実データ転送まで起動する。
+pub async fn share_and_send(
+    exchange: Arc<Exchange>,
+    request: ShareRequest,
+) -> Result<TransferId, FileSharingError> {
+    let transfer_id = exchange.share_file(request.clone()).await?;
+    let ex = exchange.clone();
+    let req = request.clone();
+    let tid = transfer_id.clone();
+    tokio::spawn(async move {
+        spawn_send_after_share(ex, req, tid).await;
+    });
+    Ok(transfer_id)
+}
+
+/// share_file 実行時に QUIC 経由でバックグラウンド送信するためのエントリポイント。
+/// `Arc<Exchange>` 経由でしか呼べないので、ラッパメソッドとして分離。
+pub async fn spawn_send_after_share(
+    exchange: Arc<Exchange>,
+    request: ShareRequest,
+    transfer_id: TransferId,
+) {
+    let target = match &request.target_peer {
+        Some(p) => p.clone(),
+        None => return, // target_peer が None の場合はブロードキャスト offer のみで終了
+    };
+    if exchange.quic.is_none() {
+        return;
+    }
+
+    let path = request.file_path.clone();
+    let project_id = request.project_id.clone();
+    let file_id = request.file_id.clone();
+    let version = request.version;
+
+    // 全体ハッシュを事前計算
+    let (total_hash, total_size, chunk_count) = match synergos_net::transfer::hash_file(&path).await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("hash_file failed for {}: {e}", path.display());
+            exchange.fail_transfer(&transfer_id, format!("hash_file: {e}"));
+            return;
+        }
+    };
+
+    let header = TransferHeader {
+        transfer_id: transfer_id.0.clone(),
+        project_id,
+        file_id: file_id.0.clone(),
+        total_size,
+        chunk_count,
+        total_hash,
+    };
+    let _ = version; // 既存の ActiveTransfer.version に既に載っている
+
+    if let Err(e) = exchange.execute_send(transfer_id, target, path, header).await {
+        tracing::warn!("execute_send failed: {e}");
     }
 }
 

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -583,7 +583,7 @@ fn filter_event(
 }
 
 /// コマンドをディスパッチしてレスポンスを生成
-async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcResponse {
+pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcResponse {
     match command {
         IpcCommand::Ping => IpcResponse::Pong,
 

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -846,6 +846,7 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                 }
             };
 
+            use synergos_net::types::redact_path;
             let mut notifications: Vec<PublishNotification> = Vec::with_capacity(file_paths.len());
             for path in &file_paths {
                 let absolute = if path.is_absolute() {
@@ -858,7 +859,10 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     Err(e) => {
                         return IpcResponse::Error {
                             code: 3,
-                            message: format!("file not found or unreadable: {:?}: {e}", absolute),
+                            message: format!(
+                                "file not found or unreadable: {}: {e}",
+                                redact_path(&project_root, &absolute)
+                            ),
                         };
                     }
                 };
@@ -866,8 +870,8 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     return IpcResponse::Error {
                         code: 3,
                         message: format!(
-                            "file outside project root: {:?} (root: {:?})",
-                            canonical, project_root
+                            "file outside project root: {}",
+                            redact_path(&project_root, &canonical)
                         ),
                     };
                 }
@@ -877,7 +881,10 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     Err(e) => {
                         return IpcResponse::Error {
                             code: 3,
-                            message: format!("metadata failed {:?}: {e}", canonical),
+                            message: format!(
+                                "metadata failed {}: {e}",
+                                redact_path(&project_root, &canonical)
+                            ),
                         };
                     }
                 };
@@ -887,7 +894,10 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     Err(e) => {
                         return IpcResponse::Error {
                             code: 3,
-                            message: format!("read failed {:?}: {e}", canonical),
+                            message: format!(
+                                "read failed {}: {e}",
+                                redact_path(&project_root, &canonical)
+                            ),
                         };
                     }
                 };
@@ -956,5 +966,59 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
         // 処理するため、ここに届くことはない。保険として Ok を返す。
         IpcCommand::Subscribe { .. } => IpcResponse::Ok,
         IpcCommand::Unsubscribe { .. } => IpcResponse::Ok,
+
+        IpcCommand::ConflictList { project_id } => {
+            let items = ctx
+                .conflict_manager
+                .list_conflicts(project_id.as_deref())
+                .into_iter()
+                .map(|c| synergos_ipc::response::ConflictInfoDto {
+                    file_id: c.file_id.to_string(),
+                    file_path: c.file_path,
+                    project_id: c.project_id,
+                    local_version: c.local_version,
+                    local_author: c.local_author.to_string(),
+                    remote_version: c.remote_version,
+                    remote_author: c.remote_author.to_string(),
+                    detected_at: c.detected_at,
+                    state: match c.state {
+                        crate::conflict::ConflictState::Active => "active".into(),
+                        crate::conflict::ConflictState::Resolved { resolution } => {
+                            format!("resolved:{:?}", resolution)
+                        }
+                    },
+                })
+                .collect();
+            IpcResponse::ConflictList(items)
+        }
+        IpcCommand::ConflictResolve { file_id, resolution } => {
+            let res = match resolution.as_str() {
+                "keep_local" => crate::conflict::ConflictResolution::KeepLocal,
+                "accept_remote" => crate::conflict::ConflictResolution::AcceptRemote,
+                "manual_merge" => crate::conflict::ConflictResolution::ManualMerge,
+                other => {
+                    return IpcResponse::Error {
+                        code: 4,
+                        message: format!("invalid resolution: {other}"),
+                    }
+                }
+            };
+            match ctx
+                .conflict_manager
+                .resolve_conflict(&synergos_net::types::FileId::new(file_id), res)
+            {
+                Ok(_) => IpcResponse::Ok,
+                Err(e) => IpcResponse::Error {
+                    code: 4,
+                    message: e.to_string(),
+                },
+            }
+        }
+        IpcCommand::ConfigUpdate { .. } => {
+            // 現状はホット差替えなしで、将来の完全対応までは受理のみ。
+            // デーモンを再起動するかどうかは呼び出し側が決定する。
+            tracing::info!("ConfigUpdate received; no hot-swap implemented yet");
+            IpcResponse::Ok
+        }
     }
 }

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -991,7 +991,10 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                 .collect();
             IpcResponse::ConflictList(items)
         }
-        IpcCommand::ConflictResolve { file_id, resolution } => {
+        IpcCommand::ConflictResolve {
+            file_id,
+            resolution,
+        } => {
             let res = match resolution.as_str() {
                 "keep_local" => crate::conflict::ConflictResolution::KeepLocal,
                 "accept_remote" => crate::conflict::ConflictResolution::AcceptRemote,

--- a/synergos-core/src/lib.rs
+++ b/synergos-core/src/lib.rs
@@ -1,0 +1,12 @@
+//! synergos-core ライブラリ公開面。
+//! 統合テスト / 他クレートから Exchange, ProjectManager 等にアクセスするためのエントリポイント。
+
+pub mod cli;
+pub mod conflict;
+pub mod event_bus;
+pub mod exchange;
+pub mod presence;
+pub mod project;
+
+pub mod daemon;
+pub mod ipc_server;

--- a/synergos-core/src/main.rs
+++ b/synergos-core/src/main.rs
@@ -4,18 +4,8 @@
 //! EventBus + IPC サーバーを提供し、GUI / CLI / Ars Plugin からの
 //! コマンドを受け付ける。
 
-mod cli;
-mod daemon;
-mod event_bus;
-mod ipc_server;
-mod project;
-
-pub mod conflict;
-pub mod exchange;
-pub mod presence;
-
 use clap::Parser;
-use cli::Cli;
+use synergos_core::cli::{self, Cli};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/synergos-core/src/presence/mod.rs
+++ b/synergos-core/src/presence/mod.rs
@@ -259,7 +259,7 @@ impl NodeRegistry for PresenceService {
     async fn unregister_self(&self) -> Result<(), NodeRegistryError> {
         let mut local = self.local_node.write().await;
         if let Some(reg) = local.take() {
-            tracing::info!("Unregistering self (peer_id={})", reg.peer_id);
+            tracing::info!("Unregistering self (peer_id={})", reg.peer_id.short());
             self.nodes.remove(&reg.peer_id);
 
             // Gossipsub でオフラインステータスをブロードキャスト

--- a/synergos-core/tests/auto_transfer_e2e.rs
+++ b/synergos-core/tests/auto_transfer_e2e.rs
@@ -1,0 +1,182 @@
+//! 自動更新 E2E: Peer A が共有しているファイルを、Peer B の Gossip FileWant
+//! 受信をトリガに Peer A が自動で QUIC push する流れを検証する。
+//!
+//! 全パイプは Synergos 既存機構を通る:
+//!   - 登録: `share_file` → `TransferLedger::register_offer` + `shared_files`
+//!   - トリガ: Exchange::handle_file_want(remote_requester, file_id, version)
+//!   - 送信: share_and_send → QUIC bidi `TXFR` stream
+//!   - 受信: Daemon 相当のアクセプタ → `handle_incoming_transfer`
+//!
+//! 本テストでは 2 ノード間の gossip 中継は手で叩き、QUIC 転送だけを本物で
+//! 通す。gossip の mesh 自体は別途 integration される。
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use synergos_core::event_bus::{CoreEventBus, SharedEventBus};
+use synergos_core::exchange::{
+    Exchange, FileSharing, OutPathResolver, ShareRequest, TransferPriority,
+};
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
+use synergos_net::transfer::TRANSFER_STREAM_MAGIC;
+use synergos_net::types::{Blake3Hash, FileId};
+
+fn qcfg() -> QuicConfig {
+    QuicConfig {
+        max_concurrent_streams: 8,
+        idle_timeout_ms: 5_000,
+        max_udp_payload_size: 1350,
+        enable_0rtt: false,
+    }
+}
+
+#[tokio::test]
+async fn file_want_auto_triggers_share_and_send_over_quic() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // ── セットアップ ──
+    let id_a = Arc::new(Identity::generate()); // sender / offerer
+    let id_b = Arc::new(Identity::generate()); // requester / receiver
+
+    let quic_a = Arc::new(QuicManager::new(qcfg(), id_a.clone()));
+    let quic_b = Arc::new(QuicManager::new(qcfg(), id_b.clone()));
+    let bound_a: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let _ = quic_a.bind(bound_a).await.unwrap();
+    let bound_b = quic_b.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+
+    // 受信側 (B) の保存先
+    let dst_dir = std::env::temp_dir().join(format!("synergos-auto-{}", uuid::Uuid::new_v4()));
+    tokio::fs::create_dir_all(&dst_dir).await.unwrap();
+
+    let bus_b: SharedEventBus = Arc::new(CoreEventBus::new());
+    let mut ex_b_inner = Exchange::with_network(bus_b.clone(), id_b.peer_id().clone(), None);
+    let dst_dir_b = dst_dir.clone();
+    let resolver_b: OutPathResolver =
+        Arc::new(move |_p, fid: &FileId| Some(dst_dir_b.join(&fid.0)));
+    ex_b_inner.attach_quic(quic_b.clone(), resolver_b);
+    let ex_b = Arc::new(ex_b_inner);
+
+    // B の accept ループ (Daemon 相当): 1 bidi 受けたら handle_incoming_transfer
+    let qb = quic_b.clone();
+    let ex_b_for_task = ex_b.clone();
+    let receive_task = tokio::spawn(async move {
+        if let Ok(Some(acc)) = qb.accept().await {
+            let sender = acc.peer_id.clone();
+            while let Ok((send, mut recv)) = acc.connection.accept_bi().await {
+                let _ = send;
+                let mut magic = [0u8; 4];
+                if recv.read_exact(&mut magic).await.is_err() {
+                    continue;
+                }
+                if &magic == TRANSFER_STREAM_MAGIC {
+                    let _ = ex_b_for_task
+                        .handle_incoming_transfer(recv, sender.clone())
+                        .await;
+                }
+                break;
+            }
+        }
+    });
+
+    // 送信側 (A) の Exchange
+    let bus_a: SharedEventBus = Arc::new(CoreEventBus::new());
+    let mut ex_a_inner = Exchange::with_network(bus_a.clone(), id_a.peer_id().clone(), None);
+    let dummy_resolver: OutPathResolver = Arc::new(|_, _| None);
+    ex_a_inner.attach_quic(quic_a.clone(), dummy_resolver);
+    let ex_a = Arc::new(ex_a_inner);
+
+    // A が file を共有登録 (TransferLedger + shared_files 両方)
+    let src_dir = std::env::temp_dir().join(format!("synergos-auto-src-{}", uuid::Uuid::new_v4()));
+    tokio::fs::create_dir_all(&src_dir).await.unwrap();
+    let src_file = src_dir.join("report.bin");
+    let payload: Vec<u8> = (0..100u32)
+        .flat_map(|n| (n as u8).to_le_bytes())
+        .cycle()
+        .take(200 * 1024)
+        .collect();
+    tokio::fs::write(&src_file, &payload).await.unwrap();
+
+    let file_id = FileId::new("report.bin");
+    ex_a.share_file(ShareRequest {
+        project_id: "p".into(),
+        file_id: file_id.clone(),
+        file_path: src_file.clone(),
+        file_size: payload.len() as u64,
+        checksum: Blake3Hash::default(),
+        priority: TransferPriority::Interactive,
+        target_peer: None, // broadcast offer; want 側でトリガ
+        version: 1,
+    })
+    .await
+    .unwrap();
+
+    // A が B に接続 (実運用では Conduit/Gossip が経路を提示してから張る)
+    quic_a
+        .connect(id_b.peer_id().clone(), bound_b, "synergos")
+        .await
+        .unwrap();
+
+    // ── B が FileWant を broadcast した、と想定して A の gossip subscriber
+    // 経由で handle_file_want を直接叩く (gossip 中継は別途統合) ──
+    ex_a.handle_file_want(id_b.peer_id().clone(), file_id.clone(), 1);
+
+    // 受信完了を待つ
+    tokio::time::timeout(Duration::from_secs(5), receive_task)
+        .await
+        .expect("receive task should finish")
+        .unwrap();
+
+    let got = tokio::fs::read(dst_dir.join("report.bin")).await.unwrap();
+    assert_eq!(got.len(), payload.len());
+    assert_eq!(got, payload);
+
+    let _ = tokio::fs::remove_dir_all(&src_dir).await;
+    let _ = tokio::fs::remove_dir_all(&dst_dir).await;
+}
+
+#[tokio::test]
+async fn file_want_without_shared_file_is_noop() {
+    let id = Arc::new(Identity::generate());
+    let quic = Arc::new(QuicManager::new(qcfg(), id.clone()));
+    quic.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+
+    let bus: SharedEventBus = Arc::new(CoreEventBus::new());
+    let mut ex_inner = Exchange::with_network(bus, id.peer_id().clone(), None);
+    let resolver: OutPathResolver = Arc::new(|_, _| None);
+    ex_inner.attach_quic(quic, resolver);
+    let ex = Arc::new(ex_inner);
+
+    // shared_files に無いので無視される (panic せず、転送も起動しない)
+    ex.handle_file_want(
+        synergos_net::types::PeerId::new("some-peer"),
+        FileId::new("nonexistent"),
+        1,
+    );
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(ex.list_transfers(None).await.len(), 0);
+}
+
+#[tokio::test]
+async fn file_offer_registers_remote_offer_in_ledger() {
+    let id = Arc::new(Identity::generate());
+    let bus: SharedEventBus = Arc::new(CoreEventBus::new());
+    let ex = Exchange::with_network(bus, id.peer_id().clone(), None);
+
+    // リモートピアからの offer を handle_file_offer で受け取る
+    ex.handle_file_offer(
+        synergos_net::types::PeerId::new("remote-sender"),
+        FileId::new("cool.bin"),
+        1,
+        1024,
+        42,
+    );
+    // ledger の pending_want_count は 0 (まだ Want 無い)
+    assert_eq!(
+        ex.ledger().pending_want_count(&FileId::new("cool.bin"), 1),
+        0
+    );
+}

--- a/synergos-core/tests/core_services.rs
+++ b/synergos-core/tests/core_services.rs
@@ -1,0 +1,222 @@
+//! PR-4: synergos-core サービスレイヤ L1。
+//!
+//! 対象:
+//! - ProjectManager::open/close/update
+//! - ConflictManager::detect/resolve/list/get
+//! - ExchangeManager (FileSharing trait) の Queued→Running→Cancelled 遷移
+//! - PresenceManager の update_bandwidth / update_rtt
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use synergos_core::conflict::{ConflictManager, ConflictResolution, ConflictState};
+use synergos_core::event_bus::{CoreEventBus, SharedEventBus};
+use synergos_core::exchange::{
+    Exchange, FetchRequest, FileSharing, ShareRequest, TransferPriority, TransferState,
+};
+use synergos_core::presence::PresenceService;
+use synergos_core::project::{ProjectConfiguration, ProjectManager};
+use synergos_net::types::{Blake3Hash, FileId, PeerId};
+
+fn bus() -> SharedEventBus {
+    Arc::new(CoreEventBus::new())
+}
+
+fn tmp_dir() -> PathBuf {
+    let p = std::env::temp_dir().join(format!("synergos-core-test-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+// ── ProjectManager ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn project_open_rejects_duplicate() {
+    let pm = ProjectManager::new(bus());
+    let dir = tmp_dir();
+    pm.open_project("p1".into(), dir.clone(), None).await.unwrap();
+    let err = pm
+        .open_project("p1".into(), dir.clone(), None)
+        .await
+        .unwrap_err();
+    use synergos_core::project::ProjectError;
+    assert!(matches!(err, ProjectError::AlreadyExists(_)));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn project_open_uses_fallback_display_name() {
+    let pm = ProjectManager::new(bus());
+    let dir = tmp_dir();
+    pm.open_project("pAlpha".into(), dir.clone(), None)
+        .await
+        .unwrap();
+    // Fallback: display_name が project_id になっているはず
+    let info = pm
+        .get_project("pAlpha")
+        .await
+        .expect("project exists");
+    assert_eq!(info.display_name, "pAlpha");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn project_close_unknown_errors() {
+    let pm = ProjectManager::new(bus());
+    let err = pm.close_project("unknown").await.unwrap_err();
+    use synergos_core::project::ProjectError;
+    assert!(matches!(err, ProjectError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn project_root_returns_registered_path() {
+    let pm = ProjectManager::new(bus());
+    let dir = tmp_dir();
+    pm.open_project("pB".into(), dir.clone(), None)
+        .await
+        .unwrap();
+    let root = pm.project_root("pB").expect("project registered");
+    assert_eq!(root, dir);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── ConflictManager ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn conflict_resolve_on_unknown_returns_err() {
+    let cm = ConflictManager::new(bus());
+    let err = cm.resolve_conflict(
+        &FileId::new("nofile"),
+        ConflictResolution::KeepLocal,
+    );
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn conflict_list_on_empty_returns_empty() {
+    let cm = ConflictManager::new(bus());
+    assert!(cm.list_conflicts(None).is_empty());
+}
+
+#[tokio::test]
+async fn conflict_cleanup_resolved_preserves_active() {
+    let cm = ConflictManager::new(bus());
+    // active な疑似コンフリクトを直接 conflicts に突っ込む手段が無いので
+    // cleanup 呼び出しだけ観測する (no-op の健全性確認)
+    cm.cleanup_resolved();
+    cm.cleanup_expired_notifications(1_000);
+    assert!(cm.list_conflicts(None).is_empty());
+}
+
+// ── Exchange (TransferState transitions) ────────────────────────────
+
+#[tokio::test]
+async fn exchange_fetch_registers_queued_transfer() {
+    let ex = Exchange::new(bus());
+    let id = ex
+        .fetch_file(FetchRequest {
+            project_id: "p".into(),
+            file_id: FileId::new("f"),
+            source_peer: None,
+            priority: TransferPriority::Background,
+            version: 0,
+        })
+        .await
+        .unwrap();
+    let info = ex.get_transfer(&id).await.expect("transfer stored");
+    // Queued でも Matched (offer 先行があれば Running) でも OK
+    assert!(matches!(info.state, TransferState::Queued | TransferState::Running));
+}
+
+#[tokio::test]
+async fn exchange_cancel_transitions_to_cancelled() {
+    let ex = Exchange::new(bus());
+    let id = ex
+        .share_file(ShareRequest {
+            project_id: "p".into(),
+            file_id: FileId::new("f"),
+            file_path: PathBuf::from("/tmp/none"),
+            file_size: 10,
+            checksum: Blake3Hash::default(),
+            priority: TransferPriority::Interactive,
+            target_peer: Some(PeerId::new("peer")),
+            version: 1,
+        })
+        .await
+        .unwrap();
+    ex.cancel_transfer(&id).await.unwrap();
+    let info = ex.get_transfer(&id).await.unwrap();
+    assert_eq!(info.state, TransferState::Cancelled);
+}
+
+#[tokio::test]
+async fn exchange_gc_finished_reaps_cancelled() {
+    let ex = Exchange::new(bus());
+    let id = ex
+        .share_file(ShareRequest {
+            project_id: "p".into(),
+            file_id: FileId::new("f"),
+            file_path: PathBuf::from("/tmp/none"),
+            file_size: 10,
+            checksum: Blake3Hash::default(),
+            priority: TransferPriority::Interactive,
+            target_peer: Some(PeerId::new("peer")),
+            version: 1,
+        })
+        .await
+        .unwrap();
+    ex.cancel_transfer(&id).await.unwrap();
+    let reaped = ex.gc_finished_transfers();
+    assert_eq!(reaped, 1);
+    assert!(ex.get_transfer(&id).await.is_none());
+}
+
+#[tokio::test]
+async fn exchange_pause_resume_roundtrip() {
+    let ex = Exchange::new(bus());
+    let id = ex
+        .share_file(ShareRequest {
+            project_id: "p".into(),
+            file_id: FileId::new("f"),
+            file_path: PathBuf::from("/tmp/none"),
+            file_size: 10,
+            checksum: Blake3Hash::default(),
+            priority: TransferPriority::Interactive,
+            target_peer: Some(PeerId::new("peer")),
+            version: 1,
+        })
+        .await
+        .unwrap();
+    // Queued 状態では pause は no-op
+    ex.pause_transfer(&id).await.unwrap();
+    // update_progress で Running にしてから pause
+    ex.update_progress(&id, 1, 1);
+    ex.pause_transfer(&id).await.unwrap();
+    assert_eq!(ex.get_transfer(&id).await.unwrap().state, TransferState::Paused);
+    ex.resume_transfer(&id).await.unwrap();
+    assert_eq!(ex.get_transfer(&id).await.unwrap().state, TransferState::Running);
+}
+
+// ── PresenceService ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn presence_update_rtt_and_bandwidth_are_idempotent() {
+    let p = PresenceService::new(bus());
+    let pid = PeerId::new("peer");
+    p.update_rtt(&pid, 42);
+    p.update_rtt(&pid, 50); // 上書き
+    p.update_bandwidth(&pid, 1_000_000);
+    p.update_bandwidth(&pid, 2_000_000);
+    // panic しなければ OK (内部 DashMap の set_if_exists パスを叩くだけ)
+}
+
+// Use ConflictState and ConflictResolution to silence unused warnings
+#[allow(dead_code)]
+fn _conflict_enum_coverage() -> (ConflictState, ConflictResolution) {
+    (
+        ConflictState::Resolved {
+            resolution: ConflictResolution::AcceptRemote,
+        },
+        ConflictResolution::ManualMerge,
+    )
+}

--- a/synergos-core/tests/core_services.rs
+++ b/synergos-core/tests/core_services.rs
@@ -34,7 +34,9 @@ fn tmp_dir() -> PathBuf {
 async fn project_open_rejects_duplicate() {
     let pm = ProjectManager::new(bus());
     let dir = tmp_dir();
-    pm.open_project("p1".into(), dir.clone(), None).await.unwrap();
+    pm.open_project("p1".into(), dir.clone(), None)
+        .await
+        .unwrap();
     let err = pm
         .open_project("p1".into(), dir.clone(), None)
         .await
@@ -52,10 +54,7 @@ async fn project_open_uses_fallback_display_name() {
         .await
         .unwrap();
     // Fallback: display_name が project_id になっているはず
-    let info = pm
-        .get_project("pAlpha")
-        .await
-        .expect("project exists");
+    let info = pm.get_project("pAlpha").await.expect("project exists");
     assert_eq!(info.display_name, "pAlpha");
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -85,10 +84,7 @@ async fn project_root_returns_registered_path() {
 #[tokio::test]
 async fn conflict_resolve_on_unknown_returns_err() {
     let cm = ConflictManager::new(bus());
-    let err = cm.resolve_conflict(
-        &FileId::new("nofile"),
-        ConflictResolution::KeepLocal,
-    );
+    let err = cm.resolve_conflict(&FileId::new("nofile"), ConflictResolution::KeepLocal);
     assert!(err.is_err());
 }
 
@@ -125,7 +121,10 @@ async fn exchange_fetch_registers_queued_transfer() {
         .unwrap();
     let info = ex.get_transfer(&id).await.expect("transfer stored");
     // Queued でも Matched (offer 先行があれば Running) でも OK
-    assert!(matches!(info.state, TransferState::Queued | TransferState::Running));
+    assert!(matches!(
+        info.state,
+        TransferState::Queued | TransferState::Running
+    ));
 }
 
 #[tokio::test]
@@ -192,9 +191,15 @@ async fn exchange_pause_resume_roundtrip() {
     // update_progress で Running にしてから pause
     ex.update_progress(&id, 1, 1);
     ex.pause_transfer(&id).await.unwrap();
-    assert_eq!(ex.get_transfer(&id).await.unwrap().state, TransferState::Paused);
+    assert_eq!(
+        ex.get_transfer(&id).await.unwrap().state,
+        TransferState::Paused
+    );
     ex.resume_transfer(&id).await.unwrap();
-    assert_eq!(ex.get_transfer(&id).await.unwrap().state, TransferState::Running);
+    assert_eq!(
+        ex.get_transfer(&id).await.unwrap().state,
+        TransferState::Running
+    );
 }
 
 // ── PresenceService ─────────────────────────────────────────────────

--- a/synergos-core/tests/ipc_handlers.rs
+++ b/synergos-core/tests/ipc_handlers.rs
@@ -3,12 +3,12 @@
 
 use std::sync::Arc;
 
+use synergos_core::conflict::ConflictManager;
 use synergos_core::event_bus::{CoreEventBus, SharedEventBus};
 use synergos_core::exchange::Exchange;
 use synergos_core::ipc_server::{dispatch_command, ServiceContext};
 use synergos_core::presence::PresenceService;
 use synergos_core::project::ProjectManager;
-use synergos_core::conflict::ConflictManager;
 use synergos_ipc::command::IpcCommand;
 use synergos_ipc::response::IpcResponse;
 use tokio::sync::broadcast;

--- a/synergos-core/tests/ipc_handlers.rs
+++ b/synergos-core/tests/ipc_handlers.rs
@@ -1,0 +1,140 @@
+//! PR-5: synergos-core IPC サーバー handler 単体テスト。
+//! dispatch_command を直接呼び、各コマンドが期待した IpcResponse を返すか確認する。
+
+use std::sync::Arc;
+
+use synergos_core::event_bus::{CoreEventBus, SharedEventBus};
+use synergos_core::exchange::Exchange;
+use synergos_core::ipc_server::{dispatch_command, ServiceContext};
+use synergos_core::presence::PresenceService;
+use synergos_core::project::ProjectManager;
+use synergos_core::conflict::ConflictManager;
+use synergos_ipc::command::IpcCommand;
+use synergos_ipc::response::IpcResponse;
+use tokio::sync::broadcast;
+
+fn make_ctx() -> Arc<ServiceContext> {
+    let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
+    let (shutdown_tx, _) = broadcast::channel(1);
+    Arc::new(ServiceContext {
+        event_bus: event_bus.clone(),
+        project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
+        exchange: Arc::new(Exchange::new(event_bus.clone())),
+        presence: Arc::new(PresenceService::new(event_bus.clone())),
+        conflict_manager: Arc::new(ConflictManager::new(event_bus.clone())),
+        shutdown_tx,
+        started_at: 0,
+    })
+}
+
+#[tokio::test]
+async fn ping_returns_pong() {
+    let ctx = make_ctx();
+    let resp = dispatch_command(IpcCommand::Ping, &ctx).await;
+    matches!(resp, IpcResponse::Pong);
+}
+
+#[tokio::test]
+async fn status_reports_zero_counts_initially() {
+    let ctx = make_ctx();
+    let resp = dispatch_command(IpcCommand::Status, &ctx).await;
+    match resp {
+        IpcResponse::Status(s) => {
+            assert_eq!(s.project_count, 0);
+            assert_eq!(s.active_connections, 0);
+            assert_eq!(s.active_transfers, 0);
+            assert!(s.pid > 0);
+        }
+        other => panic!("expected Status, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn project_list_on_empty_returns_empty() {
+    let ctx = make_ctx();
+    let resp = dispatch_command(IpcCommand::ProjectList, &ctx).await;
+    match resp {
+        IpcResponse::ProjectList(list) => assert!(list.is_empty()),
+        other => panic!("expected ProjectList, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn project_get_unknown_returns_error() {
+    let ctx = make_ctx();
+    let resp = dispatch_command(
+        IpcCommand::ProjectGet {
+            project_id: "doesnotexist".into(),
+        },
+        &ctx,
+    )
+    .await;
+    match resp {
+        IpcResponse::Error { .. } => (),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn project_open_then_list_reflects_it() {
+    let ctx = make_ctx();
+    let dir = std::env::temp_dir().join(format!("synergos-ipc-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let resp = dispatch_command(
+        IpcCommand::ProjectOpen {
+            project_id: "pX".into(),
+            root_path: dir.clone(),
+            display_name: Some("Project X".into()),
+        },
+        &ctx,
+    )
+    .await;
+    matches!(resp, IpcResponse::Ok);
+
+    let list_resp = dispatch_command(IpcCommand::ProjectList, &ctx).await;
+    match list_resp {
+        IpcResponse::ProjectList(list) => {
+            assert!(list.iter().any(|p| p.project_id == "pX"));
+        }
+        other => panic!("expected ProjectList, got {other:?}"),
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn transfer_list_on_empty_is_empty() {
+    let ctx = make_ctx();
+    let resp = dispatch_command(IpcCommand::TransferList { project_id: None }, &ctx).await;
+    match resp {
+        IpcResponse::TransferList(list) => assert!(list.is_empty()),
+        other => panic!("expected TransferList, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unsubscribe_unknown_returns_ok() {
+    // 現状実装は未知の subscription_id を silently ignore する。
+    // 将来 Error を返す設計にするなら回帰テストでここを更新する。
+    let ctx = make_ctx();
+    let resp = dispatch_command(
+        IpcCommand::Unsubscribe {
+            subscription_id: "nope".into(),
+        },
+        &ctx,
+    )
+    .await;
+    match resp {
+        IpcResponse::Ok | IpcResponse::Error { .. } => (),
+        other => panic!("expected Ok/Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn network_status_returns_hardcoded_shape() {
+    let ctx = make_ctx();
+    let resp = dispatch_command(IpcCommand::NetworkStatus, &ctx).await;
+    match resp {
+        IpcResponse::NetworkStatus(_) => (),
+        other => panic!("expected NetworkStatus, got {other:?}"),
+    }
+}

--- a/synergos-core/tests/ipc_integration.rs
+++ b/synergos-core/tests/ipc_integration.rs
@@ -1,0 +1,128 @@
+//! PR-7: L3 IPC Client ↔ Server 統合テスト (duplex pipe 版)。
+//!
+//! 実 Unix socket / Named pipe ではなく `tokio::io::duplex` を使って
+//! IpcTransport ベースのラウンドトリップを検証する。
+
+use std::sync::Arc;
+
+use synergos_core::conflict::ConflictManager;
+use synergos_core::event_bus::{CoreEventBus, SharedEventBus};
+use synergos_core::exchange::Exchange;
+use synergos_core::ipc_server::{dispatch_command, ServiceContext};
+use synergos_core::presence::PresenceService;
+use synergos_core::project::ProjectManager;
+use synergos_ipc::command::IpcCommand;
+use synergos_ipc::response::IpcResponse;
+use synergos_ipc::transport::IpcTransport;
+use tokio::io::duplex;
+use tokio::sync::broadcast;
+
+fn make_ctx() -> Arc<ServiceContext> {
+    let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
+    let (shutdown_tx, _) = broadcast::channel(1);
+    Arc::new(ServiceContext {
+        event_bus: event_bus.clone(),
+        project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
+        exchange: Arc::new(Exchange::new(event_bus.clone())),
+        presence: Arc::new(PresenceService::new(event_bus.clone())),
+        conflict_manager: Arc::new(ConflictManager::new(event_bus.clone())),
+        shutdown_tx,
+        started_at: 0,
+    })
+}
+
+/// duplex pipe の片方でサーバーループを回し、もう片方をクライアント代わりに使う
+async fn run_server_once(
+    ctx: Arc<ServiceContext>,
+    mut reader: tokio::io::DuplexStream,
+    mut writer: tokio::io::DuplexStream,
+) {
+    loop {
+        let cmd: IpcCommand = match IpcTransport::read_message(&mut reader).await {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        let resp = dispatch_command(cmd, &ctx).await;
+        if IpcTransport::write_message(&mut writer, &resp).await.is_err() {
+            return;
+        }
+    }
+}
+
+#[tokio::test]
+async fn ping_pong_roundtrip_over_duplex() {
+    let ctx = make_ctx();
+    let (mut client_tx, server_rx) = duplex(64 * 1024);
+    let (server_tx, mut client_rx) = duplex(64 * 1024);
+
+    let server_task = tokio::spawn(run_server_once(ctx, server_rx, server_tx));
+
+    IpcTransport::write_message(&mut client_tx, &IpcCommand::Ping)
+        .await
+        .unwrap();
+    let resp: IpcResponse = IpcTransport::read_message(&mut client_rx).await.unwrap();
+    matches!(resp, IpcResponse::Pong);
+
+    drop(client_tx);
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn multiple_commands_preserve_order() {
+    let ctx = make_ctx();
+    let (mut client_tx, server_rx) = duplex(64 * 1024);
+    let (server_tx, mut client_rx) = duplex(64 * 1024);
+
+    let server_task = tokio::spawn(run_server_once(ctx, server_rx, server_tx));
+
+    for _ in 0..3 {
+        IpcTransport::write_message(&mut client_tx, &IpcCommand::Ping)
+            .await
+            .unwrap();
+    }
+    for _ in 0..3 {
+        let resp: IpcResponse = IpcTransport::read_message(&mut client_rx).await.unwrap();
+        assert!(matches!(resp, IpcResponse::Pong));
+    }
+
+    drop(client_tx);
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn malformed_client_frame_closes_server_gracefully() {
+    let ctx = make_ctx();
+    let (mut client_tx, server_rx) = duplex(64 * 1024);
+    let (server_tx, _client_rx) = duplex(64 * 1024);
+
+    let server_task = tokio::spawn(run_server_once(ctx, server_rx, server_tx));
+
+    // 偽のフレーム: length-prefix は正しいがペイロードが壊れている
+    use tokio::io::AsyncWriteExt;
+    let bad_len = 10u32.to_le_bytes();
+    client_tx.write_all(&bad_len).await.unwrap();
+    client_tx.write_all(&[0xffu8; 10]).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    drop(client_tx);
+    // サーバ側が抜けることを確認 (タイムアウト付き)
+    tokio::time::timeout(std::time::Duration::from_secs(2), server_task)
+        .await
+        .expect("server should exit on malformed frame")
+        .ok();
+}
+
+#[tokio::test]
+async fn client_disconnect_cleans_up_server() {
+    let ctx = make_ctx();
+    let (client_tx, server_rx) = duplex(64 * 1024);
+    let (server_tx, _client_rx) = duplex(64 * 1024);
+
+    let server_task = tokio::spawn(run_server_once(ctx, server_rx, server_tx));
+
+    drop(client_tx);
+    tokio::time::timeout(std::time::Duration::from_secs(2), server_task)
+        .await
+        .expect("server must exit after client close")
+        .ok();
+}

--- a/synergos-core/tests/ipc_integration.rs
+++ b/synergos-core/tests/ipc_integration.rs
@@ -43,7 +43,10 @@ async fn run_server_once(
             Err(_) => return,
         };
         let resp = dispatch_command(cmd, &ctx).await;
-        if IpcTransport::write_message(&mut writer, &resp).await.is_err() {
+        if IpcTransport::write_message(&mut writer, &resp)
+            .await
+            .is_err()
+        {
             return;
         }
     }

--- a/synergos-core/tests/transfer_e2e.rs
+++ b/synergos-core/tests/transfer_e2e.rs
@@ -1,0 +1,176 @@
+//! Exchange::execute_send と handle_incoming_transfer を 2 ノード QUIC 間で
+//! 往復させる E2E。S1 認証、`TXFR` magic ディスパッチ、進捗イベント、
+//! complete_transfer までが繋がっていることを確認する。
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use synergos_core::event_bus::{CoreEventBus, SharedEventBus};
+use synergos_core::exchange::{Exchange, FileSharing, OutPathResolver, ShareRequest};
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
+use synergos_net::transfer::{hash_file, TransferHeader, TRANSFER_STREAM_MAGIC};
+use synergos_net::types::{Blake3Hash, FileId, TransferId};
+
+fn qcfg() -> QuicConfig {
+    QuicConfig {
+        max_concurrent_streams: 8,
+        idle_timeout_ms: 5_000,
+        max_udp_payload_size: 1350,
+        enable_0rtt: false,
+    }
+}
+
+#[tokio::test]
+async fn execute_send_and_handle_incoming_roundtrip() {
+    use synergos_core::exchange::TransferPriority;
+
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let server_id = Arc::new(Identity::generate());
+    let client_id = Arc::new(Identity::generate());
+
+    let server_quic = Arc::new(QuicManager::new(qcfg(), server_id.clone()));
+    let client_quic = Arc::new(QuicManager::new(qcfg(), client_id.clone()));
+
+    let server_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let bound = server_quic.bind(server_addr).await.unwrap();
+    client_quic
+        .bind((Ipv4Addr::LOCALHOST, 0).into())
+        .await
+        .unwrap();
+
+    // サーバ側 accept + dispatcher を spawn
+    let dst_dir = std::env::temp_dir().join(format!(
+        "synergos-e2e-dst-{}",
+        uuid::Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&dst_dir).await.unwrap();
+
+    let event_bus_server: SharedEventBus = Arc::new(CoreEventBus::new());
+    let mut ex_server = Exchange::with_network(
+        event_bus_server.clone(),
+        server_id.peer_id().clone(),
+        None,
+    );
+    let dst_dir_clone = dst_dir.clone();
+    let resolver: OutPathResolver = Arc::new(move |_p, file_id: &FileId| {
+        Some(dst_dir_clone.join(&file_id.0))
+    });
+    ex_server.attach_quic(server_quic.clone(), resolver);
+    let ex_server = Arc::new(ex_server);
+
+    let sq = server_quic.clone();
+    let ex = ex_server.clone();
+    let accept_task = tokio::spawn(async move {
+        // accept 1 回 + bidi 1 本 を処理する最小ディスパッチャ
+        if let Ok(Some(acc)) = sq.accept().await {
+            let sender = acc.peer_id.clone();
+            let connection = acc.connection;
+            loop {
+                match connection.accept_bi().await {
+                    Ok((send, mut recv)) => {
+                        let _ = send; // 受信側は不要
+                        let mut magic = [0u8; 4];
+                        if recv.read_exact(&mut magic).await.is_err() {
+                            continue;
+                        }
+                        if &magic == TRANSFER_STREAM_MAGIC {
+                            let _ = ex.handle_incoming_transfer(recv, sender.clone()).await;
+                        }
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    });
+
+    // ソースファイルを用意
+    let src_dir = std::env::temp_dir().join(format!(
+        "synergos-e2e-src-{}",
+        uuid::Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&src_dir).await.unwrap();
+    let src_file = src_dir.join("sample.bin");
+    let payload = (0..200u32)
+        .flat_map(|n| (n as u8).to_le_bytes())
+        .cycle()
+        .take(256 * 1024)
+        .collect::<Vec<u8>>();
+    tokio::fs::write(&src_file, &payload).await.unwrap();
+
+    // クライアント→サーバへ接続
+    client_quic
+        .connect(server_id.peer_id().clone(), bound, "synergos")
+        .await
+        .unwrap();
+
+    // クライアント側 Exchange
+    let event_bus_client: SharedEventBus = Arc::new(CoreEventBus::new());
+    let mut ex_client = Exchange::with_network(
+        event_bus_client.clone(),
+        client_id.peer_id().clone(),
+        None,
+    );
+    let dummy_resolver: OutPathResolver = Arc::new(|_, _| None);
+    ex_client.attach_quic(client_quic.clone(), dummy_resolver);
+    let ex_client = Arc::new(ex_client);
+
+    // share_file を直接呼ぶ代わりに execute_send を発射
+    let (total_hash, total_size, chunk_count) = hash_file(&src_file).await.unwrap();
+    let file_id = FileId::new("sample.bin");
+    let transfer_id = TransferId::generate();
+    let header = TransferHeader {
+        transfer_id: transfer_id.0.clone(),
+        project_id: "proj-1".into(),
+        file_id: file_id.0.clone(),
+        total_size,
+        chunk_count,
+        total_hash,
+    };
+
+    // クライアント側でも ActiveTransfer を用意しておく (execute_send が更新する対象)
+    ex_client
+        .share_file(ShareRequest {
+            project_id: "proj-1".into(),
+            file_id: file_id.clone(),
+            file_path: src_file.clone(),
+            file_size: total_size,
+            checksum: Blake3Hash::default(),
+            priority: TransferPriority::Interactive,
+            target_peer: Some(server_id.peer_id().clone()),
+            version: 1,
+        })
+        .await
+        .unwrap();
+
+    // ActiveTransfer の transfer_id が自動生成されるので、新規に作り直して
+    // execute_send に渡す — ここでは直接低レベル API をテストする。
+    ex_client
+        .execute_send(
+            transfer_id.clone(),
+            server_id.peer_id().clone(),
+            src_file.clone(),
+            header,
+        )
+        .await
+        .unwrap();
+
+    // 受信側の完了を待つ
+    tokio::time::timeout(Duration::from_secs(5), accept_task)
+        .await
+        .expect("accept task should finish")
+        .unwrap();
+
+    // サーバ側が完了ファイルを保存していることを確認
+    let received = tokio::fs::read(dst_dir.join("sample.bin")).await.unwrap();
+    assert_eq!(received.len(), payload.len());
+    assert_eq!(received, payload);
+
+    // クリーンアップ
+    let _ = tokio::fs::remove_dir_all(&src_dir).await;
+    let _ = tokio::fs::remove_dir_all(&dst_dir).await;
+}

--- a/synergos-core/tests/transfer_e2e.rs
+++ b/synergos-core/tests/transfer_e2e.rs
@@ -43,22 +43,15 @@ async fn execute_send_and_handle_incoming_roundtrip() {
         .unwrap();
 
     // サーバ側 accept + dispatcher を spawn
-    let dst_dir = std::env::temp_dir().join(format!(
-        "synergos-e2e-dst-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let dst_dir = std::env::temp_dir().join(format!("synergos-e2e-dst-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&dst_dir).await.unwrap();
 
     let event_bus_server: SharedEventBus = Arc::new(CoreEventBus::new());
-    let mut ex_server = Exchange::with_network(
-        event_bus_server.clone(),
-        server_id.peer_id().clone(),
-        None,
-    );
+    let mut ex_server =
+        Exchange::with_network(event_bus_server.clone(), server_id.peer_id().clone(), None);
     let dst_dir_clone = dst_dir.clone();
-    let resolver: OutPathResolver = Arc::new(move |_p, file_id: &FileId| {
-        Some(dst_dir_clone.join(&file_id.0))
-    });
+    let resolver: OutPathResolver =
+        Arc::new(move |_p, file_id: &FileId| Some(dst_dir_clone.join(&file_id.0)));
     ex_server.attach_quic(server_quic.clone(), resolver);
     let ex_server = Arc::new(ex_server);
 
@@ -69,30 +62,22 @@ async fn execute_send_and_handle_incoming_roundtrip() {
         if let Ok(Some(acc)) = sq.accept().await {
             let sender = acc.peer_id.clone();
             let connection = acc.connection;
-            loop {
-                match connection.accept_bi().await {
-                    Ok((send, mut recv)) => {
-                        let _ = send; // 受信側は不要
-                        let mut magic = [0u8; 4];
-                        if recv.read_exact(&mut magic).await.is_err() {
-                            continue;
-                        }
-                        if &magic == TRANSFER_STREAM_MAGIC {
-                            let _ = ex.handle_incoming_transfer(recv, sender.clone()).await;
-                        }
-                        break;
-                    }
-                    Err(_) => break,
+            while let Ok((send, mut recv)) = connection.accept_bi().await {
+                let _ = send; // 受信側は不要
+                let mut magic = [0u8; 4];
+                if recv.read_exact(&mut magic).await.is_err() {
+                    continue;
                 }
+                if &magic == TRANSFER_STREAM_MAGIC {
+                    let _ = ex.handle_incoming_transfer(recv, sender.clone()).await;
+                }
+                break;
             }
         }
     });
 
     // ソースファイルを用意
-    let src_dir = std::env::temp_dir().join(format!(
-        "synergos-e2e-src-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let src_dir = std::env::temp_dir().join(format!("synergos-e2e-src-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&src_dir).await.unwrap();
     let src_file = src_dir.join("sample.bin");
     let payload = (0..200u32)
@@ -110,11 +95,8 @@ async fn execute_send_and_handle_incoming_roundtrip() {
 
     // クライアント側 Exchange
     let event_bus_client: SharedEventBus = Arc::new(CoreEventBus::new());
-    let mut ex_client = Exchange::with_network(
-        event_bus_client.clone(),
-        client_id.peer_id().clone(),
-        None,
-    );
+    let mut ex_client =
+        Exchange::with_network(event_bus_client.clone(), client_id.peer_id().clone(), None);
     let dummy_resolver: OutPathResolver = Arc::new(|_, _| None);
     ex_client.attach_quic(client_quic.clone(), dummy_resolver);
     let ex_client = Arc::new(ex_client);

--- a/synergos-gui/src/connection.rs
+++ b/synergos-gui/src/connection.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use synergos_ipc::command::IpcCommand;
 use synergos_ipc::response::{
-    DaemonStatus, NetworkStatusInfo, PeerInfo, ProjectInfo, TransferInfo,
+    ConflictInfoDto, DaemonStatus, NetworkStatusInfo, PeerInfo, ProjectInfo, TransferInfo,
 };
 
 /// Core デーモンへの接続状態
@@ -27,6 +27,7 @@ pub struct ConnectionCache {
     pub peers: Vec<PeerInfo>,
     pub transfers: Vec<TransferInfo>,
     pub network: Option<NetworkStatusInfo>,
+    pub conflicts: Vec<ConflictInfoDto>,
     /// 最後にリフレッシュした時刻
     pub last_refresh: Option<std::time::Instant>,
 }
@@ -201,6 +202,46 @@ impl CoreConnection {
             project_id: project_id.into(),
             file_id: file_id.into(),
             peer_id: peer_id.into(),
+        });
+        matches!(resp, Some(synergos_ipc::IpcResponse::Ok))
+    }
+
+    // ── コンフリクト (#13) ──
+
+    /// コンフリクト一覧をリフレッシュ
+    pub fn refresh_conflicts(&self, project_id: Option<&str>) {
+        let resp = self.send_command(IpcCommand::ConflictList {
+            project_id: project_id.map(String::from),
+        });
+        if let Some(synergos_ipc::IpcResponse::ConflictList(items)) = resp {
+            let mut cache = self.cache.lock().unwrap();
+            cache.conflicts = items;
+        }
+    }
+
+    /// コンフリクトを解決する。
+    /// `resolution` は "keep_local" / "accept_remote" / "manual_merge"。
+    pub fn resolve_conflict(&self, file_id: &str, resolution: &str) -> bool {
+        let resp = self.send_command(IpcCommand::ConflictResolve {
+            file_id: file_id.into(),
+            resolution: resolution.into(),
+        });
+        matches!(resp, Some(synergos_ipc::IpcResponse::Ok))
+    }
+
+    // ── 設定変更 (#13) ──
+
+    /// ネットワーク設定を部分更新する。成功時 true。
+    pub fn update_config(
+        &self,
+        mesh_n: Option<u16>,
+        max_concurrent_streams: Option<u32>,
+        tunnel_hostname: Option<String>,
+    ) -> bool {
+        let resp = self.send_command(IpcCommand::ConfigUpdate {
+            mesh_n,
+            max_concurrent_streams,
+            tunnel_hostname,
         });
         matches!(resp, Some(synergos_ipc::IpcResponse::Ok))
     }

--- a/synergos-gui/src/ui/conflicts.rs
+++ b/synergos-gui/src/ui/conflicts.rs
@@ -27,9 +27,7 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection) {
     if conflicts.is_empty() {
         ui.label("No active conflicts.");
         ui.add_space(8.0);
-        ui.label(
-            "When file conflicts are detected between peers, they will appear here.",
-        );
+        ui.label("When file conflicts are detected between peers, they will appear here.");
         render_help(ui);
         return;
     }
@@ -50,24 +48,32 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection) {
 
                 for c in &conflicts {
                     ui.label(&c.file_path);
-                    ui.label(format!("{} ({})", c.local_version, truncate(&c.local_author)));
-                    ui.label(format!("{} ({})", c.remote_version, truncate(&c.remote_author)));
+                    ui.label(format!(
+                        "{} ({})",
+                        c.local_version,
+                        truncate(&c.local_author)
+                    ));
+                    ui.label(format!(
+                        "{} ({})",
+                        c.remote_version,
+                        truncate(&c.remote_author)
+                    ));
                     ui.label(&c.state);
                     ui.horizontal(|ui| {
-                        if ui.button("Keep Local").clicked() {
-                            if connection.resolve_conflict(&c.file_id, "keep_local") {
-                                connection.refresh_conflicts(None);
-                            }
+                        if ui.button("Keep Local").clicked()
+                            && connection.resolve_conflict(&c.file_id, "keep_local")
+                        {
+                            connection.refresh_conflicts(None);
                         }
-                        if ui.button("Accept Remote").clicked() {
-                            if connection.resolve_conflict(&c.file_id, "accept_remote") {
-                                connection.refresh_conflicts(None);
-                            }
+                        if ui.button("Accept Remote").clicked()
+                            && connection.resolve_conflict(&c.file_id, "accept_remote")
+                        {
+                            connection.refresh_conflicts(None);
                         }
-                        if ui.button("Manual").clicked() {
-                            if connection.resolve_conflict(&c.file_id, "manual_merge") {
-                                connection.refresh_conflicts(None);
-                            }
+                        if ui.button("Manual").clicked()
+                            && connection.resolve_conflict(&c.file_id, "manual_merge")
+                        {
+                            connection.refresh_conflicts(None);
                         }
                     });
                     ui.end_row();

--- a/synergos-gui/src/ui/conflicts.rs
+++ b/synergos-gui/src/ui/conflicts.rs
@@ -1,18 +1,93 @@
 //! コンフリクト管理パネル
+//!
+//! `ConflictList` IPC でアクティブコンフリクトを取得し、各行に
+//! [Keep Local] / [Accept Remote] / [Manual Merge] の解決ボタンを描画する。
 
 use crate::connection::CoreConnection;
 
-pub fn show(ui: &mut egui::Ui, _connection: &CoreConnection) {
-    ui.heading("Conflicts");
+pub fn show(ui: &mut egui::Ui, connection: &CoreConnection) {
+    ui.horizontal(|ui| {
+        ui.heading("Conflicts");
+        if ui.button("Refresh").clicked() {
+            connection.refresh_conflicts(None);
+        }
+    });
     ui.separator();
 
-    ui.label("No active conflicts.");
-    ui.add_space(8.0);
+    // キャッシュからコンフリクト一覧を取得
+    let (conflicts, _stale) = {
+        let cache = connection.cache.lock().unwrap();
+        let stale = cache
+            .last_refresh
+            .map(|t| t.elapsed().as_secs() > 5)
+            .unwrap_or(true);
+        (cache.conflicts.clone(), stale)
+    };
 
-    ui.label("When file conflicts are detected between peers, they will appear here.");
+    if conflicts.is_empty() {
+        ui.label("No active conflicts.");
+        ui.add_space(8.0);
+        ui.label(
+            "When file conflicts are detected between peers, they will appear here.",
+        );
+        render_help(ui);
+        return;
+    }
+
+    // 一覧テーブル
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        egui::Grid::new("conflicts_table")
+            .num_columns(5)
+            .striped(true)
+            .spacing([12.0, 8.0])
+            .show(ui, |ui| {
+                ui.strong("File");
+                ui.strong("Local v.");
+                ui.strong("Remote v.");
+                ui.strong("State");
+                ui.strong("Actions");
+                ui.end_row();
+
+                for c in &conflicts {
+                    ui.label(&c.file_path);
+                    ui.label(format!("{} ({})", c.local_version, truncate(&c.local_author)));
+                    ui.label(format!("{} ({})", c.remote_version, truncate(&c.remote_author)));
+                    ui.label(&c.state);
+                    ui.horizontal(|ui| {
+                        if ui.button("Keep Local").clicked() {
+                            if connection.resolve_conflict(&c.file_id, "keep_local") {
+                                connection.refresh_conflicts(None);
+                            }
+                        }
+                        if ui.button("Accept Remote").clicked() {
+                            if connection.resolve_conflict(&c.file_id, "accept_remote") {
+                                connection.refresh_conflicts(None);
+                            }
+                        }
+                        if ui.button("Manual").clicked() {
+                            if connection.resolve_conflict(&c.file_id, "manual_merge") {
+                                connection.refresh_conflicts(None);
+                            }
+                        }
+                    });
+                    ui.end_row();
+                }
+            });
+    });
+
+    render_help(ui);
+}
+
+fn truncate(id: &str) -> String {
+    if id.len() > 12 {
+        format!("{}…", &id[..12])
+    } else {
+        id.to_string()
+    }
+}
+
+fn render_help(ui: &mut egui::Ui) {
     ui.add_space(16.0);
-
-    // コンフリクト解決方法の説明
     ui.collapsing("Resolution Methods", |ui| {
         egui::Grid::new("conflict_help")
             .num_columns(2)

--- a/synergos-gui/src/ui/settings.rs
+++ b/synergos-gui/src/ui/settings.rs
@@ -73,12 +73,11 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection) {
     // ── ネットワーク設定 編集 (#13) ──
     ui.collapsing("Network Tuning", |ui| {
         let id = ui.make_persistent_id("synergos_net_tuning");
-        let (mut mesh_n, mut max_streams, mut hostname, mut feedback) =
-            ui.memory_mut(|m| {
-                m.data
-                    .get_persisted::<(String, String, String, String)>(id)
-                    .unwrap_or_default()
-            });
+        let (mut mesh_n, mut max_streams, mut hostname, mut feedback) = ui.memory_mut(|m| {
+            m.data
+                .get_persisted::<(String, String, String, String)>(id)
+                .unwrap_or_default()
+        });
 
         egui::Grid::new("network_tuning_form")
             .num_columns(2)

--- a/synergos-gui/src/ui/settings.rs
+++ b/synergos-gui/src/ui/settings.rs
@@ -70,6 +70,62 @@ pub fn show(ui: &mut egui::Ui, connection: &CoreConnection) {
 
     ui.add_space(8.0);
 
+    // ── ネットワーク設定 編集 (#13) ──
+    ui.collapsing("Network Tuning", |ui| {
+        let id = ui.make_persistent_id("synergos_net_tuning");
+        let (mut mesh_n, mut max_streams, mut hostname, mut feedback) =
+            ui.memory_mut(|m| {
+                m.data
+                    .get_persisted::<(String, String, String, String)>(id)
+                    .unwrap_or_default()
+            });
+
+        egui::Grid::new("network_tuning_form")
+            .num_columns(2)
+            .spacing([12.0, 6.0])
+            .show(ui, |ui| {
+                ui.label("gossipsub.mesh_n:");
+                ui.text_edit_singleline(&mut mesh_n);
+                ui.end_row();
+
+                ui.label("quic.max_concurrent_streams:");
+                ui.text_edit_singleline(&mut max_streams);
+                ui.end_row();
+
+                ui.label("tunnel.hostname:");
+                ui.text_edit_singleline(&mut hostname);
+                ui.end_row();
+            });
+
+        if ui.button("Apply").clicked() {
+            let parsed_mesh = mesh_n.trim().parse::<u16>().ok();
+            let parsed_max = max_streams.trim().parse::<u32>().ok();
+            let parsed_host = if hostname.trim().is_empty() {
+                None
+            } else {
+                Some(hostname.trim().to_string())
+            };
+            let ok = connection.update_config(parsed_mesh, parsed_max, parsed_host);
+            feedback = if ok {
+                "Applied (restart daemon for full effect)".into()
+            } else {
+                "Update rejected".into()
+            };
+        }
+
+        ui.memory_mut(|m| {
+            m.data
+                .insert_persisted(id, (mesh_n, max_streams, hostname, feedback.clone()))
+        });
+
+        if !feedback.is_empty() {
+            ui.add_space(4.0);
+            ui.colored_label(egui::Color32::from_rgb(120, 120, 180), &feedback);
+        }
+    });
+
+    ui.add_space(8.0);
+
     // 転送設定（説明のみ）
     ui.collapsing("Transfer Policy", |ui| {
         egui::Grid::new("transfer_settings")

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -198,7 +198,10 @@ impl IpcCommand {
                 }
                 Ok(())
             }
-            Self::ConflictResolve { file_id, resolution } => {
+            Self::ConflictResolve {
+                file_id,
+                resolution,
+            } => {
                 check_id("file_id", file_id)?;
                 match resolution.as_str() {
                     "keep_local" | "accept_remote" | "manual_merge" => Ok(()),

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -78,6 +78,27 @@ pub enum IpcCommand {
         file_paths: Vec<PathBuf>,
     },
 
+    // ── コンフリクト管理 ──
+    /// プロジェクトのアクティブなコンフリクト一覧
+    ConflictList { project_id: Option<String> },
+    /// コンフリクトを解決する
+    ConflictResolve {
+        file_id: String,
+        /// "keep_local" | "accept_remote" | "manual_merge"
+        resolution: String,
+    },
+
+    // ── 設定変更 ──
+    /// NetConfig の部分更新 (受け取れる主要フィールドだけ)
+    ConfigUpdate {
+        /// gossipsub.mesh_n
+        mesh_n: Option<u16>,
+        /// quic.max_concurrent_streams
+        max_concurrent_streams: Option<u32>,
+        /// tunnel.hostname
+        tunnel_hostname: Option<String>,
+    },
+
     // ── モニタリング ──
     /// ネットワーク状態取得
     NetworkStatus,
@@ -170,6 +191,21 @@ impl IpcCommand {
 
             Self::Subscribe { .. } => Ok(()),
             Self::Unsubscribe { subscription_id } => check_id("subscription_id", subscription_id),
+
+            Self::ConflictList { project_id } => {
+                if let Some(p) = project_id {
+                    check_id("project_id", p)?;
+                }
+                Ok(())
+            }
+            Self::ConflictResolve { file_id, resolution } => {
+                check_id("file_id", file_id)?;
+                match resolution.as_str() {
+                    "keep_local" | "accept_remote" | "manual_merge" => Ok(()),
+                    other => Err(format!("invalid resolution: {other}")),
+                }
+            }
+            Self::ConfigUpdate { .. } => Ok(()),
         }
     }
 }

--- a/synergos-ipc/src/response.rs
+++ b/synergos-ipc/src/response.rs
@@ -40,8 +40,25 @@ pub enum IpcResponse {
     /// ネットワーク状態
     NetworkStatus(NetworkStatusInfo),
 
+    /// コンフリクト一覧
+    ConflictList(Vec<ConflictInfoDto>),
+
     /// イベント購読完了
     Subscribed { subscription_id: String },
+}
+
+/// コンフリクト情報 (IPC 向け DTO)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConflictInfoDto {
+    pub file_id: String,
+    pub file_path: String,
+    pub project_id: String,
+    pub local_version: u64,
+    pub local_author: String,
+    pub remote_version: u64,
+    pub remote_author: String,
+    pub detected_at: u64,
+    pub state: String,
 }
 
 /// デーモン状態

--- a/synergos-net/Cargo.toml
+++ b/synergos-net/Cargo.toml
@@ -8,6 +8,7 @@ description = "P2P network foundation with QUIC, Cloudflare Tunnel, DHT/Gossipsu
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
+futures = "0.3"
 
 # QUIC
 quinn = "0.11"
@@ -17,13 +18,15 @@ rustls = { version = "0.23", features = ["ring"] }
 prost = "0.13"
 prost-types = "0.13"
 serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
 rmp-serde = "1"
 
 # Crypto / Hash
 blake3 = "1"
-ed25519-dalek = { version = "2", features = ["std", "rand_core"] }
+ed25519-dalek = { version = "2", features = ["std", "rand_core", "pkcs8"] }
 rand = "0.8"
 hex = "0.4"
+x509-parser = "0.16"
 
 # DNS
 hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls"] }

--- a/synergos-net/src/chain/file_chain.rs
+++ b/synergos-net/src/chain/file_chain.rs
@@ -102,21 +102,23 @@ impl ChainBlock {
     pub fn verify(&self) -> Result<()> {
         let derived = identity::peer_id_from_public_bytes(&self.author_public_key);
         if derived != self.author {
-            return Err(SynergosNetError::Gossip(
+            return Err(SynergosNetError::Identity(
                 "ChainBlock author does not match public key".into(),
             ));
         }
         let mut clone = self.clone();
         clone.compute_hash();
         if clone.hash != self.hash {
-            return Err(SynergosNetError::Gossip("ChainBlock hash mismatch".into()));
+            return Err(SynergosNetError::Identity(
+                "ChainBlock hash mismatch".into(),
+            ));
         }
         identity::verify(
             &self.author_public_key,
             &self.signing_message(),
             &self.signature,
         )
-        .map_err(|_| SynergosNetError::Gossip("ChainBlock signature invalid".into()))?;
+        .map_err(|_| SynergosNetError::Identity("ChainBlock signature invalid".into()))?;
         Ok(())
     }
 

--- a/synergos-net/src/dht/mod.rs
+++ b/synergos-net/src/dht/mod.rs
@@ -1,5 +1,9 @@
 mod node;
 mod routing;
+pub mod rpc;
+pub mod transport;
 
 pub use node::*;
 pub use routing::*;
+pub use rpc::{DhtRequest, DhtResponse, DhtTransport, PeerRecordDto, RouteDto};
+pub use transport::{handle_dht_stream, QuicDhtTransport, DHT_STREAM_MAGIC};

--- a/synergos-net/src/dht/node.rs
+++ b/synergos-net/src/dht/node.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tokio::sync::RwLock;
 
 use super::routing::{BucketEntry, RoutingTable};
+use super::rpc::{DhtRequest, DhtResponse, DhtTransport, PeerRecordDto};
 use crate::config::DhtConfig;
 use crate::types::{NodeId, PeerId, Route};
 
@@ -24,6 +26,53 @@ pub struct PeerRecord {
 impl PeerRecord {
     pub fn is_expired(&self) -> bool {
         self.published_at.elapsed() > self.ttl
+    }
+
+    /// DTO への変換 (送信用)
+    pub fn to_dto(&self) -> PeerRecordDto {
+        PeerRecordDto {
+            peer_id: self.peer_id.clone(),
+            display_name: self.display_name.clone(),
+            endpoints: self.endpoints.iter().map(Into::into).collect(),
+            active_projects: self.active_projects.clone(),
+            ttl_secs: self.ttl.as_secs(),
+        }
+    }
+
+    /// DTO → PeerRecord の復元。published_at は受信側の now で近似する。
+    pub fn from_dto(dto: PeerRecordDto) -> Self {
+        Self {
+            peer_id: dto.peer_id,
+            display_name: dto.display_name,
+            endpoints: dto.endpoints.iter().map(Into::into).collect(),
+            active_projects: dto.active_projects,
+            published_at: Instant::now(),
+            ttl: Duration::from_secs(dto.ttl_secs),
+        }
+    }
+}
+
+/// `find_peer_iterative` の動作パラメータ。
+#[derive(Debug, Clone)]
+pub struct FindNodeOptions {
+    /// 1 ラウンド (= 1 peer への問合せ) あたりのタイムアウト
+    pub per_request_timeout: Duration,
+    /// 最大ホップ数 (再帰深さ)
+    pub max_hops: u8,
+    /// 1 ラウンドあたりに並行問合せる α (Kademlia でいう α = 3 が標準)
+    pub alpha: usize,
+    /// 最終的に束ねる closest k 件
+    pub k: usize,
+}
+
+impl Default for FindNodeOptions {
+    fn default() -> Self {
+        Self {
+            per_request_timeout: Duration::from_secs(3),
+            max_hops: 4,
+            alpha: 3,
+            k: 20,
+        }
     }
 }
 
@@ -60,20 +109,178 @@ impl DhtNode {
         }
     }
 
-    /// ピアを検索（Kademlia FIND_NODE）
-    pub async fn find_peer(&self, peer_id: &PeerId) -> Option<PeerRecord> {
+    /// ローカルストアのみから peer_id を探す。ネットワーク lookup は含まない。
+    pub async fn find_peer_local(&self, peer_id: &PeerId) -> Option<PeerRecord> {
         let target_node_id = NodeId::from_peer_id(peer_id);
-
-        // まずローカルストアを確認
         if let Some(record) = self.store.get(&target_node_id) {
             if !record.is_expired() {
                 return Some(record.clone());
             }
         }
-
-        // ルーティングテーブルから最も近いノードを取得
-        // （実際のネットワーク問い合わせは上位レイヤが行う）
         None
+    }
+
+    /// ピアを検索 (ローカルストア優先)。トランスポートが無い環境では
+    /// この `find_peer` (= `find_peer_local`) を使う。
+    pub async fn find_peer(&self, peer_id: &PeerId) -> Option<PeerRecord> {
+        self.find_peer_local(peer_id).await
+    }
+
+    /// Kademlia iterative FIND_NODE。ネットワーク経由で target PeerId を探す。
+    ///
+    /// アルゴリズム:
+    /// 1. ローカル store に hit すれば即座に返す
+    /// 2. ルーティングテーブルから target に近い α 件を候補として取り、問合せキューへ
+    /// 3. 並行に `FindNode` を投げ、返ってきた候補をキューへ足す
+    /// 4. hop 数が `max_hops` に達するか、新たに追加できる近接ノードが尽きたら終了
+    ///
+    /// `alpha`, `max_hops`, `per_request_timeout` で暴走を防止する。
+    pub async fn find_peer_iterative(
+        &self,
+        target: &PeerId,
+        transport: &dyn DhtTransport,
+        opts: FindNodeOptions,
+    ) -> Option<PeerRecord> {
+        if let Some(local) = self.find_peer_local(target).await {
+            return Some(local);
+        }
+
+        let target_node_id = NodeId::from_peer_id(target);
+
+        // ルーティングテーブルから初期 α 件
+        let mut queried: HashSet<PeerId> = HashSet::new();
+        queried.insert(self.local_peer_id.clone());
+
+        let mut candidates: Vec<PeerId> = self
+            .closest_peers(&target_node_id, opts.alpha.max(1))
+            .await
+            .into_iter()
+            .filter(|p| !queried.contains(p))
+            .collect();
+
+        for hop in 0..opts.max_hops {
+            if candidates.is_empty() {
+                tracing::debug!(
+                    "find_peer_iterative: no more candidates at hop {hop} for target {}",
+                    target.short()
+                );
+                break;
+            }
+
+            // 今回 hop でまわす α 件をピック。queried に追加しておくことで重複を防ぐ。
+            let round: Vec<PeerId> = candidates.drain(..).take(opts.alpha).collect();
+            for p in &round {
+                queried.insert(p.clone());
+            }
+
+            // α 件を並列発射
+            let mut futures = Vec::with_capacity(round.len());
+            for peer in &round {
+                let peer = peer.clone();
+                let req = DhtRequest::FindNode {
+                    target: target.clone(),
+                };
+                let timeout = opts.per_request_timeout;
+                futures.push(async move {
+                    let fut = transport.request(&peer, &req);
+                    match tokio::time::timeout(timeout, fut).await {
+                        Ok(Ok(resp)) => Some((peer, resp)),
+                        Ok(Err(e)) => {
+                            tracing::debug!(
+                                "find_peer_iterative: transport error from {}: {e}",
+                                peer.short()
+                            );
+                            None
+                        }
+                        Err(_) => {
+                            tracing::debug!(
+                                "find_peer_iterative: timeout from {}",
+                                peer.short()
+                            );
+                            None
+                        }
+                    }
+                });
+            }
+            let round_results = futures::future::join_all(futures).await;
+
+            for (_responder, response) in round_results.into_iter().flatten() {
+                match response {
+                    DhtResponse::Nodes { exact, closest } => {
+                        if let Some(dto) = exact {
+                            let rec = PeerRecord::from_dto(dto);
+                            // 受信側でも local store に kick back しておく
+                            self.announce(rec.clone()).await;
+                            return Some(rec);
+                        }
+                        for dto in closest {
+                            let rec = PeerRecord::from_dto(dto);
+                            let pid = rec.peer_id.clone();
+                            // routing table にも反映
+                            self.add_peer(pid.clone(), rec.endpoints.clone(), None).await;
+                            // 未問合せなら候補に入れる
+                            if !queried.contains(&pid) && !candidates.contains(&pid) {
+                                candidates.push(pid);
+                            }
+                        }
+                    }
+                    DhtResponse::Error { message } => {
+                        tracing::debug!("find_peer_iterative: peer error: {message}");
+                    }
+                    _ => {
+                        tracing::debug!("find_peer_iterative: unexpected response variant");
+                    }
+                }
+            }
+
+            // 候補を target に近い順へソートして次 hop へ
+            candidates.sort_by(|a, b| {
+                let da = NodeId::from_peer_id(a).xor_distance(&target_node_id);
+                let db = NodeId::from_peer_id(b).xor_distance(&target_node_id);
+                da.cmp(&db)
+            });
+            candidates.truncate(opts.k);
+        }
+
+        // 全 hop 消化した後にもう一度ローカル (受信側で announce された分) を確認
+        self.find_peer_local(target).await
+    }
+
+    /// 受信したリクエストをディスパッチする (サーバ側ハンドラ)。
+    /// 受信する型を既に判別済みの前提 — トランスポート層から呼ばれる。
+    pub async fn handle_request(&self, req: DhtRequest) -> DhtResponse {
+        match req {
+            DhtRequest::Ping => DhtResponse::Pong,
+            DhtRequest::FindNode { target } => {
+                let target_node_id = NodeId::from_peer_id(&target);
+                let exact = self.find_peer_local(&target).await.map(|r| r.to_dto());
+                let closest_ids = self.closest_peers(&target_node_id, 20).await;
+                let closest = closest_ids
+                    .into_iter()
+                    .filter_map(|pid| {
+                        let node_id = NodeId::from_peer_id(&pid);
+                        self.store.get(&node_id).map(|e| e.value().to_dto())
+                    })
+                    .collect();
+                DhtResponse::Nodes { exact, closest }
+            }
+            DhtRequest::FindProjectPeers { project_id } => {
+                let peers = self
+                    .find_project_peers(&project_id)
+                    .await
+                    .iter()
+                    .map(|r| r.to_dto())
+                    .collect();
+                DhtResponse::ProjectPeers { peers }
+            }
+            DhtRequest::Announce { record } => {
+                let peer_id = record.peer_id.clone();
+                let endpoints = record.endpoints.iter().map(Into::into).collect::<Vec<_>>();
+                self.announce(PeerRecord::from_dto(record)).await;
+                self.add_peer(peer_id, endpoints, None).await;
+                DhtResponse::AnnounceAck
+            }
+        }
     }
 
     /// 特定プロジェクトに参加しているピアを検索

--- a/synergos-net/src/dht/node.rs
+++ b/synergos-net/src/dht/node.rs
@@ -193,10 +193,7 @@ impl DhtNode {
                             None
                         }
                         Err(_) => {
-                            tracing::debug!(
-                                "find_peer_iterative: timeout from {}",
-                                peer.short()
-                            );
+                            tracing::debug!("find_peer_iterative: timeout from {}", peer.short());
                             None
                         }
                     }
@@ -217,7 +214,8 @@ impl DhtNode {
                             let rec = PeerRecord::from_dto(dto);
                             let pid = rec.peer_id.clone();
                             // routing table にも反映
-                            self.add_peer(pid.clone(), rec.endpoints.clone(), None).await;
+                            self.add_peer(pid.clone(), rec.endpoints.clone(), None)
+                                .await;
                             // 未問合せなら候補に入れる
                             if !queried.contains(&pid) && !candidates.contains(&pid) {
                                 candidates.push(pid);

--- a/synergos-net/src/dht/rpc.rs
+++ b/synergos-net/src/dht/rpc.rs
@@ -1,0 +1,224 @@
+//! DHT FIND_NODE RPC (S-BASE の iterative Kademlia lookup に必要な
+//! 最小限のメッセージ型 + 汎用トランスポートトレイト).
+//!
+//! トランスポート自体は QUIC に固定せず、トレイト `DhtTransport` を介して
+//! 注入できるようにしてある。これにより:
+//!
+//! - 単体テストで in-memory のモックトランスポートを使える
+//! - 将来 TLS over WebSocket 経由の relay lookup を差し込むのも容易
+//!
+//! フレーミングは `[u32 length][msgpack payload]` の単純形。リクエストと
+//! レスポンスは 1 ラウンド = 1 ストリームで完結する (長時間のフォローアップは無い)。
+
+use std::net::SocketAddrV6;
+
+use async_trait::async_trait;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SynergosNetError};
+use crate::types::{PeerId, Route};
+
+/// DHT レコード (PeerRecord の over-the-wire 表現)。
+/// `Instant` は序列化できないので published_at は省略し、TTL だけ伝える。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerRecordDto {
+    pub peer_id: PeerId,
+    pub display_name: String,
+    pub endpoints: Vec<RouteDto>,
+    pub active_projects: Vec<String>,
+    pub ttl_secs: u64,
+}
+
+/// Route のシリアライズ用。`Route` は現状 serde 実装済みだが、将来の
+/// network 表現のブレから隔離するため DTO を噛ませておく。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RouteDto {
+    Direct {
+        addr: SocketAddrV6,
+        fqdn: Option<String>,
+    },
+    Tunnel {
+        tunnel_id: String,
+        hostname: String,
+    },
+    Relay {
+        server_url: String,
+        room_id: String,
+    },
+}
+
+impl From<&Route> for RouteDto {
+    fn from(r: &Route) -> Self {
+        match r {
+            Route::Direct { addr, fqdn } => RouteDto::Direct {
+                addr: *addr,
+                fqdn: fqdn.clone(),
+            },
+            Route::Tunnel {
+                tunnel_id,
+                hostname,
+            } => RouteDto::Tunnel {
+                tunnel_id: tunnel_id.clone(),
+                hostname: hostname.clone(),
+            },
+            Route::Relay {
+                server_url,
+                room_id,
+            } => RouteDto::Relay {
+                server_url: server_url.clone(),
+                room_id: room_id.clone(),
+            },
+        }
+    }
+}
+
+impl From<&RouteDto> for Route {
+    fn from(r: &RouteDto) -> Self {
+        match r {
+            RouteDto::Direct { addr, fqdn } => Route::Direct {
+                addr: *addr,
+                fqdn: fqdn.clone(),
+            },
+            RouteDto::Tunnel {
+                tunnel_id,
+                hostname,
+            } => Route::Tunnel {
+                tunnel_id: tunnel_id.clone(),
+                hostname: hostname.clone(),
+            },
+            RouteDto::Relay {
+                server_url,
+                room_id,
+            } => Route::Relay {
+                server_url: server_url.clone(),
+                room_id: room_id.clone(),
+            },
+        }
+    }
+}
+
+/// DHT RPC リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DhtRequest {
+    /// 近接ノードの返却を要求
+    FindNode { target: PeerId },
+    /// プロジェクトに参加しているピアを要求
+    FindProjectPeers { project_id: String },
+    /// 自分のレコードを announce
+    Announce { record: PeerRecordDto },
+    /// ヘルスチェック
+    Ping,
+}
+
+/// DHT RPC レスポンス
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DhtResponse {
+    /// FIND_NODE への応答 (closest k 件 + もしあれば exact match を含む)
+    Nodes {
+        /// 応答ノードの exact hit (responder 自身が target レコードを持っていた場合)
+        exact: Option<PeerRecordDto>,
+        /// target に近い closest k 件
+        closest: Vec<PeerRecordDto>,
+    },
+    /// FindProjectPeers への応答
+    ProjectPeers { peers: Vec<PeerRecordDto> },
+    /// Announce の ack
+    AnnounceAck,
+    /// Ping への pong
+    Pong,
+    /// エラー
+    Error { message: String },
+}
+
+/// RPC ラウンドをトランスポートを介して往復させる trait。
+/// QUIC / 相関テストで差し替え可能にする。
+#[async_trait]
+pub trait DhtTransport: Send + Sync {
+    /// 指定ピアに `req` を送り、1 回の応答を受け取る。
+    async fn request(&self, peer: &PeerId, req: &DhtRequest) -> Result<DhtResponse>;
+}
+
+/// バイト列 → `DhtRequest` のフレーム復号。ヘッダ `[u32 big-endian length]` の後ろに msgpack ペイロード。
+pub fn encode<T: Serialize>(msg: &T) -> Result<Vec<u8>> {
+    let body =
+        rmp_serde::to_vec(msg).map_err(|e| SynergosNetError::Serialization(format!("{e}")))?;
+    if body.len() > MAX_FRAME_SIZE {
+        return Err(SynergosNetError::Serialization(format!(
+            "DHT frame too large: {} > {}",
+            body.len(),
+            MAX_FRAME_SIZE
+        )));
+    }
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+pub fn decode<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T> {
+    if bytes.len() < 4 {
+        return Err(SynergosNetError::Serialization(
+            "DHT frame too short".into(),
+        ));
+    }
+    let len = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    if len > MAX_FRAME_SIZE || bytes.len() != 4 + len {
+        return Err(SynergosNetError::Serialization(format!(
+            "DHT frame length mismatch ({} declared, {} actual)",
+            len,
+            bytes.len() - 4
+        )));
+    }
+    rmp_serde::from_slice(&bytes[4..]).map_err(|e| SynergosNetError::Serialization(format!("{e}")))
+}
+
+/// リクエスト 1 本あたりの最大サイズ (1 MiB)。`FindNode` でも 1 shard の
+/// 返すノード数は k 個 (20 程度) なので十分な余裕。
+pub const MAX_FRAME_SIZE: usize = 1024 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_request_roundtrip() {
+        let req = DhtRequest::FindNode {
+            target: PeerId::new("abc"),
+        };
+        let bytes = encode(&req).unwrap();
+        let back: DhtRequest = decode(&bytes).unwrap();
+        match back {
+            DhtRequest::FindNode { target } => assert_eq!(target.0, "abc"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn encode_decode_response_roundtrip() {
+        let resp = DhtResponse::Nodes {
+            exact: None,
+            closest: vec![PeerRecordDto {
+                peer_id: PeerId::new("a"),
+                display_name: "alice".into(),
+                endpoints: vec![],
+                active_projects: vec!["p1".into()],
+                ttl_secs: 60,
+            }],
+        };
+        let bytes = encode(&resp).unwrap();
+        let back: DhtResponse = decode(&bytes).unwrap();
+        match back {
+            DhtResponse::Nodes { closest, .. } => assert_eq!(closest.len(), 1),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn decode_rejects_malformed_length() {
+        let mut bytes = vec![0u8; 10];
+        bytes[0..4].copy_from_slice(&999u32.to_be_bytes());
+        let r: Result<DhtRequest> = decode(&bytes);
+        assert!(r.is_err());
+    }
+}

--- a/synergos-net/src/dht/transport.rs
+++ b/synergos-net/src/dht/transport.rs
@@ -1,0 +1,118 @@
+//! QUIC を実体としたい `DhtTransport` 実装と、サーバ側の受信ループ。
+//!
+//! 前提条件:
+//! - 相手ピアとは既に `QuicManager::connect` 済み (= ピア真性認証済み)
+//! - DHT RPC は独立した双方向ストリームを 1 本使う。1 ストリーム = 1 ラウンド
+//!
+//! フレーミングは `rpc::encode` / `rpc::decode` のペア。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::error::{Result, SynergosNetError};
+use crate::quic::{QuicManager, StreamType};
+use crate::types::PeerId;
+
+use super::node::DhtNode;
+use super::rpc::{self, DhtRequest, DhtResponse, DhtTransport, MAX_FRAME_SIZE};
+
+/// プロトコルマジック: DHT ストリームのヘッダ先頭に置いて識別する。
+pub const DHT_STREAM_MAGIC: &[u8; 4] = b"DHT1";
+
+/// QUIC バックエンド。`QuicManager` が相手ピアへの既存コネクションを
+/// 保持している必要がある。
+pub struct QuicDhtTransport {
+    quic: Arc<QuicManager>,
+}
+
+impl QuicDhtTransport {
+    pub fn new(quic: Arc<QuicManager>) -> Self {
+        Self { quic }
+    }
+}
+
+#[async_trait]
+impl DhtTransport for QuicDhtTransport {
+    async fn request(&self, peer: &PeerId, req: &DhtRequest) -> Result<DhtResponse> {
+        let (mut send, mut recv) = self.quic.open_stream(peer, StreamType::Control).await?;
+
+        // ヘッダ + フレーム
+        send.write_all(DHT_STREAM_MAGIC).await.map_err(to_err)?;
+        let payload = rpc::encode(req)?;
+        send.write_all(&payload).await.map_err(to_err)?;
+        send.finish()
+            .map_err(|e| SynergosNetError::Quic(format!("finish: {e}")))?;
+
+        // 応答を受け取る
+        let mut magic = [0u8; 4];
+        recv.read_exact(&mut magic).await.map_err(to_err)?;
+        if &magic != DHT_STREAM_MAGIC {
+            return Err(SynergosNetError::Serialization(
+                "DHT response magic mismatch".into(),
+            ));
+        }
+
+        let mut len_buf = [0u8; 4];
+        recv.read_exact(&mut len_buf).await.map_err(to_err)?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+        if len > MAX_FRAME_SIZE {
+            return Err(SynergosNetError::Serialization(format!(
+                "DHT response too large: {len}"
+            )));
+        }
+        let mut body = vec![0u8; len];
+        recv.read_exact(&mut body).await.map_err(to_err)?;
+
+        // rpc::decode はヘッダ付きを期待するので合成
+        let mut full = Vec::with_capacity(4 + len);
+        full.extend_from_slice(&len_buf);
+        full.extend_from_slice(&body);
+        rpc::decode(&full)
+    }
+}
+
+/// 1 本の DHT ストリームを処理する: ヘッダ読み込み → リクエスト復号 →
+/// `DhtNode::handle_request` → 応答送信。エラーはログ化。
+pub async fn handle_dht_stream(
+    dht: Arc<DhtNode>,
+    mut send: quinn::SendStream,
+    mut recv: quinn::RecvStream,
+) -> Result<()> {
+    let mut magic = [0u8; 4];
+    recv.read_exact(&mut magic).await.map_err(to_err)?;
+    if &magic != DHT_STREAM_MAGIC {
+        return Err(SynergosNetError::Serialization(
+            "DHT request magic mismatch".into(),
+        ));
+    }
+
+    let mut len_buf = [0u8; 4];
+    recv.read_exact(&mut len_buf).await.map_err(to_err)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > MAX_FRAME_SIZE {
+        return Err(SynergosNetError::Serialization(format!(
+            "DHT request too large: {len}"
+        )));
+    }
+    let mut body = vec![0u8; len];
+    recv.read_exact(&mut body).await.map_err(to_err)?;
+
+    let mut full = Vec::with_capacity(4 + len);
+    full.extend_from_slice(&len_buf);
+    full.extend_from_slice(&body);
+    let req: DhtRequest = rpc::decode(&full)?;
+
+    let resp = dht.handle_request(req).await;
+
+    send.write_all(DHT_STREAM_MAGIC).await.map_err(to_err)?;
+    let out = rpc::encode(&resp)?;
+    send.write_all(&out).await.map_err(to_err)?;
+    send.finish()
+        .map_err(|e| SynergosNetError::Quic(format!("finish: {e}")))?;
+    Ok(())
+}
+
+fn to_err<E: std::fmt::Display>(e: E) -> SynergosNetError {
+    SynergosNetError::Quic(format!("DHT IO: {e}"))
+}

--- a/synergos-net/src/dht/transport.rs
+++ b/synergos-net/src/dht/transport.rs
@@ -72,21 +72,17 @@ impl DhtTransport for QuicDhtTransport {
     }
 }
 
-/// 1 本の DHT ストリームを処理する: ヘッダ読み込み → リクエスト復号 →
-/// `DhtNode::handle_request` → 応答送信。エラーはログ化。
+/// 1 本の DHT ストリームを処理する: 長さ付きリクエスト読込 →
+/// `DhtNode::handle_request` → 応答送信。
+///
+/// 呼び出し側 (ストリームディスパッチャ) が magic (`DHT1`) を既に消費済みの
+/// 前提で入る。`send.write_all(DHT_STREAM_MAGIC)` で応答側の magic は
+/// このハンドラが付与する。
 pub async fn handle_dht_stream(
     dht: Arc<DhtNode>,
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
 ) -> Result<()> {
-    let mut magic = [0u8; 4];
-    recv.read_exact(&mut magic).await.map_err(to_err)?;
-    if &magic != DHT_STREAM_MAGIC {
-        return Err(SynergosNetError::Serialization(
-            "DHT request magic mismatch".into(),
-        ));
-    }
-
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf).await.map_err(to_err)?;
     let len = u32::from_be_bytes(len_buf) as usize;

--- a/synergos-net/src/gossip/message.rs
+++ b/synergos-net/src/gossip/message.rs
@@ -35,12 +35,12 @@ impl SignedGossipMessage {
     /// 等の peer_id が `sender_public_key` の導出結果と一致することも確認する。
     pub fn verify(&self) -> Result<()> {
         if self.sender_public_key.len() != 32 {
-            return Err(SynergosNetError::Gossip(
+            return Err(SynergosNetError::Identity(
                 "gossip sender_public_key length != 32".into(),
             ));
         }
         if self.signature.len() != 64 {
-            return Err(SynergosNetError::Gossip(
+            return Err(SynergosNetError::Identity(
                 "gossip signature length != 64".into(),
             ));
         }
@@ -55,21 +55,21 @@ impl SignedGossipMessage {
         match &self.message {
             GossipMessage::PeerStatus { origin, .. } => {
                 if origin != &derived {
-                    return Err(SynergosNetError::Gossip(
+                    return Err(SynergosNetError::Identity(
                         "gossip origin peer_id mismatch with signer".into(),
                     ));
                 }
             }
             GossipMessage::FileOffer { sender, .. } => {
                 if sender != &derived {
-                    return Err(SynergosNetError::Gossip(
+                    return Err(SynergosNetError::Identity(
                         "gossip FileOffer sender mismatch with signer".into(),
                     ));
                 }
             }
             GossipMessage::FileWant { requester, .. } => {
                 if requester != &derived {
-                    return Err(SynergosNetError::Gossip(
+                    return Err(SynergosNetError::Identity(
                         "gossip FileWant requester mismatch with signer".into(),
                     ));
                 }
@@ -79,7 +79,7 @@ impl SignedGossipMessage {
             GossipMessage::CatalogUpdate { .. } | GossipMessage::ConflictAlert { .. } => {}
         }
         identity::verify(&pub_bytes, &signing_bytes(&self.message), &sig_bytes)
-            .map_err(|_| SynergosNetError::Gossip("gossip signature invalid".into()))
+            .map_err(|_| SynergosNetError::Identity("gossip signature invalid".into()))
     }
 }
 

--- a/synergos-net/src/identity.rs
+++ b/synergos-net/src/identity.rs
@@ -13,6 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
+use ed25519_dalek::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey, SECRET_KEY_LENGTH};
 
 use crate::types::PeerId;
@@ -119,6 +120,33 @@ impl Identity {
     /// 任意のバイト列に対する署名 (64 bytes)
     pub fn sign(&self, message: &[u8]) -> [u8; 64] {
         self.signing.sign(message).to_bytes()
+    }
+
+    /// 秘密鍵を PKCS#8 v2 DER で出力する (rcgen / rustls 取り込み用)。
+    pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, IdentityError> {
+        self.signing
+            .to_pkcs8_der()
+            .map(|doc| doc.as_bytes().to_vec())
+            .map_err(|e| IdentityError::InvalidKeyFile {
+                reason: format!("pkcs8 export failed: {e}"),
+            })
+    }
+
+    /// PKCS#8 DER で受け取った ed25519 秘密鍵から Identity を組み立てる。
+    /// テスト用にしか使わない想定だが、`identity.key` が PKCS#8 形式で
+    /// 供給された場合の読み込みにも使える。
+    pub fn from_pkcs8_der(der: &[u8]) -> Result<Self, IdentityError> {
+        let signing =
+            SigningKey::from_pkcs8_der(der).map_err(|e| IdentityError::InvalidKeyFile {
+                reason: format!("pkcs8 import failed: {e}"),
+            })?;
+        let verifying = signing.verifying_key();
+        let peer_id = peer_id_from_verifying(&verifying);
+        Ok(Self {
+            signing,
+            verifying,
+            peer_id,
+        })
     }
 
     /// 既定のアイデンティティ格納パス。プロセス内で一度だけ解決する想定。

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -69,10 +69,11 @@ impl SynergosNet {
     /// Network Foundation を起動する
     pub fn new(
         config: NetConfig,
-        local_peer_id: PeerId,
+        identity: Arc<Identity>,
         project_id: String,
         handler: Arc<dyn NetEventHandler>,
     ) -> Self {
+        let local_peer_id = identity.peer_id().clone();
         let dht = DhtNode::new(local_peer_id.clone(), config.dht.clone());
         let gossip = GossipNode::new(local_peer_id, config.gossipsub.clone());
         let catalog = CatalogManager::new(
@@ -81,7 +82,7 @@ impl SynergosNet {
             config.catalog.chain_max_depth,
         );
         let ledger = TransferLedger::new();
-        let quic = Arc::new(QuicManager::new(config.quic.clone()));
+        let quic = Arc::new(QuicManager::new(config.quic.clone(), identity));
         let tunnel = Arc::new(TunnelManager::new(&config.tunnel));
         let mesh = Arc::new(Mesh::new(config.mesh.clone()));
         let conduit = Conduit::new(

--- a/synergos-net/src/mesh/mod.rs
+++ b/synergos-net/src/mesh/mod.rs
@@ -300,23 +300,50 @@ impl Mesh {
 
     // ── 内部ヘルパー ──
 
-    /// DNS-over-HTTPS で AAAA レコードを解決
+    /// DNS-over-HTTPS で AAAA レコードを解決 (複数プロバイダ + DNSSEC 検証)
+    ///
+    /// Cloudflare → Google の順で試行し、いずれか応答が得られればそれを返す。
+    /// DNSSEC 検証を常時 ON にすることで、中間者による偽 AAAA 注入を防ぐ (S23)。
     async fn resolve_doh(&self, fqdn: &str) -> Result<Vec<Ipv6Addr>> {
         use hickory_resolver::config::{ResolverConfig, ResolverOpts};
         use hickory_resolver::TokioAsyncResolver;
 
-        let resolver =
-            TokioAsyncResolver::tokio(ResolverConfig::cloudflare_https(), ResolverOpts::default());
+        let providers: Vec<(&str, ResolverConfig)> = vec![
+            ("cloudflare_https", ResolverConfig::cloudflare_https()),
+            ("google_https", ResolverConfig::google_https()),
+        ];
 
-        let response = resolver
-            .ipv6_lookup(fqdn)
-            .await
-            .map_err(|e| SynergosNetError::DnsResolution(format!("DoH lookup failed: {}", e)))?;
+        let mut last_err: Option<String> = None;
+        for (name, cfg) in providers {
+            let mut opts = ResolverOpts::default();
+            opts.validate = true; // DNSSEC 検証を要求
+            opts.timeout = Duration::from_secs(5);
 
-        let addrs: Vec<Ipv6Addr> = response.iter().map(|aaaa| aaaa.0).collect();
+            let resolver = TokioAsyncResolver::tokio(cfg, opts);
+            match resolver.ipv6_lookup(fqdn).await {
+                Ok(response) => {
+                    let addrs: Vec<Ipv6Addr> = response.iter().map(|aaaa| aaaa.0).collect();
+                    if !addrs.is_empty() {
+                        tracing::debug!(
+                            "DoH ({}) resolved {} → {} addresses",
+                            name,
+                            fqdn,
+                            addrs.len()
+                        );
+                        return Ok(addrs);
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("DoH ({}) lookup for {} failed: {e}", name, fqdn);
+                    last_err = Some(format!("{name}: {e}"));
+                }
+            }
+        }
 
-        tracing::debug!("DoH resolved {} → {} addresses", fqdn, addrs.len());
-        Ok(addrs)
+        Err(SynergosNetError::DnsResolution(format!(
+            "DoH lookup failed across all providers: {}",
+            last_err.unwrap_or_else(|| "no response".into())
+        )))
     }
 
     /// 通常の DNS で AAAA レコードを解決

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -2,6 +2,23 @@
 //!
 //! quinn を使った QUIC 接続の確立・管理・ストリーム制御を提供する。
 //! サーバー（リスナー）とクライアント（コネクタ）の両方の役割を担う。
+//!
+//! ## S1 ピア真性認証
+//!
+//! Synergos の PeerId は `blake3(pubkey)[:20]` である。S1 対策として
+//! QUIC 層では以下を強制している:
+//!
+//! 1. サーバ (着信側) は、ローカル `Identity` の ed25519 キーから rcgen で
+//!    自己署名証明書を生成する。証明書の `subjectPublicKeyInfo` には
+//!    ed25519 公開鍵がそのまま載るため、クライアントは SPKI の公開鍵を
+//!    取り出して `blake3(pubkey)[:20] == expected_peer_id` を検証できる。
+//! 2. クライアント (発信側) は `connect()` で期待する PeerId を明示的に
+//!    渡す必要があり、内部で `PeerPinningVerifier` を差し込んだ
+//!    `ClientConfig` を都度生成して `endpoint.connect_with()` する。
+//! 3. ピアの公開鍵が PeerId に一致しない場合は TLS ハンドシェイク時点で
+//!    拒否する。緩和パス (旧 `DevOnlySkipVerify`) は完全に削除した。
+
+mod verifier;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -12,7 +29,10 @@ use tokio::sync::RwLock;
 
 use crate::config::QuicConfig;
 use crate::error::{Result, SynergosNetError};
+use crate::identity::Identity;
 use crate::types::{PeerId, TransferId};
+
+pub use verifier::PeerPinningVerifier;
 
 /// QUIC ストリーム種別
 #[derive(Debug, Clone)]
@@ -114,6 +134,8 @@ impl ConnectionCalibrator {
 /// サーバー（着信接続の受付）とクライアント（発信接続の確立）の両方を担当する。
 pub struct QuicManager {
     config: QuicConfig,
+    /// 自ノードの暗号アイデンティティ (S1 の真性認証で使う)
+    identity: Arc<Identity>,
     /// アクティブなコネクション（PeerId → QuicConnection）
     connections: DashMap<PeerId, QuicConnection>,
     /// quinn エンドポイント（初期化後にセット）
@@ -125,9 +147,11 @@ pub struct QuicManager {
 }
 
 impl QuicManager {
-    pub fn new(config: QuicConfig) -> Self {
+    pub fn new(config: QuicConfig, identity: Arc<Identity>) -> Self {
+        install_default_crypto_provider();
         Self {
             config,
+            identity,
             connections: DashMap::new(),
             endpoint: RwLock::new(None),
             local_addr: RwLock::new(None),
@@ -137,21 +161,13 @@ impl QuicManager {
 
     /// QUIC エンドポイントを初期化し、リスンを開始する。
     ///
-    /// サーバ設定に加え、クライアント既定設定も同時に差し込むので
-    /// 以降 `connect()` は同 endpoint で使える (これをしないと `connect()`
-    /// は "no default client config" エラーで必ず失敗する既知バグがあった)。
+    /// サーバ設定はローカル `Identity` の ed25519 キーから派生した自己署名
+    /// 証明書を使う。クライアント接続側は S1 仕様で `expected_peer_id` を
+    /// 必須としているため、ここでデフォルトの `ClientConfig` はセットしない。
     pub async fn bind(&self, addr: SocketAddr) -> Result<SocketAddr> {
         let server_config = self.build_server_config()?;
-        let mut endpoint = quinn::Endpoint::server(server_config, addr)
+        let endpoint = quinn::Endpoint::server(server_config, addr)
             .map_err(|e| SynergosNetError::Quic(format!("Failed to bind: {}", e)))?;
-
-        // Phase D で導入した dev 向け ClientConfig を差し込む。
-        // S1 の最終対策 (ピア公開鍵派生 cert + カスタム CertVerifier) は
-        // 後続作業で build_client_config をハード化することで置き換える。
-        match self.build_client_config() {
-            Ok(cc) => endpoint.set_default_client_config(cc),
-            Err(e) => tracing::warn!("QUIC client config init failed: {e}"),
-        }
 
         let actual_addr = endpoint
             .local_addr()
@@ -165,10 +181,15 @@ impl QuicManager {
         Ok(actual_addr)
     }
 
-    /// 指定アドレスに QUIC 接続を確立する
+    /// 指定アドレスに QUIC 接続を確立する。
+    ///
+    /// `expected_peer_id` は接続先ピアから期待する PeerId。サーバ側から
+    /// 提示される自己署名証明書の ed25519 公開鍵が `blake3[:20]` でこれと
+    /// 一致しなかった場合、TLS ハンドシェイクは失敗し `connect` は
+    /// `SynergosNetError::Identity` を返す。
     pub async fn connect(
         &self,
-        peer_id: PeerId,
+        expected_peer_id: PeerId,
         addr: SocketAddr,
         server_name: &str,
     ) -> Result<()> {
@@ -177,18 +198,32 @@ impl QuicManager {
             .as_ref()
             .ok_or_else(|| SynergosNetError::Quic("Endpoint not initialized".into()))?;
 
-        tracing::info!("Connecting to peer {} at {}", peer_id.short(), addr);
+        tracing::info!(
+            "Connecting to peer {} at {}",
+            expected_peer_id.short(),
+            addr
+        );
+
+        let client_config = self.build_client_config_for(expected_peer_id.clone())?;
 
         let connection = endpoint
-            .connect(addr, server_name)
+            .connect_with(client_config, addr, server_name)
             .map_err(|e| SynergosNetError::Quic(format!("Connect error: {}", e)))?
             .await
-            .map_err(|e| SynergosNetError::Quic(format!("Connection failed: {}", e)))?;
+            .map_err(|e| {
+                // TLS 真性認証失敗は SynergosNetError::Identity に寄せる
+                let msg = format!("{e}");
+                if msg.contains("PeerPinning") || msg.contains("UnknownIssuer") {
+                    SynergosNetError::Identity(format!("peer auth failed: {msg}"))
+                } else {
+                    SynergosNetError::Quic(format!("Connection failed: {msg}"))
+                }
+            })?;
 
         let rtt = connection.rtt().as_millis() as u32;
 
         let quic_conn = QuicConnection {
-            peer_id: peer_id.clone(),
+            peer_id: expected_peer_id.clone(),
             remote_addr: addr,
             active_streams: 0,
             state: QuicConnectionState::Connected,
@@ -196,7 +231,7 @@ impl QuicManager {
             connection: Some(connection),
         };
 
-        self.connections.insert(peer_id, quic_conn);
+        self.connections.insert(expected_peer_id, quic_conn);
         Ok(())
     }
 
@@ -220,15 +255,19 @@ impl QuicManager {
         peer_id: &PeerId,
         stream_type: StreamType,
     ) -> Result<(quinn::SendStream, quinn::RecvStream)> {
-        let entry = self
-            .connections
-            .get(peer_id)
-            .ok_or_else(|| SynergosNetError::PeerNotFound(peer_id.to_string()))?;
-
-        let conn = entry
-            .connection
-            .as_ref()
-            .ok_or_else(|| SynergosNetError::Quic("Connection not established".into()))?;
+        // entry を読み終えた直後にロックを解放してから get_mut を取ることで
+        // DashMap の同一 shard 内再取得によるデッドロックを避ける。
+        let conn = {
+            let entry = self
+                .connections
+                .get(peer_id)
+                .ok_or_else(|| SynergosNetError::PeerNotFound(peer_id.to_string()))?;
+            entry
+                .connection
+                .as_ref()
+                .ok_or_else(|| SynergosNetError::Quic("Connection not established".into()))?
+                .clone()
+        };
 
         let (send, recv) = conn
             .open_bi()
@@ -237,8 +276,6 @@ impl QuicManager {
 
         tracing::debug!("Opened {:?} stream to peer {}", stream_type, peer_id);
 
-        // ストリーム数を更新
-        drop(entry);
         if let Some(mut entry) = self.connections.get_mut(peer_id) {
             entry.active_streams += 1;
         }
@@ -287,6 +324,48 @@ impl QuicManager {
             .collect()
     }
 
+    /// 着信した接続を受け付ける (サーバ側のハンドシェイク完了を待つ)。
+    /// S1 を相互 (サーバ側も相手の公開鍵から PeerId を再計算して検証する)
+    /// 構造にするための土台。戻り値として相手から派生した PeerId を返す。
+    pub async fn accept(&self) -> Result<Option<AcceptedConnection>> {
+        let endpoint_guard = self.endpoint.read().await;
+        let endpoint = match endpoint_guard.as_ref() {
+            Some(ep) => ep.clone(),
+            None => return Ok(None),
+        };
+        drop(endpoint_guard);
+
+        let incoming = match endpoint.accept().await {
+            Some(inc) => inc,
+            None => return Ok(None),
+        };
+
+        let connection = incoming
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("Incoming handshake failed: {e}")))?;
+
+        let remote_addr = connection.remote_address();
+        let rtt = connection.rtt().as_millis() as u32;
+
+        let peer_id = peer_id_from_connection(&connection)?;
+
+        let quic_conn = QuicConnection {
+            peer_id: peer_id.clone(),
+            remote_addr,
+            active_streams: 0,
+            state: QuicConnectionState::Connected,
+            rtt_ms: rtt,
+            connection: Some(connection.clone()),
+        };
+        self.connections.insert(peer_id.clone(), quic_conn);
+
+        Ok(Some(AcceptedConnection {
+            peer_id,
+            remote_addr,
+            connection,
+        }))
+    }
+
     /// 全接続を切断する
     pub async fn shutdown(&self) {
         let peer_ids: Vec<PeerId> = self.connections.iter().map(|e| e.key().clone()).collect();
@@ -325,7 +404,6 @@ impl QuicManager {
 
         for _ in 0..count {
             let start = std::time::Instant::now();
-            // 小さいデータでラウンドトリップ計測
             self.send_control(peer_id, b"ping").await?;
             let elapsed = start.elapsed().as_millis() as u32;
             rtts.push(elapsed);
@@ -340,59 +418,16 @@ impl QuicManager {
 
     // ── 内部ヘルパー ──
 
-    /// サーバー用 TLS 設定を構築（自己署名証明書）
-    /// 開発時の簡易 ClientConfig。**本物のピア認証ではない**。
+    /// クライアント用 TLS 設定を構築。
     ///
-    /// TODO(S1): `identity::Identity` の公開鍵を cert に埋め、ピア側で
-    /// (1) cert から公開鍵を取り出し、(2) hash(pubkey) == PeerId を検証、
-    /// (3) その公開鍵を後続の署名検証に転用する CertVerifier を実装する。
-    /// 現状は dev/テスト用に `SkipServerVerification` を採用し、`connect()`
-    /// を「そもそも通る」ようにするに留める。リリースビルドでは使わせない。
-    fn build_client_config(&self) -> Result<quinn::ClientConfig> {
-        #[derive(Debug)]
-        struct DevOnlySkipVerify;
-        impl rustls::client::danger::ServerCertVerifier for DevOnlySkipVerify {
-            fn verify_server_cert(
-                &self,
-                _end_entity: &rustls::pki_types::CertificateDer<'_>,
-                _intermediates: &[rustls::pki_types::CertificateDer<'_>],
-                _server_name: &rustls::pki_types::ServerName<'_>,
-                _ocsp: &[u8],
-                _now: rustls::pki_types::UnixTime,
-            ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error>
-            {
-                Ok(rustls::client::danger::ServerCertVerified::assertion())
-            }
-            fn verify_tls12_signature(
-                &self,
-                _message: &[u8],
-                _cert: &rustls::pki_types::CertificateDer<'_>,
-                _dss: &rustls::DigitallySignedStruct,
-            ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
-            {
-                Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-            }
-            fn verify_tls13_signature(
-                &self,
-                _message: &[u8],
-                _cert: &rustls::pki_types::CertificateDer<'_>,
-                _dss: &rustls::DigitallySignedStruct,
-            ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
-            {
-                Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-            }
-            fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-                vec![
-                    rustls::SignatureScheme::ED25519,
-                    rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-                    rustls::SignatureScheme::RSA_PSS_SHA256,
-                ]
-            }
-        }
+    /// `expected_peer_id` をサーバ証明書の公開鍵派生 PeerId と照合する
+    /// `PeerPinningVerifier` を差し込む。connect 1 回ごとに構築する。
+    fn build_client_config_for(&self, expected_peer_id: PeerId) -> Result<quinn::ClientConfig> {
+        let verifier = Arc::new(PeerPinningVerifier::new(expected_peer_id));
 
         let client_crypto = rustls::ClientConfig::builder()
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(DevOnlySkipVerify))
+            .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
 
         let qcc = quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto)
@@ -411,12 +446,7 @@ impl QuicManager {
     }
 
     fn build_server_config(&self) -> Result<quinn::ServerConfig> {
-        let cert = rcgen::generate_simple_self_signed(vec!["synergos".into()])
-            .map_err(|e| SynergosNetError::Quic(format!("Cert generation error: {}", e)))?;
-
-        let cert_der = rustls::pki_types::CertificateDer::from(cert.cert);
-        let key_der = rustls::pki_types::PrivateKeyDer::try_from(cert.key_pair.serialize_der())
-            .map_err(|e| SynergosNetError::Quic(format!("Key error: {}", e)))?;
+        let (cert_der, key_der) = build_server_cert(&self.identity)?;
 
         let server_crypto = rustls::ServerConfig::builder()
             .with_no_client_auth()
@@ -439,6 +469,87 @@ impl QuicManager {
 
         Ok(server_config)
     }
+}
+
+/// rustls 0.23 は `ServerConfig::builder()` / `ClientConfig::builder()` が
+/// 既定の `CryptoProvider` を要求する。`rustls` の feature `ring` 有効化と
+/// `aws-lc-rs` 未有効の条件でのみ auto-detect が働くが、依存グラフの都合で
+/// 両方の provider が見えることがあるので、プロセス起動時に明示的に
+/// install する。`set_default` は 2 度目以降はエラーになるだけで副作用なし。
+fn install_default_crypto_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+/// accept 後に呼び出し側へ返す情報。相手 PeerId を証明書から再計算しておく。
+pub struct AcceptedConnection {
+    pub peer_id: PeerId,
+    pub remote_addr: SocketAddr,
+    pub connection: quinn::Connection,
+}
+
+/// quinn::Connection から相手のピア証明書を取り出し、SPKI の公開鍵から
+/// PeerId を再計算する。サーバ側は `no_client_auth` で接続を受けるので
+/// クライアント証明書は存在せず、このヘルパは accept 側でも SPKI が
+/// 取れない前提。よって今は remote_address から派生した仮 PeerId を返す。
+fn peer_id_from_connection(connection: &quinn::Connection) -> Result<PeerId> {
+    if let Some(identity) = connection.peer_identity() {
+        if let Ok(certs) =
+            identity.downcast::<Vec<rustls::pki_types::CertificateDer<'static>>>()
+        {
+            if let Some(cert) = certs.first() {
+                if let Some(peer_id) = verifier::peer_id_from_cert(cert.as_ref()) {
+                    return Ok(peer_id);
+                }
+            }
+        }
+    }
+    // クライアント証明書が無い場合は、remote_addr 由来のダミー PeerId を
+    // 返す。これはゴシップ層で正しい PeerId が確定するまでの橋渡し用で、
+    // 真性認証は gossip 署名側で担保する。
+    Ok(PeerId::new(format!(
+        "pending-{}",
+        connection.remote_address()
+    )))
+}
+
+/// rcgen で ed25519 keypair から自己署名証明書を作り、rustls が受け取れる
+/// `(CertificateDer, PrivateKeyDer)` ペアを返す。
+fn build_server_cert(
+    identity: &Identity,
+) -> Result<(
+    rustls::pki_types::CertificateDer<'static>,
+    rustls::pki_types::PrivateKeyDer<'static>,
+)> {
+    let pkcs8 = identity
+        .to_pkcs8_der()
+        .map_err(|e| SynergosNetError::Quic(format!("identity pkcs8 export: {e}")))?;
+
+    let key_pair =
+        rcgen::KeyPair::try_from(pkcs8.as_slice())
+            .map_err(|e| SynergosNetError::Quic(format!("rcgen keypair: {e}")))?;
+
+    let mut params = rcgen::CertificateParams::new(vec![
+        "synergos".to_string(),
+        identity.peer_id().to_string(),
+    ])
+    .map_err(|e| SynergosNetError::Quic(format!("rcgen params: {e}")))?;
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, identity.peer_id().to_string());
+
+    let cert = params
+        .self_signed(&key_pair)
+        .map_err(|e| SynergosNetError::Quic(format!("rcgen self-sign: {e}")))?;
+
+    let cert_der = rustls::pki_types::CertificateDer::from(cert.der().to_vec());
+    let key_der = rustls::pki_types::PrivateKeyDer::try_from(pkcs8)
+        .map_err(|e| SynergosNetError::Quic(format!("rustls key der: {e}")))?;
+
+    Ok((cert_der, key_der))
 }
 
 /// コネクション情報（外部公開用、quinn ハンドルなし）

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -497,9 +497,7 @@ pub struct AcceptedConnection {
 /// 取れない前提。よって今は remote_address から派生した仮 PeerId を返す。
 fn peer_id_from_connection(connection: &quinn::Connection) -> Result<PeerId> {
     if let Some(identity) = connection.peer_identity() {
-        if let Ok(certs) =
-            identity.downcast::<Vec<rustls::pki_types::CertificateDer<'static>>>()
-        {
+        if let Ok(certs) = identity.downcast::<Vec<rustls::pki_types::CertificateDer<'static>>>() {
             if let Some(cert) = certs.first() {
                 if let Some(peer_id) = verifier::peer_id_from_cert(cert.as_ref()) {
                     return Ok(peer_id);
@@ -528,15 +526,12 @@ fn build_server_cert(
         .to_pkcs8_der()
         .map_err(|e| SynergosNetError::Quic(format!("identity pkcs8 export: {e}")))?;
 
-    let key_pair =
-        rcgen::KeyPair::try_from(pkcs8.as_slice())
-            .map_err(|e| SynergosNetError::Quic(format!("rcgen keypair: {e}")))?;
+    let key_pair = rcgen::KeyPair::try_from(pkcs8.as_slice())
+        .map_err(|e| SynergosNetError::Quic(format!("rcgen keypair: {e}")))?;
 
-    let mut params = rcgen::CertificateParams::new(vec![
-        "synergos".to_string(),
-        identity.peer_id().to_string(),
-    ])
-    .map_err(|e| SynergosNetError::Quic(format!("rcgen params: {e}")))?;
+    let mut params =
+        rcgen::CertificateParams::new(vec!["synergos".to_string(), identity.peer_id().to_string()])
+            .map_err(|e| SynergosNetError::Quic(format!("rcgen params: {e}")))?;
     params
         .distinguished_name
         .push(rcgen::DnType::CommonName, identity.peer_id().to_string());

--- a/synergos-net/src/quic/verifier.rs
+++ b/synergos-net/src/quic/verifier.rs
@@ -1,0 +1,200 @@
+//! S1 ピア真性認証の要: サーバ証明書の ed25519 公開鍵を取り出し、
+//! `blake3(pubkey)[:20]` が期待する PeerId と一致するかを検証する。
+//!
+//! rustls の `ServerCertVerifier` として差し込むことで、TLS ハンドシェイク
+//! 時点でなりすましを拒否できる。`verify_tls13_signature` /
+//! `verify_tls12_signature` は rustls の ring backend に委譲し、
+//! ハンドシェイクトランスクリプト署名の検証は暗号ライブラリに任せる。
+
+use std::sync::Arc;
+
+use rustls::client::danger::{
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+
+use crate::identity::peer_id_from_public_bytes;
+use crate::types::PeerId;
+
+/// ed25519 公開鍵の OID: `1.3.101.112`
+const OID_ED25519: &[u64] = &[1, 3, 101, 112];
+
+#[derive(Debug)]
+pub struct PeerPinningVerifier {
+    expected_peer_id: PeerId,
+    /// 実際に signature 検証を担う rustls の ring provider
+    crypto_provider: Arc<rustls::crypto::CryptoProvider>,
+}
+
+impl PeerPinningVerifier {
+    pub fn new(expected_peer_id: PeerId) -> Self {
+        Self {
+            expected_peer_id,
+            crypto_provider: Arc::new(rustls::crypto::ring::default_provider()),
+        }
+    }
+
+    /// 証明書から ed25519 pubkey を取り出して期待値と照合する。
+    /// 取り出した生の 32-byte pubkey を返す (後続で署名検証に使える)。
+    fn check_peer_binding<'a>(
+        &self,
+        end_entity: &'a CertificateDer<'a>,
+    ) -> Result<Vec<u8>, rustls::Error> {
+        let pubkey = extract_ed25519_spki(end_entity.as_ref()).ok_or_else(|| {
+            rustls::Error::General(
+                "PeerPinning: server cert does not expose an ed25519 public key".to_string(),
+            )
+        })?;
+
+        if pubkey.len() != 32 {
+            return Err(rustls::Error::General(format!(
+                "PeerPinning: unexpected ed25519 public key length {}",
+                pubkey.len()
+            )));
+        }
+        let mut key_arr = [0u8; 32];
+        key_arr.copy_from_slice(&pubkey);
+
+        let derived = peer_id_from_public_bytes(&key_arr);
+        if derived != self.expected_peer_id {
+            return Err(rustls::Error::General(format!(
+                "PeerPinning: peer identity mismatch (expected {}, got {})",
+                self.expected_peer_id.short(),
+                derived.short(),
+            )));
+        }
+        Ok(pubkey)
+    }
+}
+
+impl ServerCertVerifier for PeerPinningVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        self.check_peer_binding(end_entity)?;
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.crypto_provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.crypto_provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        // ed25519 のみを許可することで、相手が ed25519 以外の鍵で
+        // 署名した場合はここで弾ける (= Synergos の鍵と一致しない)。
+        vec![SignatureScheme::ED25519]
+    }
+}
+
+/// サーバ証明書 DER から ed25519 SPKI を取り出すヘルパ。
+/// x509-parser で `subjectPublicKeyInfo.algorithm.algorithm` が
+/// `1.3.101.112` (id-Ed25519) のときだけ pubkey bytes を返す。
+pub(crate) fn extract_ed25519_spki(cert_der: &[u8]) -> Option<Vec<u8>> {
+    use x509_parser::prelude::*;
+
+    let (_, parsed) = X509Certificate::from_der(cert_der).ok()?;
+    let spki = parsed.public_key();
+    let oid_iter: Vec<u64> = spki.algorithm.algorithm.iter()?.collect();
+    if oid_iter.as_slice() != OID_ED25519 {
+        return None;
+    }
+    Some(spki.subject_public_key.data.to_vec())
+}
+
+/// `accept` 時に相手の証明書 DER から PeerId を再計算するためのヘルパ。
+/// サーバ側は現状クライアント証明書を要求していないので、ここが呼ばれるのは
+/// 相互認証を導入したときに限られる。
+pub(crate) fn peer_id_from_cert(cert_der: &[u8]) -> Option<PeerId> {
+    let pubkey = extract_ed25519_spki(cert_der)?;
+    if pubkey.len() != 32 {
+        return None;
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&pubkey);
+    Some(peer_id_from_public_bytes(&arr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::Identity;
+
+    fn self_signed_cert(identity: &Identity) -> rustls::pki_types::CertificateDer<'static> {
+        let pkcs8 = identity.to_pkcs8_der().unwrap();
+        let key_pair = rcgen::KeyPair::try_from(pkcs8.as_slice()).unwrap();
+        let mut params = rcgen::CertificateParams::new(vec!["synergos".into()]).unwrap();
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, identity.peer_id().to_string());
+        let cert = params.self_signed(&key_pair).unwrap();
+        rustls::pki_types::CertificateDer::from(cert.der().to_vec())
+    }
+
+    #[test]
+    fn verifier_accepts_matching_peer_id() {
+        let id = Identity::generate();
+        let cert = self_signed_cert(&id);
+        let verifier = PeerPinningVerifier::new(id.peer_id().clone());
+        let server_name = rustls::pki_types::ServerName::try_from("synergos").unwrap();
+        let now = rustls::pki_types::UnixTime::now();
+        let verified = verifier
+            .verify_server_cert(&cert, &[], &server_name, &[], now)
+            .unwrap();
+        let _ = verified;
+    }
+
+    #[test]
+    fn verifier_rejects_mismatched_peer_id() {
+        let id_a = Identity::generate();
+        let id_b = Identity::generate();
+        let cert = self_signed_cert(&id_a);
+        let verifier = PeerPinningVerifier::new(id_b.peer_id().clone());
+        let server_name = rustls::pki_types::ServerName::try_from("synergos").unwrap();
+        let now = rustls::pki_types::UnixTime::now();
+        let err = verifier
+            .verify_server_cert(&cert, &[], &server_name, &[], now)
+            .unwrap_err();
+        match err {
+            rustls::Error::General(msg) => assert!(msg.contains("mismatch")),
+            other => panic!("expected General, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peer_id_from_cert_matches_identity() {
+        let id = Identity::generate();
+        let cert = self_signed_cert(&id);
+        let recovered = peer_id_from_cert(cert.as_ref()).unwrap();
+        assert_eq!(&recovered, id.peer_id());
+    }
+}

--- a/synergos-net/src/quic/verifier.rs
+++ b/synergos-net/src/quic/verifier.rs
@@ -8,9 +8,7 @@
 
 use std::sync::Arc;
 
-use rustls::client::danger::{
-    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
-};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, SignatureScheme};
 

--- a/synergos-net/src/transfer/mod.rs
+++ b/synergos-net/src/transfer/mod.rs
@@ -205,10 +205,7 @@ where
 
 /// 受信ラッパ: magic は呼び出し側で既に消費済みの前提。QUIC recv half を
 /// そのまま `receive_stream` に渡す。
-pub async fn receive_over_quic(
-    recv: quinn::RecvStream,
-    out_path: &Path,
-) -> Result<TransferHeader> {
+pub async fn receive_over_quic(recv: quinn::RecvStream, out_path: &Path) -> Result<TransferHeader> {
     receive_stream(recv, out_path).await
 }
 

--- a/synergos-net/src/transfer/mod.rs
+++ b/synergos-net/src/transfer/mod.rs
@@ -48,7 +48,8 @@ pub struct ChunkFrame {
     pub index: u64,
     /// 当該チャンク単体の Blake3 ハッシュ
     pub hash: Blake3Hash,
-    /// 生データ
+    /// 生データ (msgpack の bin として直列化するため serde_bytes を使う)
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
 }
 
@@ -178,6 +179,37 @@ where
             }
         }
     }
+}
+
+/// QUIC ストリーム上の転送セッションを示すマジックバイト列。
+/// Daemon のストリーム受信ディスパッチャはこの 4 byte を先読みして
+/// DHT / Transfer / その他を振り分ける。
+pub const TRANSFER_STREAM_MAGIC: &[u8; 4] = b"TXFR";
+
+/// 送信ラッパ: QUIC bidi send half の先頭に `TXFR` を書き、続けて send_stream 本体。
+/// 受信側はディスパッチャで magic を消費した後の recv half を `receive_stream` に
+/// そのまま流す。
+pub async fn send_over_quic<R>(
+    mut send: quinn::SendStream,
+    reader: R,
+    header: TransferHeader,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    send.write_all(TRANSFER_STREAM_MAGIC)
+        .await
+        .map_err(|e| SynergosNetError::Quic(format!("write magic: {e}")))?;
+    send_stream(reader, send, header).await
+}
+
+/// 受信ラッパ: magic は呼び出し側で既に消費済みの前提。QUIC recv half を
+/// そのまま `receive_stream` に渡す。
+pub async fn receive_over_quic(
+    recv: quinn::RecvStream,
+    out_path: &Path,
+) -> Result<TransferHeader> {
+    receive_stream(recv, out_path).await
 }
 
 /// ディスク上のファイルの全体 Blake3 ハッシュとサイズ + チャンク数を計算する。

--- a/synergos-net/src/types.rs
+++ b/synergos-net/src/types.rs
@@ -216,6 +216,28 @@ impl FileSizeClass {
     }
 }
 
+/// PeerId をログ用に短縮する。`PeerId::short` と同じだが、参照を `&PeerId`
+/// として受け取れるので `tracing::info!("{}", truncate_peer_id(&pid))` と書ける。
+pub fn truncate_peer_id(pid: &PeerId) -> String {
+    pid.short()
+}
+
+/// プロジェクト相対にパスを縮める。パスがプロジェクトルート配下なら相対化、
+/// 外にはみ出していれば file_name のみ、それも取れなければ "<redacted>"。
+///
+/// S20 対策として `IpcResponse::Error.message` や tracing ログに載せる path を
+/// すべてこのヘルパを経由させることで、絶対パス (ユーザのホームディレクトリ等)
+/// の漏洩を抑える。
+pub fn redact_path(project_root: &std::path::Path, path: &std::path::Path) -> String {
+    if let Ok(rel) = path.strip_prefix(project_root) {
+        return rel.display().to_string();
+    }
+    match path.file_name() {
+        Some(name) => name.to_string_lossy().into_owned(),
+        None => "<redacted>".to_string(),
+    }
+}
+
 /// UNIX epoch からの経過時間を milliseconds で返す共通ユーティリティ。
 /// `conflict` / `exchange` / `catalog` で個別定義されていた重複を解消する。
 ///
@@ -225,4 +247,30 @@ pub fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests_redact {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn redact_keeps_relative_within_root() {
+        let root = PathBuf::from("/home/user/project");
+        let inside = root.join("src/main.rs");
+        assert_eq!(redact_path(&root, &inside), "src/main.rs");
+    }
+
+    #[test]
+    fn redact_outside_root_returns_file_name_only() {
+        let root = PathBuf::from("/home/user/project");
+        let outside = PathBuf::from("/etc/passwd");
+        assert_eq!(redact_path(&root, &outside), "passwd");
+    }
+
+    #[test]
+    fn truncate_peer_id_short() {
+        let p = PeerId::new("abcdefghijklmno");
+        assert!(truncate_peer_id(&p).ends_with('…'));
+    }
 }

--- a/synergos-net/tests/dht_find_node.rs
+++ b/synergos-net/tests/dht_find_node.rs
@@ -1,0 +1,287 @@
+//! Kademlia iterative FIND_NODE のテスト。モックトランスポートで
+//! ホップ数上限・タイムアウト・exact hit を確認する。
+
+use std::collections::HashMap;
+use std::net::SocketAddrV6;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+use synergos_net::config::DhtConfig;
+use synergos_net::dht::rpc::{DhtRequest, DhtResponse, DhtTransport, PeerRecordDto, RouteDto};
+use synergos_net::dht::{DhtNode, FindNodeOptions, PeerRecord};
+use synergos_net::error::{Result as NetResult, SynergosNetError};
+use synergos_net::types::{PeerId, Route};
+
+fn addr_for(n: u16) -> SocketAddrV6 {
+    use std::net::Ipv6Addr;
+    SocketAddrV6::new(Ipv6Addr::LOCALHOST, n, 0, 0)
+}
+
+fn dto(peer_id: &PeerId) -> PeerRecordDto {
+    PeerRecordDto {
+        peer_id: peer_id.clone(),
+        display_name: peer_id.0.clone(),
+        endpoints: vec![RouteDto::Direct {
+            addr: addr_for(9000),
+            fqdn: None,
+        }],
+        active_projects: vec!["p1".to_string()],
+        ttl_secs: 60,
+    }
+}
+
+fn cfg() -> DhtConfig {
+    DhtConfig {
+        k_bucket_size: 8,
+        routing_refresh_secs: 300,
+        peer_ttl_secs: 300,
+    }
+}
+
+/// モックトランスポート。各ピアが「target をどれくらい知っているか」を
+/// 事前設定して振る舞わせる。
+struct MockTransport {
+    /// responder peer_id → (exact target, closest neighbors)
+    table: HashMap<PeerId, (Option<PeerRecordDto>, Vec<PeerRecordDto>)>,
+    /// 応答遅延 (ms)
+    latency_ms: Arc<Mutex<HashMap<PeerId, u64>>>,
+}
+
+impl MockTransport {
+    fn new() -> Self {
+        Self {
+            table: HashMap::new(),
+            latency_ms: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn set_response(
+        &mut self,
+        responder: PeerId,
+        exact: Option<PeerRecordDto>,
+        closest: Vec<PeerRecordDto>,
+    ) {
+        self.table.insert(responder, (exact, closest));
+    }
+
+    fn set_latency(&self, responder: PeerId, ms: u64) {
+        self.latency_ms.lock().unwrap().insert(responder, ms);
+    }
+}
+
+#[async_trait]
+impl DhtTransport for MockTransport {
+    async fn request(&self, peer: &PeerId, req: &DhtRequest) -> NetResult<DhtResponse> {
+        let latency = self
+            .latency_ms
+            .lock()
+            .unwrap()
+            .get(peer)
+            .cloned()
+            .unwrap_or(0);
+        if latency > 0 {
+            tokio::time::sleep(Duration::from_millis(latency)).await;
+        }
+        match req {
+            DhtRequest::FindNode { .. } => {
+                let (exact, closest) = self.table.get(peer).cloned().ok_or_else(|| {
+                    SynergosNetError::PeerNotFound(format!("mock has no entry for {peer}"))
+                })?;
+                Ok(DhtResponse::Nodes { exact, closest })
+            }
+            _ => Ok(DhtResponse::Error {
+                message: "unsupported".into(),
+            }),
+        }
+    }
+}
+
+fn make_record(pid: &PeerId) -> PeerRecord {
+    PeerRecord {
+        peer_id: pid.clone(),
+        display_name: pid.0.clone(),
+        endpoints: vec![Route::Direct {
+            addr: addr_for(9000),
+            fqdn: None,
+        }],
+        active_projects: vec!["p1".into()],
+        published_at: Instant::now(),
+        ttl: Duration::from_secs(60),
+    }
+}
+
+#[tokio::test]
+async fn find_peer_local_hit_short_circuits() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+    let target = PeerId::new("target");
+    node.announce(make_record(&target)).await;
+
+    let transport = MockTransport::new();
+    let opts = FindNodeOptions::default();
+    let found = node
+        .find_peer_iterative(&target, &transport, opts)
+        .await
+        .unwrap();
+    assert_eq!(found.peer_id, target);
+}
+
+#[tokio::test]
+async fn find_peer_iterative_returns_exact_hit_from_neighbor() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+
+    let neighbor = PeerId::new("neighbor");
+    let target = PeerId::new("target");
+
+    // 自分の routing table には neighbor を入れておく
+    node.add_peer(
+        neighbor.clone(),
+        vec![Route::Direct {
+            addr: addr_for(9000),
+            fqdn: None,
+        }],
+        None,
+    )
+    .await;
+
+    // neighbor は target を exact hit で持っている
+    let mut transport = MockTransport::new();
+    transport.set_response(neighbor.clone(), Some(dto(&target)), vec![]);
+
+    let opts = FindNodeOptions {
+        max_hops: 2,
+        alpha: 3,
+        ..Default::default()
+    };
+    let found = node
+        .find_peer_iterative(&target, &transport, opts)
+        .await
+        .expect("target should be resolved via neighbor");
+    assert_eq!(found.peer_id, target);
+}
+
+#[tokio::test]
+async fn find_peer_iterative_follows_closest_chain() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+    let n1 = PeerId::new("n1");
+    let n2 = PeerId::new("n2");
+    let target = PeerId::new("target");
+
+    node.add_peer(
+        n1.clone(),
+        vec![Route::Direct {
+            addr: addr_for(9001),
+            fqdn: None,
+        }],
+        None,
+    )
+    .await;
+
+    // n1 は target 自体は知らず、closer な n2 だけを返す
+    let mut transport = MockTransport::new();
+    transport.set_response(n1.clone(), None, vec![dto(&n2)]);
+    transport.set_response(n2.clone(), Some(dto(&target)), vec![]);
+
+    let found = node
+        .find_peer_iterative(&target, &transport, FindNodeOptions::default())
+        .await
+        .expect("target should be resolved after 2 hops");
+    assert_eq!(found.peer_id, target);
+}
+
+#[tokio::test]
+async fn find_peer_iterative_respects_hop_limit() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+    let n1 = PeerId::new("n1");
+    let n2 = PeerId::new("n2");
+    let n3 = PeerId::new("n3");
+    let target = PeerId::new("target");
+
+    node.add_peer(
+        n1.clone(),
+        vec![Route::Direct {
+            addr: addr_for(9001),
+            fqdn: None,
+        }],
+        None,
+    )
+    .await;
+
+    let mut transport = MockTransport::new();
+    transport.set_response(n1.clone(), None, vec![dto(&n2)]);
+    transport.set_response(n2.clone(), None, vec![dto(&n3)]);
+    transport.set_response(n3.clone(), Some(dto(&target)), vec![]);
+
+    // max_hops = 2 なので n3 への問合せは実行されず target に到達しない
+    let opts = FindNodeOptions {
+        max_hops: 2,
+        alpha: 1,
+        ..Default::default()
+    };
+    let found = node.find_peer_iterative(&target, &transport, opts).await;
+    assert!(
+        found.is_none(),
+        "hop limit must prevent resolving target at depth 3"
+    );
+}
+
+#[tokio::test]
+async fn find_peer_iterative_timeout_on_slow_peer() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+    let slow = PeerId::new("slow");
+    let target = PeerId::new("target");
+
+    node.add_peer(
+        slow.clone(),
+        vec![Route::Direct {
+            addr: addr_for(9001),
+            fqdn: None,
+        }],
+        None,
+    )
+    .await;
+
+    let mut transport = MockTransport::new();
+    transport.set_response(slow.clone(), Some(dto(&target)), vec![]);
+    transport.set_latency(slow.clone(), 500);
+
+    let opts = FindNodeOptions {
+        per_request_timeout: Duration::from_millis(50),
+        max_hops: 1,
+        alpha: 1,
+        ..Default::default()
+    };
+    let start = Instant::now();
+    let found = node.find_peer_iterative(&target, &transport, opts).await;
+    assert!(found.is_none(), "slow peer should be timed-out");
+    // 500ms 待たずに早期脱出していること
+    assert!(start.elapsed() < Duration::from_millis(300));
+}
+
+#[tokio::test]
+async fn handle_request_find_node_returns_local_exact() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+    let target = PeerId::new("target");
+    node.announce(make_record(&target)).await;
+
+    let resp = node
+        .handle_request(DhtRequest::FindNode {
+            target: target.clone(),
+        })
+        .await;
+    match resp {
+        DhtResponse::Nodes { exact, closest: _ } => {
+            let exact = exact.expect("expected exact hit");
+            assert_eq!(exact.peer_id, target);
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn handle_request_ping_pong() {
+    let node = DhtNode::new(PeerId::new("self"), cfg());
+    let resp = node.handle_request(DhtRequest::Ping).await;
+    matches!(resp, DhtResponse::Pong);
+}

--- a/synergos-net/tests/dht_over_quic.rs
+++ b/synergos-net/tests/dht_over_quic.rs
@@ -67,17 +67,10 @@ async fn find_node_over_quic_resolves_target_via_server_announce() {
     let server_task = tokio::spawn(async move {
         if let Ok(Some(acc)) = sq.accept().await {
             let connection = acc.connection;
-            loop {
-                match connection.accept_bi().await {
-                    Ok((send, mut recv)) => {
-                        let mut magic = [0u8; 4];
-                        if recv.read_exact(&mut magic).await.is_ok()
-                            && &magic == b"DHT1"
-                        {
-                            let _ = handle_dht_stream(sdht.clone(), send, recv).await;
-                        }
-                    }
-                    Err(_) => break,
+            while let Ok((send, mut recv)) = connection.accept_bi().await {
+                let mut magic = [0u8; 4];
+                if recv.read_exact(&mut magic).await.is_ok() && &magic == b"DHT1" {
+                    let _ = handle_dht_stream(sdht.clone(), send, recv).await;
                 }
             }
         }
@@ -112,5 +105,7 @@ async fn find_node_over_quic_resolves_target_via_server_announce() {
     client_quic
         .disconnect(server_id_entity.peer_id(), "done")
         .await;
-    tokio::time::timeout(Duration::from_millis(200), server_task).await.ok();
+    tokio::time::timeout(Duration::from_millis(200), server_task)
+        .await
+        .ok();
 }

--- a/synergos-net/tests/dht_over_quic.rs
+++ b/synergos-net/tests/dht_over_quic.rs
@@ -1,0 +1,116 @@
+//! PR-12: 2 ノードで QuicDhtTransport 経由の FIND_NODE 往復を確認する。
+//! サーバ側は accept → dispatch_peer_streams 相当を手動で組む。
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use synergos_net::config::{DhtConfig, QuicConfig};
+use synergos_net::dht::{
+    handle_dht_stream, DhtNode, DhtTransport, FindNodeOptions, PeerRecord, QuicDhtTransport,
+};
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
+use synergos_net::types::{PeerId, Route};
+
+fn qcfg() -> QuicConfig {
+    QuicConfig {
+        max_concurrent_streams: 8,
+        idle_timeout_ms: 5_000,
+        max_udp_payload_size: 1350,
+        enable_0rtt: false,
+    }
+}
+
+fn dcfg() -> DhtConfig {
+    DhtConfig {
+        k_bucket_size: 8,
+        routing_refresh_secs: 300,
+        peer_ttl_secs: 300,
+    }
+}
+
+async fn bound(identity: Arc<Identity>) -> (Arc<QuicManager>, SocketAddr) {
+    let qm = Arc::new(QuicManager::new(qcfg(), identity));
+    let bound = qm.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+    (qm, bound)
+}
+
+#[tokio::test]
+async fn find_node_over_quic_resolves_target_via_server_announce() {
+    let server_id_entity = Arc::new(Identity::generate());
+    let client_id_entity = Arc::new(Identity::generate());
+
+    // target_peer はサーバ側のローカル store に入れる。
+    let target = PeerId::new("target");
+
+    // ── サーバ側 ──
+    let (server_quic, server_addr) = bound(server_id_entity.clone()).await;
+    let server_dht = Arc::new(DhtNode::new(server_id_entity.peer_id().clone(), dcfg()));
+    server_dht
+        .announce(PeerRecord {
+            peer_id: target.clone(),
+            display_name: "t".into(),
+            endpoints: vec![Route::Tunnel {
+                tunnel_id: "t1".into(),
+                hostname: "example.com".into(),
+            }],
+            active_projects: vec!["p".into()],
+            published_at: std::time::Instant::now(),
+            ttl: Duration::from_secs(300),
+        })
+        .await;
+
+    // サーバ accept ループ (1 接続ぶんだけ処理する)
+    let sq = server_quic.clone();
+    let sdht = server_dht.clone();
+    let server_task = tokio::spawn(async move {
+        if let Ok(Some(acc)) = sq.accept().await {
+            let connection = acc.connection;
+            loop {
+                match connection.accept_bi().await {
+                    Ok((send, mut recv)) => {
+                        let mut magic = [0u8; 4];
+                        if recv.read_exact(&mut magic).await.is_ok()
+                            && &magic == b"DHT1"
+                        {
+                            let _ = handle_dht_stream(sdht.clone(), send, recv).await;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    });
+
+    // ── クライアント側 ──
+    let (client_quic, _) = bound(client_id_entity.clone()).await;
+    client_quic
+        .connect(server_id_entity.peer_id().clone(), server_addr, "synergos")
+        .await
+        .unwrap();
+
+    let client_dht = DhtNode::new(client_id_entity.peer_id().clone(), dcfg());
+    // ルーティングテーブルに server を入れる
+    client_dht
+        .add_peer(server_id_entity.peer_id().clone(), vec![], None)
+        .await;
+
+    let transport: Arc<dyn DhtTransport> = Arc::new(QuicDhtTransport::new(client_quic.clone()));
+    let opts = FindNodeOptions {
+        per_request_timeout: Duration::from_secs(3),
+        max_hops: 2,
+        alpha: 2,
+        k: 20,
+    };
+    let found = client_dht
+        .find_peer_iterative(&target, transport.as_ref(), opts)
+        .await;
+    assert!(found.is_some(), "target must be resolvable via server");
+    assert_eq!(found.unwrap().peer_id, target);
+
+    client_quic
+        .disconnect(server_id_entity.peer_id(), "done")
+        .await;
+    tokio::time::timeout(Duration::from_millis(200), server_task).await.ok();
+}

--- a/synergos-net/tests/net_additional.rs
+++ b/synergos-net/tests/net_additional.rs
@@ -1,0 +1,258 @@
+//! PR-3: synergos-net 既存ロジックの L1 補強。
+//!
+//! - ConnectionCalibrator::calibrate の境界値
+//! - RoutingTable の空バケット探索 / closest
+//! - TransferLedger::mark_fulfilled / cancel_want / 同時 Want/Offer の順序独立性
+//! - Mesh のキャッシュクリア
+
+use std::time::{Duration, Instant};
+
+use synergos_net::catalog::CatalogManager;
+use synergos_net::chain::{
+    LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry,
+};
+use synergos_net::config::MeshConfig;
+use synergos_net::dht::rpc::RouteDto;
+use synergos_net::mesh::Mesh;
+use synergos_net::quic::{ConnectionCalibrator, SpeedTestResult};
+use synergos_net::types::{FileId, PeerId};
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+// ── ConnectionCalibrator ─────────────────────────────────────────────
+
+#[test]
+fn calibrator_zero_bandwidth_minimum() {
+    let result = SpeedTestResult {
+        rtt_median_ms: 200,
+        rtt_jitter_ms: 50,
+        download_bps: 0,
+        upload_bps: 0,
+        effective_streams: 1,
+    };
+    let params = ConnectionCalibrator::calibrate(&result);
+    assert_eq!(params.max_connections, 1);
+    assert_eq!(params.large_streams, 1);
+    assert_eq!(params.medium_streams, 1);
+    assert_eq!(params.small_streams, 1);
+    assert!((params.chunk_size_multiplier - 2.0).abs() < f64::EPSILON);
+    assert_eq!(params.initial_bandwidth_limit, 0);
+}
+
+#[test]
+fn calibrator_high_bandwidth_scales_up() {
+    let result = SpeedTestResult {
+        rtt_median_ms: 10,
+        rtt_jitter_ms: 1,
+        download_bps: 500_000_000,
+        upload_bps: 500_000_000,
+        effective_streams: 16,
+    };
+    let params = ConnectionCalibrator::calibrate(&result);
+    assert_eq!(params.max_connections, 4);
+    assert_eq!(params.large_streams, 8);
+    assert_eq!(params.medium_streams, 4);
+    assert_eq!(params.small_streams, 2);
+    assert!((params.chunk_size_multiplier - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn calibrator_asymmetric_uses_min() {
+    let result = SpeedTestResult {
+        rtt_median_ms: 75,
+        rtt_jitter_ms: 5,
+        download_bps: 500_000_000,
+        upload_bps: 5_000_000,
+        effective_streams: 8,
+    };
+    let params = ConnectionCalibrator::calibrate(&result);
+    assert_eq!(params.max_connections, 1);
+    assert!((params.chunk_size_multiplier - 1.5).abs() < f64::EPSILON);
+}
+
+// ── TransferLedger ───────────────────────────────────────────────────
+
+fn want_for(requester: &str, file: &str, version: u64) -> WantEntry {
+    WantEntry {
+        requester: PeerId::new(requester),
+        file_id: FileId::new(file),
+        version,
+        requested_at: now_ms(),
+        state: LedgerEntryState::Pending,
+    }
+}
+
+fn offer_for(sender: &str, file: &str, version: u64, size: u64) -> OfferEntry {
+    OfferEntry {
+        sender: PeerId::new(sender),
+        file_id: FileId::new(file),
+        version,
+        file_size: size,
+        crc: 0,
+        offered_at: now_ms(),
+        state: LedgerEntryState::Pending,
+    }
+}
+
+#[test]
+fn ledger_mark_fulfilled_transitions_state() {
+    let ledger = TransferLedger::new();
+    ledger.register_offer(offer_for("sender", "f1", 1, 100));
+    let _ = ledger.register_want(want_for("me", "f1", 1));
+    ledger.mark_fulfilled(&FileId::new("f1"), 1, &PeerId::new("me"));
+    // fulfilled 状態: pending_want_count は 0 になる
+    assert_eq!(ledger.pending_want_count(&FileId::new("f1"), 1), 0);
+}
+
+#[test]
+fn ledger_cancel_want_removes_from_pending() {
+    let ledger = TransferLedger::new();
+    let _ = ledger.register_want(want_for("me", "f2", 1));
+    assert_eq!(ledger.pending_want_count(&FileId::new("f2"), 1), 1);
+    ledger.cancel_want(&FileId::new("f2"), 1, &PeerId::new("me"));
+    assert_eq!(ledger.pending_want_count(&FileId::new("f2"), 1), 0);
+}
+
+#[test]
+fn ledger_concurrent_want_offer_match_regardless_of_order() {
+    // Want → Offer
+    let l1 = TransferLedger::new();
+    let _ = l1.register_want(want_for("me", "f", 1));
+    let a1 = l1.register_offer(offer_for("s", "f", 1, 42));
+    assert!(a1.iter().any(|a| matches!(a, LedgerAction::Match { .. })));
+
+    // Offer → Want
+    let l2 = TransferLedger::new();
+    let _ = l2.register_offer(offer_for("s", "f", 1, 42));
+    let a2 = l2.register_want(want_for("me", "f", 1));
+    match a2 {
+        LedgerAction::Match { .. } => (),
+        other => panic!("expected Match, got {other:?}"),
+    }
+}
+
+// ── CatalogManager ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn catalog_record_update_on_missing_file_errors() {
+    let cm = CatalogManager::new("proj".to_string(), 10, 32);
+    // 直接 record_update するのは file_id 未登録 → エラー
+    use synergos_net::chain::{ChainBlock, ChainPayload};
+    use synergos_net::types::Cid;
+    let bogus_file = FileId::new("never-added");
+    let block = ChainBlock {
+        hash: Default::default(),
+        prev_hash: None,
+        version: 1,
+        author: PeerId::new("a"),
+        author_public_key: [0u8; 32],
+        timestamp: now_ms(),
+        payload: ChainPayload::BinaryCid {
+            cid: Cid("c".into()),
+            file_size: 0,
+            crc: 0,
+        },
+        signature: [0u8; 64],
+    };
+    let result = cm.record_update(&bogus_file, block).await;
+    assert!(result.is_err(), "record_update must error on missing file");
+}
+
+#[tokio::test]
+async fn catalog_add_file_is_isolated_per_project() {
+    let a = CatalogManager::new("pA".into(), 10, 32);
+    let b = CatalogManager::new("pB".into(), 10, 32);
+    let _fa = a.add_file("foo.txt", 1, 10).await;
+    let _fb = b.add_file("foo.txt", 2, 20).await;
+    // root_catalog crc はプロジェクトごとに独立
+    assert_ne!(
+        a.root_catalog().await.catalog_crc,
+        b.root_catalog().await.catalog_crc
+    );
+}
+
+// ── Mesh (DNS cache) ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn mesh_clear_dns_cache_is_noop_when_empty() {
+    let mesh = Mesh::new(MeshConfig {
+        doh_endpoint: "https://cloudflare-dns.com/dns-query".into(),
+        dns_servers: vec![],
+        turn_servers: vec![],
+        stun_servers: vec![],
+        probe_timeout_ms: 1_000,
+    });
+    mesh.clear_dns_cache();
+    assert_eq!(mesh.list_turn_sessions().len(), 0);
+}
+
+#[tokio::test]
+async fn mesh_cleanup_expired_sessions_tolerates_no_sessions() {
+    let mesh = Mesh::new(MeshConfig {
+        doh_endpoint: "https://cloudflare-dns.com/dns-query".into(),
+        dns_servers: vec![],
+        turn_servers: vec![],
+        stun_servers: vec![],
+        probe_timeout_ms: 1_000,
+    });
+    mesh.cleanup_expired_sessions();
+    assert!(mesh.list_turn_sessions().is_empty());
+}
+
+// ── RouteDto (dht::rpc) Direct roundtrip ─────────────────────────────
+
+#[test]
+fn route_dto_roundtrip_preserves_direct() {
+    use std::net::{Ipv6Addr, SocketAddrV6};
+    use synergos_net::types::Route;
+    let original = Route::Direct {
+        addr: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 9000, 0, 0),
+        fqdn: Some("example.com".into()),
+    };
+    let dto: RouteDto = (&original).into();
+    let back: Route = (&dto).into();
+    match back {
+        Route::Direct { addr, fqdn } => {
+            assert_eq!(addr.port(), 9000);
+            assert_eq!(fqdn, Some("example.com".into()));
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+// ── RoutingTable (empty bucket exploration) ──────────────────────────
+
+// RoutingTable の内部モジュールは pub ではないが、DhtNode 経由で
+// closest_peers を呼ぶことで空状態の振る舞いを確認する。
+#[tokio::test]
+async fn dht_closest_on_empty_table_returns_empty() {
+    use synergos_net::config::DhtConfig;
+    use synergos_net::dht::DhtNode;
+    use synergos_net::types::NodeId;
+
+    let node = DhtNode::new(
+        PeerId::new("self"),
+        DhtConfig {
+            k_bucket_size: 8,
+            routing_refresh_secs: 300,
+            peer_ttl_secs: 300,
+        },
+    );
+    let target = NodeId::from_peer_id(&PeerId::new("anybody"));
+    let peers = node.closest_peers(&target, 5).await;
+    assert!(peers.is_empty());
+}
+
+// last_seen を用いた upsert の時間的振る舞い (Instant の昇順確認)
+#[test]
+fn instant_ordering_sanity() {
+    let a = Instant::now();
+    std::thread::sleep(Duration::from_millis(2));
+    let b = Instant::now();
+    assert!(b > a);
+}

--- a/synergos-net/tests/net_additional.rs
+++ b/synergos-net/tests/net_additional.rs
@@ -8,9 +8,7 @@
 use std::time::{Duration, Instant};
 
 use synergos_net::catalog::CatalogManager;
-use synergos_net::chain::{
-    LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry,
-};
+use synergos_net::chain::{LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry};
 use synergos_net::config::MeshConfig;
 use synergos_net::dht::rpc::RouteDto;
 use synergos_net::mesh::Mesh;

--- a/synergos-net/tests/quic_control_stream.rs
+++ b/synergos-net/tests/quic_control_stream.rs
@@ -37,17 +37,12 @@ async fn control_stream_byte_roundtrip() {
     let server_task = tokio::spawn(async move {
         if let Ok(Some(acc)) = sq.accept().await {
             if let Ok((mut send, mut recv)) = acc.connection.accept_bi().await {
-                let mut buf = vec![0u8; 64];
+                let mut buf = [0u8; 64];
                 let mut total = 0;
-                loop {
-                    match recv.read(&mut buf[total..]).await {
-                        Ok(Some(n)) => {
-                            total += n;
-                            if total >= 4 {
-                                break;
-                            }
-                        }
-                        _ => break,
+                while let Ok(Some(n)) = recv.read(&mut buf[total..]).await {
+                    total += n;
+                    if total >= 4 {
+                        break;
                     }
                 }
                 let _ = send.write_all(b"pong").await;
@@ -95,5 +90,7 @@ async fn list_connections_tracks_active_sessions() {
     let info = client.get_connection(server_id.peer_id()).unwrap();
     assert_eq!(info.peer_id, *server_id.peer_id());
 
-    tokio::time::timeout(Duration::from_millis(200), task).await.ok();
+    tokio::time::timeout(Duration::from_millis(200), task)
+        .await
+        .ok();
 }

--- a/synergos-net/tests/quic_control_stream.rs
+++ b/synergos-net/tests/quic_control_stream.rs
@@ -1,0 +1,99 @@
+//! PR-11/PR-12: QUIC 実通信の追加テスト。
+//! 制御ストリームでのラウンドトリップ + 2 方向接続。
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
+
+fn qcfg() -> QuicConfig {
+    QuicConfig {
+        max_concurrent_streams: 8,
+        idle_timeout_ms: 5_000,
+        max_udp_payload_size: 1350,
+        enable_0rtt: false,
+    }
+}
+
+async fn bound(identity: Arc<Identity>) -> (Arc<QuicManager>, SocketAddr) {
+    let qm = Arc::new(QuicManager::new(qcfg(), identity));
+    let bound = qm.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+    (qm, bound)
+}
+
+#[tokio::test]
+async fn control_stream_byte_roundtrip() {
+    let server_id = Arc::new(Identity::generate());
+    let client_id = Arc::new(Identity::generate());
+
+    let (server, server_addr) = bound(server_id.clone()).await;
+    let (client, _client_addr) = bound(client_id).await;
+
+    // サーバ側: 1 回だけ bidi を accept して echo する
+    let sq = server.clone();
+    let server_task = tokio::spawn(async move {
+        if let Ok(Some(acc)) = sq.accept().await {
+            if let Ok((mut send, mut recv)) = acc.connection.accept_bi().await {
+                let mut buf = vec![0u8; 64];
+                let mut total = 0;
+                loop {
+                    match recv.read(&mut buf[total..]).await {
+                        Ok(Some(n)) => {
+                            total += n;
+                            if total >= 4 {
+                                break;
+                            }
+                        }
+                        _ => break,
+                    }
+                }
+                let _ = send.write_all(b"pong").await;
+                let _ = send.finish();
+            }
+        }
+    });
+
+    client
+        .connect(server_id.peer_id().clone(), server_addr, "synergos")
+        .await
+        .unwrap();
+
+    client
+        .send_control(server_id.peer_id(), b"ping")
+        .await
+        .expect("send_control");
+
+    tokio::time::timeout(Duration::from_millis(500), server_task)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn list_connections_tracks_active_sessions() {
+    let server_id = Arc::new(Identity::generate());
+    let client_id = Arc::new(Identity::generate());
+
+    let (server, server_addr) = bound(server_id.clone()).await;
+    let (client, _) = bound(client_id).await;
+
+    assert_eq!(client.list_connections().len(), 0);
+
+    let sq = server.clone();
+    let task = tokio::spawn(async move {
+        let _ = sq.accept().await;
+    });
+
+    client
+        .connect(server_id.peer_id().clone(), server_addr, "synergos")
+        .await
+        .unwrap();
+
+    assert_eq!(client.list_connections().len(), 1);
+    let info = client.get_connection(server_id.peer_id()).unwrap();
+    assert_eq!(info.peer_id, *server_id.peer_id());
+
+    tokio::time::timeout(Duration::from_millis(200), task).await.ok();
+}

--- a/synergos-net/tests/quic_peer_auth.rs
+++ b/synergos-net/tests/quic_peer_auth.rs
@@ -65,6 +65,48 @@ async fn connect_succeeds_with_matching_peer_id() {
 }
 
 #[tokio::test]
+async fn disconnect_removes_connection_entry() {
+    let server_id = Arc::new(Identity::generate());
+    let client_id = Arc::new(Identity::generate());
+
+    let (server, server_addr) = bind_server(server_id.clone()).await;
+    let client = build_client(client_id).await;
+
+    let server_task = {
+        let server = server.clone();
+        tokio::spawn(async move {
+            let _ = server.accept().await;
+        })
+    };
+
+    client
+        .connect(server_id.peer_id().clone(), server_addr, "synergos")
+        .await
+        .unwrap();
+
+    assert!(client.get_connection(server_id.peer_id()).is_some());
+    client.disconnect(server_id.peer_id(), "test").await;
+    assert!(client.get_connection(server_id.peer_id()).is_none());
+    assert_eq!(client.list_connections().len(), 0);
+
+    tokio::time::timeout(Duration::from_millis(200), server_task)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn open_stream_on_unknown_peer_errors() {
+    let id = Arc::new(Identity::generate());
+    let client = build_client(id).await;
+    use synergos_net::quic::StreamType;
+    use synergos_net::types::PeerId;
+    let result = client
+        .open_stream(&PeerId::new("unknown"), StreamType::Control)
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
 async fn connect_rejects_mismatched_peer_id() {
     let server_id = Arc::new(Identity::generate());
     let wrong_id = Identity::generate();

--- a/synergos-net/tests/quic_peer_auth.rs
+++ b/synergos-net/tests/quic_peer_auth.rs
@@ -1,0 +1,99 @@
+//! S1 QUIC ピア真性認証の E2E テスト
+//!
+//! ループバックでサーバ / クライアントを立て、connect の成否が
+//! `expected_peer_id` と実ピアの鍵一致に厳密に連動することを確認する。
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use synergos_net::config::QuicConfig;
+use synergos_net::error::SynergosNetError;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
+
+fn qcfg() -> QuicConfig {
+    QuicConfig {
+        max_concurrent_streams: 8,
+        idle_timeout_ms: 5_000,
+        max_udp_payload_size: 1350,
+        enable_0rtt: false,
+    }
+}
+
+async fn bind_server(identity: Arc<Identity>) -> (Arc<QuicManager>, SocketAddr) {
+    let server = Arc::new(QuicManager::new(qcfg(), identity));
+    let addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    let bound = server.bind(addr).await.expect("server bind");
+    (server, bound)
+}
+
+async fn build_client(identity: Arc<Identity>) -> Arc<QuicManager> {
+    let client = Arc::new(QuicManager::new(qcfg(), identity));
+    let addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
+    client.bind(addr).await.expect("client bind");
+    client
+}
+
+#[tokio::test]
+async fn connect_succeeds_with_matching_peer_id() {
+    let server_id = Arc::new(Identity::generate());
+    let client_id = Arc::new(Identity::generate());
+
+    let (server, server_addr) = bind_server(server_id.clone()).await;
+    let client = build_client(client_id).await;
+
+    // サーバが着信を accept するタスクを回す
+    let server_task = {
+        let server = server.clone();
+        tokio::spawn(async move {
+            let _ = server.accept().await;
+        })
+    };
+
+    client
+        .connect(server_id.peer_id().clone(), server_addr, "synergos")
+        .await
+        .expect("connect should succeed with matching peer id");
+
+    assert!(client.get_connection(server_id.peer_id()).is_some());
+
+    // accept タスクが進むのを少し待つ (assert 済みなので強制終了で十分)
+    tokio::time::timeout(Duration::from_millis(200), server_task)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn connect_rejects_mismatched_peer_id() {
+    let server_id = Arc::new(Identity::generate());
+    let wrong_id = Identity::generate();
+    let client_id = Arc::new(Identity::generate());
+
+    let (server, server_addr) = bind_server(server_id.clone()).await;
+    let client = build_client(client_id).await;
+
+    let server_task = {
+        let server = server.clone();
+        tokio::spawn(async move {
+            // 相手の handshake 失敗で accept が Err を返す/None を返すのは
+            // 許容する (どちらも "接続確立しなかった" ことの表明)
+            let _ = server.accept().await;
+        })
+    };
+
+    let err = client
+        .connect(wrong_id.peer_id().clone(), server_addr, "synergos")
+        .await
+        .expect_err("connect must be rejected on peer id mismatch");
+
+    match err {
+        SynergosNetError::Identity(_) | SynergosNetError::Quic(_) => {}
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+
+    assert!(client.get_connection(wrong_id.peer_id()).is_none());
+    tokio::time::timeout(Duration::from_millis(200), server_task)
+        .await
+        .ok();
+}


### PR DESCRIPTION
## Summary

Issue #12 の残タスクを優先度順に一括解決 + #9 のテスト拡充 PR-3..PR-7/PR-11/PR-12/PR-14 + #13 の GUI Conflicts/Settings を 1 本にまとめた。Critical / High / Medium / Low を全て同一ブランチで対応。

### Critical — 本番運用ブロッカー
- **S1 QUIC ピア真性認証**: `DevOnlySkipVerify` を完全削除。ed25519 Identity → rcgen 自己署名 cert (SPKI に pubkey) → `PeerPinningVerifier` が `blake3(pubkey)[:20] == expected_peer_id` を TLS ハンドシェイクで検証。`QuicManager::new` が `Arc<Identity>` を要求し、`connect()` は `expected_peer_id` 必須。Daemon は `Identity::load_or_generate` で永続化。

### High — 正しく動くために
- **DHT FIND_NODE RPC**: `DhtRequest/Response` (msgpack) + `DhtTransport` trait + `QuicDhtTransport` + サーバ側 `handle_dht_stream`。`find_peer_iterative` が α=3 / max_hops / per_request_timeout で暴走防止しつつ iterative Kademlia lookup を実現。
- **実ファイル転送完全配線**: `transfer::send_over_quic/receive_over_quic` (magic `TXFR`)。`Exchange::attach_quic/execute_send/handle_incoming_transfer` で QUIC bidi にファイルを載せ、進捗は `ProgressReader` 経由で 128KiB ごとに `TransferProgressEvent` 発行、完了時に `complete_transfer`。Daemon の QUIC accept ループが magic (`DHT1`/`TXFR`) でディスパッチ。`ChunkFrame.data` に `serde_bytes` を付けて msgpack の array 直列化による膨張バグ (#12 テスト中発見) も修正。
- **Route migration 周期駆動**: Daemon の 60 秒 cleanup タスクが接続中ピアごとに `Conduit::try_migrate_route` を呼ぶ。

### Medium — 漏洩 / DoH / error type
- **redact_path / truncate_peer_id** ヘルパを `synergos-net::types` に追加。`PublishUpdate` のエラーパスと presence ログで使用。
- **DoH 多重プロバイダ + DNSSEC**: Cloudflare → Google の順で fallback、`ResolverOpts.validate = true`。
- **Error type 統一**: chain / gossip の署名検証エラーを `SynergosNetError::Identity` に寄せ、`Gossip` は通信形式エラー専用に整理。

### Medium — GUI (#13)
- **Conflicts タブ**: `ConflictList` / `ConflictResolve` IPC 追加。アクティブコンフリクトを表示し各行に [Keep Local] / [Accept Remote] / [Manual] ボタン。
- **Settings タブ**: `ConfigUpdate` IPC 追加。`gossipsub.mesh_n` / `quic.max_concurrent_streams` / `tunnel.hostname` を編集する Apply フォーム。
- `synergos-core` に lib.rs を追加して bin + lib ハイブリッド化 (統合テストから触れるよう)。

### Tests (#9 対応分)
| PR | Location | Count |
|---|---|---|
| PR-3 synergos-net L1 | `synergos-net/tests/net_additional.rs` | 13 |
| PR-4 synergos-core services | `synergos-core/tests/core_services.rs` | 12 |
| PR-5 IPC handler 単体 | `synergos-core/tests/ipc_handlers.rs` | 8 |
| PR-7 IPC duplex 統合 | `synergos-core/tests/ipc_integration.rs` | 4 |
| PR-11 QUIC 実通信追加 | `synergos-net/tests/quic_peer_auth.rs` + `quic_control_stream.rs` | 4 + 2 |
| PR-12 DHT over QUIC E2E | `synergos-net/tests/dht_over_quic.rs` | 1 |
| S1 ユニット + E2E | `synergos-net/src/quic/verifier.rs` + `tests/quic_peer_auth.rs` | 3 + 2 |
| DHT iterative | `synergos-net/tests/dht_find_node.rs` | 7 |
| Transfer E2E | `synergos-core/tests/transfer_e2e.rs` | 1 |
| **Total workspace** | | **100 passed** |

### PR-14 coverage CI
- `.github/workflows/ci.yml` に `coverage` job を追加 (`cargo-llvm-cov --lcov` → artifact)。`continue-on-error: true` で情報提供のみ。

## Test plan
- [x] `cargo build --workspace` OK
- [x] `cargo test --workspace` → 100 件グリーン
- [x] `cargo clippy --workspace --all-targets -- -D warnings` OK
- [x] `cargo fmt --all --check` OK
- [ ] CI 3-OS matrix (ubuntu / macos / windows) — このブランチで要確認
- [ ] `cargo audit` — informational
- [ ] `cargo llvm-cov` artifact の中身確認

## 未完了 (別 PR に回す)
- **S19 残り DashMap TOCTOU**: `conduit/mod.rs` / `mesh/mod.rs` のいくつかの `get → drop → get_mut` パターン
- **PR-13 GUI テスト**: `egui_kittest` の導入が必要
- **Gossipsub での Want→Send 自動起動**: IPC 経由 / Gossip `FileWant` ハンドラから `share_and_send` を発火する配線は未接続 (helper は用意済)

Refs: #12, #9, #13, #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)