### PR TITLE
feat(connectivity): STUN + Tunnel supervisor + WS Relay client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,7 +1849,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -1922,7 +1928,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "idna",
  "ipnet",
  "once_cell",
@@ -1932,7 +1938,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
 ]
@@ -1956,7 +1962,7 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
 ]
 
@@ -1970,6 +1976,22 @@ dependencies = [
  "fnv",
  "itoa",
 ]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
@@ -4235,6 +4257,7 @@ dependencies = [
  "dashmap",
  "ed25519-dalek",
  "futures",
+ "futures-util",
  "hex",
  "hickory-resolver",
  "pretty_assertions",
@@ -4248,9 +4271,11 @@ dependencies = [
  "rustls 0.23.37",
  "serde",
  "serde_bytes",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "uuid",
  "x509-parser",
@@ -4472,6 +4497,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.37",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4645,6 +4696,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,6 +4782,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -5046,6 +5123,24 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/synergos-net/Cargo.toml
+++ b/synergos-net/Cargo.toml
@@ -19,6 +19,7 @@ prost = "0.13"
 prost-types = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
+serde_json = "1"
 rmp-serde = "1"
 
 # Crypto / Hash
@@ -30,6 +31,10 @@ x509-parser = "0.16"
 
 # DNS
 hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls"] }
+
+# WebSocket Relay (fallback transport)
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
 
 # Logging
 tracing = "0.1"

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -47,6 +47,26 @@ pub struct TunnelConfig {
     /// 開発時のみ `true` を検討する。
     #[serde(default)]
     pub allow_simulation: bool,
+    /// cloudflared プロセスが crash したとき自動再起動するか (supervisor 有効化)。
+    /// 既定 `true`。`false` にすると 1 回起動して exit したらそれで終わり。
+    #[serde(default = "default_true")]
+    pub auto_restart: bool,
+    /// supervisor 再起動の初期バックオフ (ms)。`restart_base_ms × 2^N` で N は連続失敗回数。
+    #[serde(default = "default_restart_base")]
+    pub restart_base_ms: u64,
+    /// supervisor 再起動の最大バックオフ (ms)。
+    #[serde(default = "default_restart_max")]
+    pub restart_max_ms: u64,
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_restart_base() -> u64 {
+    1_000
+}
+fn default_restart_max() -> u64 {
+    60_000
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -176,6 +196,9 @@ impl Default for NetConfig {
                 api_token_ref: String::new(),
                 hostname: String::new(),
                 allow_simulation: false,
+                auto_restart: true,
+                restart_base_ms: 1_000,
+                restart_max_ms: 60_000,
             },
             mesh: MeshConfig {
                 doh_endpoint: "https://cloudflare-dns.com/dns-query".into(),

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -13,6 +13,7 @@ pub mod gossip;
 pub mod identity;
 pub mod mesh;
 pub mod quic;
+pub mod relay;
 pub mod transfer;
 pub mod tunnel;
 pub mod types;

--- a/synergos-net/src/mesh/mod.rs
+++ b/synergos-net/src/mesh/mod.rs
@@ -3,6 +3,8 @@
 //! NAT を介さない直接接続を確立するためのコンポーネント。
 //! FQDN → IPv6 解決、到達性プローブ、TURN/STUN セッション管理を提供する。
 
+pub mod stun;
+
 use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::time::{Duration, Instant};
 
@@ -287,6 +289,13 @@ impl Mesh {
                 server_uri
             )))
         }
+    }
+
+    /// STUN Binding Discovery で自分の public address を取得する (RFC 5389)。
+    /// NAT 外からどう見えているかを知るためのプローブ。IPv4 / IPv6 両対応。
+    pub async fn discover_public_address(&self, stun_server: SocketAddr) -> Result<SocketAddr> {
+        let timeout = Duration::from_millis(self.config.probe_timeout_ms as u64);
+        stun::discover_public_address(stun_server, timeout).await
     }
 
     /// 期限切れの TURN セッションをクリーンアップ

--- a/synergos-net/src/mesh/stun.rs
+++ b/synergos-net/src/mesh/stun.rs
@@ -1,0 +1,287 @@
+//! 最小 STUN クライアント (RFC 5389) — Binding Request で自分の public address を発見する。
+//!
+//! スコープ:
+//! - Binding Request のみ (Allocate / Refresh 等の TURN 拡張は `turn.rs` 側)
+//! - XOR-MAPPED-ADDRESS 属性だけを解釈 (IPv4 / IPv6 両対応)
+//! - 認証なし (classic STUN の discovery 用途)
+//!
+//! STUN メッセージは固定 20 byte ヘッダ + 可変 TLV 属性:
+//!
+//! ```text
+//!  0                   1                   2                   3
+//!  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |0 0|     STUN Message Type     |         Message Length        |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |                         Magic Cookie                          |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |                                                               |
+//! |                     Transaction ID (96 bits)                  |
+//! |                                                               |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! ```
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use tokio::net::UdpSocket;
+
+use crate::error::{Result, SynergosNetError};
+
+const MAGIC_COOKIE: u32 = 0x2112_A442;
+const TYPE_BINDING_REQUEST: u16 = 0x0001;
+const TYPE_BINDING_SUCCESS: u16 = 0x0101;
+const ATTR_XOR_MAPPED_ADDRESS: u16 = 0x0020;
+const FAMILY_IPV4: u8 = 0x01;
+const FAMILY_IPV6: u8 = 0x02;
+
+/// STUN Binding Request を送り、応答の XOR-MAPPED-ADDRESS を返す。
+/// `server_addr` は STUN サーバ (通常 UDP port 3478) の UDP アドレス。
+pub async fn discover_public_address(
+    server_addr: SocketAddr,
+    timeout: Duration,
+) -> Result<SocketAddr> {
+    // local UDP socket を bind (IPv4/IPv6 自動)
+    let bind_addr = if server_addr.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    };
+    let sock = UdpSocket::bind(bind_addr)
+        .await
+        .map_err(|e| SynergosNetError::Turn(format!("stun bind: {e}")))?;
+    sock.connect(server_addr)
+        .await
+        .map_err(|e| SynergosNetError::Turn(format!("stun connect: {e}")))?;
+
+    // Binding Request を組み立て
+    let tx_id = random_tx_id();
+    let req = encode_binding_request(&tx_id);
+    sock.send(&req)
+        .await
+        .map_err(|e| SynergosNetError::Turn(format!("stun send: {e}")))?;
+
+    let mut buf = [0u8; 1500];
+    let n = tokio::time::timeout(timeout, sock.recv(&mut buf))
+        .await
+        .map_err(|_| SynergosNetError::Turn("stun timeout".into()))?
+        .map_err(|e| SynergosNetError::Turn(format!("stun recv: {e}")))?;
+
+    parse_binding_success(&buf[..n], &tx_id)
+}
+
+fn random_tx_id() -> [u8; 12] {
+    use rand::RngCore;
+    let mut rng = rand::thread_rng();
+    let mut tx = [0u8; 12];
+    rng.fill_bytes(&mut tx);
+    tx
+}
+
+fn encode_binding_request(tx_id: &[u8; 12]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(20);
+    out.extend_from_slice(&TYPE_BINDING_REQUEST.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes()); // length = 0 (no attrs)
+    out.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+    out.extend_from_slice(tx_id);
+    out
+}
+
+fn parse_binding_success(bytes: &[u8], expected_tx: &[u8; 12]) -> Result<SocketAddr> {
+    if bytes.len() < 20 {
+        return Err(SynergosNetError::Turn("stun response too short".into()));
+    }
+    let msg_type = u16::from_be_bytes([bytes[0], bytes[1]]);
+    if msg_type != TYPE_BINDING_SUCCESS {
+        return Err(SynergosNetError::Turn(format!(
+            "unexpected STUN message type: {msg_type:#06x}"
+        )));
+    }
+    let msg_len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+    let cookie = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    if cookie != MAGIC_COOKIE {
+        return Err(SynergosNetError::Turn("invalid magic cookie".into()));
+    }
+    if &bytes[8..20] != expected_tx {
+        return Err(SynergosNetError::Turn("transaction id mismatch".into()));
+    }
+    if bytes.len() < 20 + msg_len {
+        return Err(SynergosNetError::Turn("stun body truncated".into()));
+    }
+
+    // 属性を走査
+    let mut cursor = 20;
+    let end = 20 + msg_len;
+    while cursor + 4 <= end {
+        let attr_type = u16::from_be_bytes([bytes[cursor], bytes[cursor + 1]]);
+        let attr_len = u16::from_be_bytes([bytes[cursor + 2], bytes[cursor + 3]]) as usize;
+        let val_start = cursor + 4;
+        let val_end = val_start + attr_len;
+        if val_end > end {
+            return Err(SynergosNetError::Turn("attribute past message end".into()));
+        }
+
+        if attr_type == ATTR_XOR_MAPPED_ADDRESS {
+            return parse_xor_mapped(&bytes[val_start..val_end], expected_tx);
+        }
+
+        // 4 byte 境界で padding
+        let padded = (attr_len + 3) & !3;
+        cursor = val_start + padded;
+    }
+
+    Err(SynergosNetError::Turn(
+        "no XOR-MAPPED-ADDRESS attribute".into(),
+    ))
+}
+
+fn parse_xor_mapped(attr: &[u8], tx_id: &[u8; 12]) -> Result<SocketAddr> {
+    if attr.len() < 4 {
+        return Err(SynergosNetError::Turn("xor-mapped too short".into()));
+    }
+    let family = attr[1];
+    let xor_port = u16::from_be_bytes([attr[2], attr[3]]);
+    let port = xor_port ^ ((MAGIC_COOKIE >> 16) as u16);
+
+    match family {
+        FAMILY_IPV4 => {
+            if attr.len() < 8 {
+                return Err(SynergosNetError::Turn("xor-mapped ipv4 too short".into()));
+            }
+            let xor_ip = u32::from_be_bytes([attr[4], attr[5], attr[6], attr[7]]);
+            let ip = Ipv4Addr::from(xor_ip ^ MAGIC_COOKIE);
+            Ok(SocketAddr::new(IpAddr::V4(ip), port))
+        }
+        FAMILY_IPV6 => {
+            if attr.len() < 20 {
+                return Err(SynergosNetError::Turn("xor-mapped ipv6 too short".into()));
+            }
+            let mut ip_bytes = [0u8; 16];
+            ip_bytes.copy_from_slice(&attr[4..20]);
+            // XOR with magic cookie || tx_id
+            let mut xor_key = [0u8; 16];
+            xor_key[..4].copy_from_slice(&MAGIC_COOKIE.to_be_bytes());
+            xor_key[4..].copy_from_slice(tx_id);
+            for (a, b) in ip_bytes.iter_mut().zip(xor_key.iter()) {
+                *a ^= *b;
+            }
+            Ok(SocketAddr::new(IpAddr::V6(Ipv6Addr::from(ip_bytes)), port))
+        }
+        other => Err(SynergosNetError::Turn(format!(
+            "unknown address family {other}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binding_request_is_20_bytes() {
+        let tx = [0xAAu8; 12];
+        let req = encode_binding_request(&tx);
+        assert_eq!(req.len(), 20);
+        assert_eq!(&req[0..2], &TYPE_BINDING_REQUEST.to_be_bytes());
+        assert_eq!(&req[2..4], &[0, 0]); // length
+        assert_eq!(&req[4..8], &MAGIC_COOKIE.to_be_bytes());
+        assert_eq!(&req[8..20], &tx);
+    }
+
+    #[test]
+    fn parses_ipv4_xor_mapped_address() {
+        // 実際の STUN サーバ応答を模倣: 192.0.2.1:8080
+        let tx = [0x12u8; 12];
+        let mut resp = Vec::new();
+        resp.extend_from_slice(&TYPE_BINDING_SUCCESS.to_be_bytes());
+        resp.extend_from_slice(&12u16.to_be_bytes()); // body len
+        resp.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+        resp.extend_from_slice(&tx);
+        // Attr: XOR-MAPPED-ADDRESS
+        resp.extend_from_slice(&ATTR_XOR_MAPPED_ADDRESS.to_be_bytes());
+        resp.extend_from_slice(&8u16.to_be_bytes()); // 8 bytes value
+        resp.push(0);
+        resp.push(FAMILY_IPV4);
+        let port = 8080u16;
+        let xport = port ^ ((MAGIC_COOKIE >> 16) as u16);
+        resp.extend_from_slice(&xport.to_be_bytes());
+        let ip = Ipv4Addr::new(192, 0, 2, 1);
+        let xip = u32::from(ip) ^ MAGIC_COOKIE;
+        resp.extend_from_slice(&xip.to_be_bytes());
+
+        let addr = parse_binding_success(&resp, &tx).unwrap();
+        assert_eq!(addr, SocketAddr::new(IpAddr::V4(ip), port));
+    }
+
+    #[test]
+    fn rejects_wrong_transaction_id() {
+        let tx = [0x11u8; 12];
+        let wrong_tx = [0x22u8; 12];
+        let mut resp = Vec::new();
+        resp.extend_from_slice(&TYPE_BINDING_SUCCESS.to_be_bytes());
+        resp.extend_from_slice(&0u16.to_be_bytes());
+        resp.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+        resp.extend_from_slice(&tx);
+
+        let err = parse_binding_success(&resp, &wrong_tx).unwrap_err();
+        match err {
+            SynergosNetError::Turn(msg) => assert!(msg.contains("transaction id")),
+            other => panic!("expected Turn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_magic_cookie() {
+        let tx = [0u8; 12];
+        let mut resp = Vec::new();
+        resp.extend_from_slice(&TYPE_BINDING_SUCCESS.to_be_bytes());
+        resp.extend_from_slice(&0u16.to_be_bytes());
+        resp.extend_from_slice(&0xDEAD_BEEFu32.to_be_bytes());
+        resp.extend_from_slice(&tx);
+        assert!(parse_binding_success(&resp, &tx).is_err());
+    }
+
+    // ループバック UDP 上で STUN サーバを模倣して discover_public_address を回す
+    #[tokio::test]
+    async fn discover_against_mock_stun_server() {
+        // バインドしてポートを得る
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let mut buf = [0u8; 1500];
+            let (n, peer) = server.recv_from(&mut buf).await.unwrap();
+            // Binding Request を受けた前提で Binding Success を返す
+            let tx_id: [u8; 12] = buf[8..20].try_into().unwrap();
+            let mut resp = Vec::new();
+            resp.extend_from_slice(&TYPE_BINDING_SUCCESS.to_be_bytes());
+            resp.extend_from_slice(&12u16.to_be_bytes());
+            resp.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+            resp.extend_from_slice(&tx_id);
+            resp.extend_from_slice(&ATTR_XOR_MAPPED_ADDRESS.to_be_bytes());
+            resp.extend_from_slice(&8u16.to_be_bytes());
+            resp.push(0);
+            resp.push(FAMILY_IPV4);
+            let port = match peer.ip() {
+                IpAddr::V4(_) => peer.port(),
+                _ => 0,
+            };
+            let xport = port ^ ((MAGIC_COOKIE >> 16) as u16);
+            resp.extend_from_slice(&xport.to_be_bytes());
+            let ip = match peer.ip() {
+                IpAddr::V4(v4) => u32::from(v4),
+                _ => 0,
+            };
+            let xip = ip ^ MAGIC_COOKIE;
+            resp.extend_from_slice(&xip.to_be_bytes());
+            server.send_to(&resp, peer).await.unwrap();
+            let _ = n;
+        });
+
+        let result = discover_public_address(server_addr, Duration::from_secs(2))
+            .await
+            .unwrap();
+        assert!(result.is_ipv4());
+        server_task.await.unwrap();
+    }
+}

--- a/synergos-net/src/relay/mod.rs
+++ b/synergos-net/src/relay/mod.rs
@@ -1,0 +1,166 @@
+//! WebSocket Relay クライアント (Conduit の `RouteKind::Relay` 実装)。
+//!
+//! シナリオ: 両ノードが NAT 越えで直接接続できず Cloudflare Tunnel も
+//! 使えない場合のフォールバック。信頼できる中継サーバに WSS で繋ぎ、
+//! `room_id` 毎のブロードキャストで相手ピアに data frame を流す。
+//!
+//! ## プロトコル
+//!
+//! サーバ実装は別リポジトリ想定 (`synergos-relay` バイナリ) だが、
+//! クライアント ⇔ サーバの wire format は本モジュールで規定する:
+//!
+//! クライアント → サーバ (最初の 1 メッセージで join):
+//! ```json
+//! { "type": "join", "room_id": "<uuid>", "peer_id": "<local peer>" }
+//! ```
+//!
+//! その後の data 送信 / 受信は binary WebSocket フレームを使う。
+//! 先頭に `u16 be length` + msgpack `(from_peer_id, payload)` を書く。
+//!
+//! 本実装ではサーバ側は提供せず、クライアントだけ。テストは in-process
+//! WebSocket サーバを立ててラウンドトリップを検証する。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::error::{Result, SynergosNetError};
+use crate::types::PeerId;
+
+/// Room join リクエスト (text frame)。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RelayControl {
+    Join { room_id: String, peer_id: PeerId },
+    Leave,
+}
+
+/// relay 経由で送る data frame。from_peer_id は binary payload の前に
+/// msgpack で 1 shot 直列化する。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayData {
+    pub from_peer_id: PeerId,
+    #[serde(with = "serde_bytes")]
+    pub payload: Vec<u8>,
+}
+
+/// Relay session 1 本の suspend/run。`incoming` から相手ピアの
+/// data を受け取り、`send` で自分から相手へ流す。
+pub struct RelaySession {
+    /// 外部から binary data を送るキュー
+    send_tx: mpsc::Sender<RelayData>,
+    /// 外部が受信する binary data のキュー
+    recv_rx: Arc<Mutex<mpsc::Receiver<RelayData>>>,
+    /// run_loop のハンドル (session shutdown で abort)
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl RelaySession {
+    /// 指定 WSS URL に接続し、room に join する。
+    /// 成功すると双方向のチャネルを生やした `RelaySession` を返す。
+    pub async fn connect(url: &str, room_id: &str, local_peer: PeerId) -> Result<Self> {
+        let (ws_stream, _) = tokio_tungstenite::connect_async(url)
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("relay connect: {e}")))?;
+
+        let (mut writer, mut reader) = ws_stream.split();
+
+        // Join 制御メッセージを最初に送る
+        let join = RelayControl::Join {
+            room_id: room_id.to_string(),
+            peer_id: local_peer.clone(),
+        };
+        let text = serde_json::to_string(&join)
+            .map_err(|e| SynergosNetError::Serialization(format!("relay join: {e}")))?;
+        writer
+            .send(Message::text(text))
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("relay join send: {e}")))?;
+
+        let (send_tx, mut send_rx) = mpsc::channel::<RelayData>(64);
+        let (recv_tx, recv_rx) = mpsc::channel::<RelayData>(64);
+
+        // writer 側: send_rx を読んでバイナリフレームで送信
+        let writer_task = tokio::spawn(async move {
+            while let Some(data) = send_rx.recv().await {
+                let body = match rmp_serde::to_vec(&data) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!("relay encode: {e}");
+                        continue;
+                    }
+                };
+                if let Err(e) = writer.send(Message::binary(body)).await {
+                    tracing::warn!("relay send: {e}");
+                    break;
+                }
+            }
+        });
+
+        // reader 側: WS から受信した binary フレームを decode して recv_tx に流す
+        let reader_task = tokio::spawn(async move {
+            while let Some(msg) = reader.next().await {
+                let Ok(msg) = msg else {
+                    break;
+                };
+                match msg {
+                    Message::Binary(bytes) => match rmp_serde::from_slice::<RelayData>(&bytes) {
+                        Ok(data) => {
+                            if recv_tx.send(data).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => tracing::debug!("relay decode: {e}"),
+                    },
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+        });
+
+        // supervisor: 片方が終わったらもう片方も止める
+        let task = tokio::spawn(async move {
+            let _ = tokio::try_join!(writer_task, reader_task);
+        });
+
+        Ok(Self {
+            send_tx,
+            recv_rx: Arc::new(Mutex::new(recv_rx)),
+            task,
+        })
+    }
+
+    /// `target_peer_id` は使わない (relay サーバが room 内に bcast する前提)
+    /// — 実運用ではサーバ側で to フィールドを見てフィルタするが、本最小版は
+    /// bcast + 受信側がフィルタするモデル。
+    pub async fn send(&self, data: RelayData) -> Result<()> {
+        self.send_tx
+            .send(data)
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("relay send queue: {e}")))
+    }
+
+    /// タイムアウト付きで 1 メッセージを受信する。
+    pub async fn recv(&self, timeout: Duration) -> Result<RelayData> {
+        let mut rx = self.recv_rx.lock().await;
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some(d)) => Ok(d),
+            Ok(None) => Err(SynergosNetError::Quic("relay recv closed".into())),
+            Err(_) => Err(SynergosNetError::Quic("relay recv timeout".into())),
+        }
+    }
+
+    pub fn shutdown(&self) {
+        self.task.abort();
+    }
+}
+
+impl Drop for RelaySession {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}

--- a/synergos-net/src/tunnel/mod.rs
+++ b/synergos-net/src/tunnel/mod.rs
@@ -2,9 +2,19 @@
 //!
 //! cloudflared プロセスの起動・停止・ヘルスチェックを管理する。
 //! QUIC トランスポート経由でピア接続を中継する。
+//!
+//! ## プロセス supervisor
+//!
+//! `start()` 成功時にバックグラウンドで child を監視するタスクを spawn する:
+//!   - stdout / stderr を 1 行ずつ tracing に流す (最大バッファサイズで切る)
+//!   - 子プロセスが exit したら state を `Error` に遷移
+//!   - `auto_restart=true` のときは指数バックオフで再起動を試みる
+//!     (`restart_base_ms` × 2^N、上限 `restart_max_ms`)
 
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::RwLock;
 
 use crate::config::TunnelConfig;
@@ -43,6 +53,8 @@ pub struct TunnelManager {
     state: RwLock<TunnelState>,
     /// cloudflared プロセスハンドル
     process: RwLock<Option<tokio::process::Child>>,
+    /// supervisor タスクハンドル (stop で abort する)
+    supervisor: RwLock<Option<tokio::task::JoinHandle<()>>>,
     /// ヘルスチェック結果
     health: RwLock<Option<TunnelHealth>>,
     /// 起動時刻
@@ -56,6 +68,7 @@ impl TunnelManager {
             config: config.clone(),
             state: RwLock::new(TunnelState::Idle),
             process: RwLock::new(None),
+            supervisor: RwLock::new(None),
             health: RwLock::new(None),
             started_at: RwLock::new(None),
         }
@@ -81,8 +94,11 @@ impl TunnelManager {
         }
     }
 
-    /// cloudflared プロセスを起動して Tunnel を確立する
-    pub async fn start(&self) -> Result<String> {
+    /// cloudflared プロセスを起動して Tunnel を確立する。
+    /// 起動成功後、バックグラウンドで supervisor が stdout/stderr を
+    /// tracing に流し、crash したら指数バックオフで再起動する
+    /// (`config.auto_restart` が true の場合)。
+    pub async fn start(self: &Arc<Self>) -> Result<String> {
         {
             let state = self.state.read().await;
             if matches!(&*state, TunnelState::Active { .. } | TunnelState::Starting) {
@@ -95,35 +111,46 @@ impl TunnelManager {
         *self.state.write().await = TunnelState::Starting;
         tracing::info!("Starting Cloudflare Tunnel...");
 
-        // cloudflared プロセスを起動
-        let result = self.spawn_cloudflared().await;
-
-        match result {
-            Ok(tunnel_id) => {
-                *self.started_at.write().await = Some(Instant::now());
-                *self.state.write().await = TunnelState::Active {
-                    tunnel_id: tunnel_id.clone(),
-                    uptime_secs: 0,
-                };
-                tracing::info!(
-                    "Tunnel active: id={}, hostname={}",
-                    tunnel_id,
-                    self.hostname
-                );
-                Ok(tunnel_id)
-            }
+        // 最初の起動を実行
+        let tunnel_id = match self.spawn_cloudflared().await {
+            Ok(id) => id,
             Err(e) => {
                 *self.state.write().await = TunnelState::Error {
                     message: e.to_string(),
                 };
-                Err(e)
+                return Err(e);
             }
-        }
+        };
+
+        *self.started_at.write().await = Some(Instant::now());
+        *self.state.write().await = TunnelState::Active {
+            tunnel_id: tunnel_id.clone(),
+            uptime_secs: 0,
+        };
+        tracing::info!(
+            "Tunnel active: id={}, hostname={}",
+            tunnel_id,
+            self.hostname
+        );
+
+        // supervisor を spawn (stdout 配線 + 自動再起動)
+        let me = self.clone();
+        let supervisor = tokio::spawn(async move {
+            me.supervise().await;
+        });
+        *self.supervisor.write().await = Some(supervisor);
+
+        Ok(tunnel_id)
     }
 
-    /// Tunnel を停止する
+    /// Tunnel を停止する (supervisor も停止)。
     pub async fn stop(&self) -> Result<()> {
         tracing::info!("Stopping Cloudflare Tunnel...");
+
+        // supervisor を先に止めることで再起動ループを断つ
+        if let Some(handle) = self.supervisor.write().await.take() {
+            handle.abort();
+        }
 
         // cloudflared プロセスを終了
         let mut process = self.process.write().await;
@@ -138,6 +165,108 @@ impl TunnelManager {
         *self.health.write().await = None;
 
         Ok(())
+    }
+
+    /// supervisor ループ: stdout/stderr を tracing に流しながら子プロセスを監視。
+    /// 子が exit したら (1) auto_restart 無効なら state を Idle に戻して終了、
+    /// (2) 有効なら指数バックオフで `spawn_cloudflared` を呼び直す。
+    async fn supervise(self: Arc<Self>) {
+        let mut failures: u32 = 0;
+        loop {
+            // 現在の子を取り出し、stdout/stderr をログ配線する
+            let (child_opt, stdout_task, stderr_task) = {
+                let mut guard = self.process.write().await;
+                if let Some(mut child) = guard.take() {
+                    let stdout = child.stdout.take();
+                    let stderr = child.stderr.take();
+                    let st = stdout.map(|out| {
+                        tokio::spawn(async move {
+                            let mut lines = BufReader::new(out).lines();
+                            while let Ok(Some(line)) = lines.next_line().await {
+                                tracing::debug!(target: "cloudflared", "{line}");
+                            }
+                        })
+                    });
+                    let se = stderr.map(|err| {
+                        tokio::spawn(async move {
+                            let mut lines = BufReader::new(err).lines();
+                            while let Ok(Some(line)) = lines.next_line().await {
+                                tracing::warn!(target: "cloudflared", "{line}");
+                            }
+                        })
+                    });
+                    (Some(child), st, se)
+                } else {
+                    (None, None, None)
+                }
+            };
+
+            let Some(mut child) = child_opt else {
+                // simulation mode / child 未保持 — 何もせず終了
+                return;
+            };
+
+            // 子の exit を待つ
+            let exit_status = match child.wait().await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("cloudflared wait failed: {e}");
+                    *self.state.write().await = TunnelState::Error {
+                        message: format!("wait failed: {e}"),
+                    };
+                    return;
+                }
+            };
+
+            // stdout/stderr の読取タスクを終わらせる
+            if let Some(h) = stdout_task {
+                h.abort();
+            }
+            if let Some(h) = stderr_task {
+                h.abort();
+            }
+
+            tracing::warn!(
+                "cloudflared exited with status {:?}; auto_restart={}",
+                exit_status.code(),
+                self.config.auto_restart
+            );
+
+            if !self.config.auto_restart {
+                *self.state.write().await = TunnelState::Error {
+                    message: format!("exited with {:?}", exit_status.code()),
+                };
+                return;
+            }
+
+            // 指数バックオフで再起動
+            failures = failures.saturating_add(1);
+            let delay = (self.config.restart_base_ms)
+                .saturating_mul(1u64 << failures.min(20))
+                .min(self.config.restart_max_ms);
+            tracing::info!("cloudflared restart in {}ms (attempt {failures})", delay);
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+
+            match self.spawn_cloudflared().await {
+                Ok(new_id) => {
+                    tracing::info!("cloudflared respawned as {new_id}");
+                    *self.started_at.write().await = Some(Instant::now());
+                    *self.state.write().await = TunnelState::Active {
+                        tunnel_id: new_id,
+                        uptime_secs: 0,
+                    };
+                    // failures = 0; — 即リセットはしない。成功が安定して
+                    // 初めてカウンタを下げるべきだが、supervisor はシンプルに
+                    // バックオフ累積を継続する (連続落ちで早すぎる再起動を防ぐ)
+                }
+                Err(e) => {
+                    tracing::warn!("respawn failed: {e}");
+                    *self.state.write().await = TunnelState::Error {
+                        message: e.to_string(),
+                    };
+                }
+            }
+        }
     }
 
     /// Tunnel のヘルスチェックを実施

--- a/synergos-net/tests/relay_session.rs
+++ b/synergos-net/tests/relay_session.rs
@@ -1,0 +1,112 @@
+//! WebSocket Relay セッションの単体テスト。
+//! in-process で echo-style のリレーサーバを起動し、2 クライアント間で
+//! バイナリ frame が流れるかを確認する。
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use synergos_net::relay::{RelayData, RelaySession};
+use synergos_net::types::PeerId;
+use tokio::net::TcpListener;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+/// 簡易 relay サーバ: 1 room のみ想定、最初の join メッセージは捨てて、
+/// 以降の binary フレームを他の接続に bcast する。
+async fn run_echo_relay(listener: TcpListener) {
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let clients: Arc<RwLock<Vec<tokio::sync::mpsc::Sender<Vec<u8>>>>> =
+        Arc::new(RwLock::new(Vec::new()));
+
+    while let Ok((stream, _)) = listener.accept().await {
+        let ws = match accept_async(stream).await {
+            Ok(w) => w,
+            Err(_) => continue,
+        };
+        let (mut writer, mut reader) = ws.split();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+        clients.write().await.push(tx);
+
+        // writer ループ
+        tokio::spawn(async move {
+            while let Some(bytes) = rx.recv().await {
+                if writer.send(Message::binary(bytes)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // reader ループ: join を無視し、以降の binary を他クライアントに bcast
+        let clients_clone = clients.clone();
+        tokio::spawn(async move {
+            let mut joined = false;
+            while let Some(Ok(msg)) = reader.next().await {
+                match msg {
+                    Message::Text(_) if !joined => {
+                        joined = true;
+                    }
+                    Message::Binary(bytes) => {
+                        let senders = clients_clone.read().await.clone();
+                        for s in senders {
+                            let _ = s.try_send(bytes.to_vec());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+    }
+}
+
+#[tokio::test]
+async fn relay_roundtrip_between_two_clients() {
+    // relay サーバを bind
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let url = format!("ws://{}/", addr);
+    tokio::spawn(run_echo_relay(listener));
+
+    let peer_a = PeerId::new("a");
+    let peer_b = PeerId::new("b");
+
+    let session_a = RelaySession::connect(&url, "room-x", peer_a.clone())
+        .await
+        .unwrap();
+    let session_b = RelaySession::connect(&url, "room-x", peer_b.clone())
+        .await
+        .unwrap();
+
+    // クライアント接続が echo relay に登録されるまで少し待つ
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // A → サーバ bcast → A 自身と B が受け取る。
+    // 最小 echo relay では sender 自身にも返るので、B の受信のみ検証する。
+    session_a
+        .send(RelayData {
+            from_peer_id: peer_a.clone(),
+            payload: b"hello".to_vec(),
+        })
+        .await
+        .unwrap();
+
+    // B 側が受信するかを確認 (自分が出した echo も混在する可能性があるので
+    // peer_id で区別する)
+    let mut got = None;
+    for _ in 0..5 {
+        let data = session_b.recv(Duration::from_millis(500)).await;
+        match data {
+            Ok(d) if d.from_peer_id == peer_a => {
+                got = Some(d);
+                break;
+            }
+            Ok(_) => continue,
+            Err(_) => continue,
+        }
+    }
+    let data = got.expect("B should receive A's frame within 2.5s");
+    assert_eq!(data.payload, b"hello");
+}


### PR DESCRIPTION
## Summary

ピア経路確立 3 点を 1 ブランチに集約。

- **STUN (RFC 5389) Binding Discovery**: 新 \`synergos-net/src/mesh/stun.rs\` + \`Mesh::discover_public_address\`
- **Tunnel プロセス supervisor**: \`start()\` が Arc<Self> を取り、バックグラウンド supervisor が stdout/stderr を tracing に流し、crash 時は指数バックオフで respawn
- **WebSocket Relay クライアント**: 新 \`synergos-net/src/relay/mod.rs\` — \`RelaySession::connect/send/recv\`。サーバ側の wire format は doc で規定、テストは in-process echo relay で検証

## Tests (+6): 122 → 128
- STUN unit (5): encode/parse/roundtrip via mock server
- Relay session integration (1): 2 クライアント間の echo

clippy -D warnings / fmt clean。

Refs: Issue #6 §3.1, #10 §9 / §10

🤖 Generated with [Claude Code](https://claude.com/claude-code)