### PR TITLE
test(gui): egui_kittest UI snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.26.0",
  "atspi-common",
  "serde",
  "thiserror 1.0.69",
  "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3a17950ce0d911f132387777b9b3d05eddafb59b773ccaa53fceefaeb0228e"
+dependencies = [
+ "accesskit",
+ "immutable-chunkmap",
 ]
 
 [[package]]
@@ -56,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.26.0",
  "hashbrown 0.15.5",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -88,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_consumer 0.26.0",
  "hashbrown 0.15.5",
  "paste",
  "static_assertions",
@@ -1294,6 +1304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_kittest"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c46def610cf9486675aeec698d4e36a949ec0b0e1f6096135b0584dcfd52aa47"
+dependencies = [
+ "egui",
+ "kittest",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2286,17 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kittest"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f659954571a3c132356bd15c25f0dcf14d270a28ec5c58797adc2f432831bed5"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.25.0",
+ "parking_lot",
+]
 
 [[package]]
 name = "lazy_static"
@@ -4199,6 +4230,7 @@ dependencies = [
  "assert_matches",
  "eframe",
  "egui",
+ "egui_kittest",
  "pretty_assertions",
  "serde",
  "synergos-ipc",

--- a/synergos-gui/Cargo.toml
+++ b/synergos-gui/Cargo.toml
@@ -33,3 +33,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["full", "test-util"] }
 pretty_assertions = "1"
 assert_matches = "1"
+
+# GUI テストハーネス (Issue #9 PR-13)。ヘッドレスで UI をレンダリングし、
+# 表示内容やクリックの結果を検証する。スナップショット機能は別 feature。
+egui_kittest = "0.31"

--- a/synergos-gui/src/connection.rs
+++ b/synergos-gui/src/connection.rs
@@ -32,6 +32,12 @@ pub struct ConnectionCache {
     pub last_refresh: Option<std::time::Instant>,
 }
 
+impl Default for CoreConnection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CoreConnection {
     pub fn new() -> Self {
         let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/synergos-gui/src/lib.rs
+++ b/synergos-gui/src/lib.rs
@@ -1,0 +1,6 @@
+//! synergos-gui ライブラリ公開面。
+//! 統合テスト (egui_kittest) から UI モジュールにアクセスするための lib target。
+
+pub mod app;
+pub mod connection;
+pub mod ui;

--- a/synergos-gui/src/main.rs
+++ b/synergos-gui/src/main.rs
@@ -5,9 +5,7 @@
 //!
 //! git に対する SourceTree のような位置づけ。Ars には一切依存しない。
 
-mod app;
-mod connection;
-mod ui;
+use synergos_gui::app;
 
 use tracing_subscriber::EnvFilter;
 

--- a/synergos-gui/tests/ui_snapshot.rs
+++ b/synergos-gui/tests/ui_snapshot.rs
@@ -1,0 +1,185 @@
+//! GUI スナップショット / レンダリングテスト (Issue #9 PR-13)。
+//!
+//! `egui_kittest::Harness` を使って各タブの UI を headless で描画し、
+//! ラベルや値が期待通り出ているかを確認する。実デーモンには繋がないので
+//! `CoreConnection::new()` は "未接続" 状態で構築される。`cache` を
+//! テストから直接書き換えて描画内容を検証する。
+
+use egui_kittest::kittest::Queryable;
+use synergos_gui::app::UiInputs;
+use synergos_gui::connection::{ConnectionCache, CoreConnection};
+use synergos_gui::ui;
+use synergos_ipc::response::{
+    ConflictInfoDto, DaemonStatus, NetworkStatusInfo, PeerInfo, TransferInfo,
+};
+
+fn seeded_connection(populate: impl FnOnce(&mut ConnectionCache)) -> CoreConnection {
+    let conn = CoreConnection::new();
+    {
+        let mut cache = conn.cache.lock().unwrap();
+        populate(&mut cache);
+    }
+    conn
+}
+
+#[test]
+fn overview_renders_without_data() {
+    let conn = seeded_connection(|_| {});
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        let mut inputs = UiInputs::default();
+        ui::overview::show(ui, &conn, &mut inputs);
+    });
+    harness.run();
+    // "Overview" ヘディングが描画されることを確認
+    let _ = harness.get_by_label("Network Overview");
+}
+
+#[test]
+fn overview_shows_network_info_when_populated() {
+    let conn = seeded_connection(|cache| {
+        cache.status = Some(DaemonStatus {
+            pid: 4242,
+            started_at: 0,
+            project_count: 3,
+            active_connections: 2,
+            active_transfers: 1,
+        });
+        cache.network = Some(NetworkStatusInfo {
+            primary_route: "DirectIPv6".into(),
+            total_bandwidth_bps: 1_000_000,
+            used_bandwidth_bps: 0,
+            active_connections: 2,
+            max_connections: 8,
+            avg_latency_ms: 42,
+        });
+    });
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        let mut inputs = UiInputs::default();
+        ui::overview::show(ui, &conn, &mut inputs);
+    });
+    harness.run();
+    // network.primary_route が overview で表示されるはず
+    let _ = harness.get_by_label("DirectIPv6");
+}
+
+#[test]
+fn transfers_empty_state() {
+    let conn = seeded_connection(|_| {});
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        let mut inputs = UiInputs::default();
+        ui::transfers::show(ui, &conn, &mut inputs);
+    });
+    harness.run();
+    let _ = harness.get_by_label("Transfers");
+}
+
+#[test]
+fn transfers_lists_rows() {
+    let conn = seeded_connection(|cache| {
+        cache.transfers = vec![TransferInfo {
+            transfer_id: "t-1".into(),
+            file_name: "report.pdf".into(),
+            file_size: 2048,
+            bytes_transferred: 1024,
+            speed_bps: 512,
+            direction: "Receive".into(),
+            peer_id: "peer-xyz".into(),
+            state: "Running".into(),
+        }];
+    });
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        let mut inputs = UiInputs::default();
+        ui::transfers::show(ui, &conn, &mut inputs);
+    });
+    harness.run();
+    let _ = harness.get_by_label_contains("report.pdf");
+}
+
+#[test]
+fn peers_empty_state() {
+    let conn = seeded_connection(|_| {});
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        let mut inputs = UiInputs::default();
+        ui::peers::show(ui, &conn, &mut inputs);
+    });
+    harness.run();
+    let _ = harness.get_by_label("Peers");
+}
+
+#[test]
+fn peers_lists_rows() {
+    let conn = seeded_connection(|cache| {
+        cache.peers = vec![PeerInfo {
+            peer_id: "peer-abc".into(),
+            display_name: "Alice".into(),
+            route: "Direct".into(),
+            rtt_ms: 42,
+            bandwidth_bps: 1_000_000,
+            state: "Connected".into(),
+        }];
+    });
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        let mut inputs = UiInputs::default();
+        ui::peers::show(ui, &conn, &mut inputs);
+    });
+    harness.run();
+    let _ = harness.get_by_label_contains("Alice");
+}
+
+#[test]
+fn conflicts_empty_state_shows_help() {
+    let conn = seeded_connection(|_| {});
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        ui::conflicts::show(ui, &conn);
+    });
+    harness.run();
+    let _ = harness.get_by_label_contains("No active conflicts");
+}
+
+#[test]
+fn conflicts_lists_rows_with_resolve_buttons() {
+    let conn = seeded_connection(|cache| {
+        cache.conflicts = vec![ConflictInfoDto {
+            file_id: "f-1".into(),
+            file_path: "src/main.rs".into(),
+            project_id: "proj".into(),
+            local_version: 3,
+            local_author: "aaaabbbbccccdddd".into(),
+            remote_version: 4,
+            remote_author: "11112222333344445".into(),
+            detected_at: 0,
+            state: "active".into(),
+        }];
+    });
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        ui::conflicts::show(ui, &conn);
+    });
+    harness.run();
+    // ファイルパスと解決ボタンが描画される
+    let _ = harness.get_by_label_contains("src/main.rs");
+    let _ = harness.get_by_label("Keep Local");
+    let _ = harness.get_by_label("Accept Remote");
+    let _ = harness.get_by_label("Manual");
+}
+
+#[test]
+fn settings_renders_network_tuning_form() {
+    let conn = seeded_connection(|cache| {
+        cache.network = Some(NetworkStatusInfo {
+            primary_route: "Direct".into(),
+            total_bandwidth_bps: 1_000_000,
+            used_bandwidth_bps: 256_000,
+            active_connections: 2,
+            max_connections: 8,
+            avg_latency_ms: 42,
+        });
+    });
+    let mut harness = egui_kittest::Harness::new_ui(|ui| {
+        ui::settings::show(ui, &conn);
+    });
+    harness.run();
+    // Settings タブは collapsing header が初期状態で閉じている。
+    // ヘッダ "Daemon" / "About" などは常に見えるのでそれらで検証する。
+    let _ = harness.get_by_label("Daemon");
+    let _ = harness.get_by_label("About");
+}


### PR DESCRIPTION
## Summary

Issue #9 PR-13: GUI ラチェンダリング / 操作検証の自動テスト。

- synergos-gui を lib + bin ハイブリッド化 (tests/ から ui モジュールにアクセス)
- dev-dep に egui_kittest 0.31
- 9 件: overview / transfers / peers / conflicts / settings の各タブが empty / populated 状態で期待ラベル + ボタンを出すことを確認

Headless でレンダリングするので CI に優しい。実デーモンは不要 (ConnectionCache を直接 seed)。

## Tests (+9): 122 → 131
## Supporting change
- CoreConnection に Default impl (clippy::new_without_default 対応)

clippy clean / fmt clean。

Refs: Issue #9 PR-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)