### PR TITLE
feat(security): Critical 2 + High 2 — identity 暗号化 / Windows IPC SID / path traversal / JSON log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +291,18 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -620,6 +667,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +858,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -996,7 +1062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1099,6 +1175,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1731,6 +1808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,6 +2241,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2983,6 +3079,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,6 +3155,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3171,6 +3284,18 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4244,6 +4369,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4282,6 +4408,8 @@ dependencies = [
 name = "synergos-net"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
+ "argon2",
  "assert_matches",
  "async-trait",
  "blake3",
@@ -4704,6 +4832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4713,12 +4851,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4817,6 +4958,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/synergos-core/Cargo.toml
+++ b/synergos-core/Cargo.toml
@@ -31,7 +31,7 @@ rmp-serde = "1"
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
@@ -46,6 +46,17 @@ anyhow = "1"
 # Unix peer credential check (SO_PEERCRED via libc::geteuid)
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# Windows IPC caller SID verification (Named Pipe ACL の代替として
+# GetNamedPipeClientProcessId → OpenProcessToken → GetTokenInformation で
+# caller SID を取得し、現在プロセスの owner SID と比較する)
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -299,15 +299,158 @@ fn peer_uid_of_fd(_fd: std::os::unix::io::RawFd) -> std::io::Result<libc::uid_t>
 
 /// Windows Named Pipe 接続のハンドリング。Unix 版と共通の dispatch/relay
 /// ロジックをトレイト越しに呼び出すラッパ。
+///
+/// 接続直後に **caller SID と daemon プロセスの owner SID を比較** して、
+/// 同一ユーザでなければ即切断する。Named Pipe は `first_pipe_instance` で
+/// 名前占有はしているが、ACL を細かく設定していないため Windows 上の任意
+/// ユーザが接続できてしまう穴があった (CWE-269)。
 #[cfg(windows)]
 async fn handle_client_windows(
     pipe: tokio::net::windows::named_pipe::NamedPipeServer,
     ctx: Arc<ServiceContext>,
 ) -> Result<(), IpcError> {
+    if let Err(reason) = verify_windows_caller(&pipe) {
+        tracing::warn!("rejecting client (Windows): {reason}");
+        // pipe を drop して接続を切る
+        return Ok(());
+    }
     let (reader, writer) = tokio::io::split(pipe);
     let writer: Arc<Mutex<tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeServer>>> =
         Arc::new(Mutex::new(writer));
     handle_client_generic(reader, writer, ctx).await
+}
+
+/// 接続中の Named Pipe に対し、caller プロセスの SID が現在の daemon プロセスの
+/// owner SID と一致するか確認する。
+///
+/// 手順:
+///   1. `GetNamedPipeClientProcessId` で caller PID を取得
+///   2. `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` で caller プロセスをオープン
+///   3. `OpenProcessToken(TOKEN_QUERY)` でアクセス token を取得
+///   4. `GetTokenInformation(TokenUser)` で caller の SID を取得
+///   5. 自プロセスでも 2-4 を行い `EqualSid` で比較
+#[cfg(windows)]
+fn verify_windows_caller(
+    pipe: &tokio::net::windows::named_pipe::NamedPipeServer,
+) -> Result<(), String> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Security::EqualSid;
+    use windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId;
+
+    let pipe_handle = pipe.as_raw_handle() as HANDLE;
+    if pipe_handle.is_null() || pipe_handle == INVALID_HANDLE_VALUE {
+        return Err("invalid pipe handle".into());
+    }
+
+    let mut caller_pid: u32 = 0;
+    // SAFETY: pipe_handle は今回のスコープで生きている valid な handle。
+    let ok = unsafe { GetNamedPipeClientProcessId(pipe_handle, &mut caller_pid) };
+    if ok == 0 {
+        return Err(format!(
+            "GetNamedPipeClientProcessId failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    let caller_sid = read_process_sid(caller_pid).map_err(|e| format!("caller sid: {e}"))?;
+    let self_sid = read_self_sid().map_err(|e| format!("self sid: {e}"))?;
+
+    // SAFETY: 双方の TOKEN_USER バッファは valid。
+    let equal = unsafe { EqualSid(caller_sid.token_user.User.Sid, self_sid.token_user.User.Sid) };
+
+    if equal == 0 {
+        return Err(format!("caller SID mismatch (pid {caller_pid})"));
+    }
+    Ok(())
+}
+
+/// TOKEN_USER のバッキングストアを保持する RAII。`token_user.User.Sid` は
+/// `_backing` の中を指している。
+#[cfg(windows)]
+struct TokenUserBuf {
+    token_user: windows_sys::Win32::Security::TOKEN_USER,
+    _backing: Vec<u8>,
+}
+
+#[cfg(windows)]
+fn read_process_sid(pid: u32) -> std::io::Result<TokenUserBuf> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    // SAFETY: PID は信頼できる入力 (Named Pipe 経由で取得済) として扱う。
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return Err(std::io::Error::last_os_error());
+    }
+    let res = read_token_user(process);
+    // SAFETY: process はこのスコープで取得した valid handle。
+    unsafe { CloseHandle(process) };
+    res
+}
+
+#[cfg(windows)]
+fn read_self_sid() -> std::io::Result<TokenUserBuf> {
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+    // SAFETY: GetCurrentProcess は擬似ハンドルで close 不要。
+    let h = unsafe { GetCurrentProcess() };
+    read_token_user(h)
+}
+
+/// `OpenProcessToken` + `GetTokenInformation(TokenUser)` の rust ラッパ。
+#[cfg(windows)]
+fn read_token_user(
+    process_handle: windows_sys::Win32::Foundation::HANDLE,
+) -> std::io::Result<TokenUserBuf> {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
+    use windows_sys::Win32::System::Threading::OpenProcessToken;
+
+    let mut token_handle: HANDLE = std::ptr::null_mut();
+    // SAFETY: process_handle は呼び出し側保証で valid。
+    if unsafe { OpenProcessToken(process_handle, TOKEN_QUERY, &mut token_handle) } == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // 1 回目: 必要サイズを取得
+    let mut required: u32 = 0;
+    // SAFETY: 1st call は intentional に NULL/0 を渡してサイズだけ取る。
+    unsafe {
+        GetTokenInformation(
+            token_handle,
+            TokenUser,
+            std::ptr::null_mut(),
+            0,
+            &mut required,
+        );
+    }
+    if required == 0 {
+        let err = std::io::Error::last_os_error();
+        unsafe { CloseHandle(token_handle) };
+        return Err(err);
+    }
+
+    let mut buf = vec![0u8; required as usize];
+    // SAFETY: buf は required 以上のサイズを持つ。
+    let res = unsafe {
+        GetTokenInformation(
+            token_handle,
+            TokenUser,
+            buf.as_mut_ptr() as *mut _,
+            required,
+            &mut required,
+        )
+    };
+    unsafe { CloseHandle(token_handle) };
+    if res == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // SAFETY: buf 先頭は TOKEN_USER 構造体として WinAPI が書き込んだもの。
+    let token_user = unsafe { *(buf.as_ptr() as *const TOKEN_USER) };
+    Ok(TokenUserBuf {
+        token_user,
+        _backing: buf,
+    })
 }
 
 /// クライアント接続のハンドリング

--- a/synergos-core/src/main.rs
+++ b/synergos-core/src/main.rs
@@ -3,6 +3,14 @@
 //! クロスプラットフォーム対応のバックグラウンドデーモン。
 //! EventBus + IPC サーバーを提供し、GUI / CLI / Ars Plugin からの
 //! コマンドを受け付ける。
+//!
+//! ## ロギング書式
+//!
+//! `SYNERGOS_LOG_FORMAT` 環境変数で出力形式を切り替える:
+//! - 未指定 / `"text"` / `"pretty"` → 既定のヒューマンリーダブル fmt (開発時)
+//! - `"json"` → 1 行 1 イベントの JSON 構造化ログ (production / log 集約用)
+//!
+//! ログレベルは従来通り `RUST_LOG` で制御 (例: `RUST_LOG=synergos_core=debug`)。
 
 use clap::Parser;
 use synergos_core::cli::{self, Cli};
@@ -10,14 +18,32 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // ロギング初期化
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("synergos_core=info")),
-        )
-        .init();
+    init_logging();
 
     let cli = Cli::parse();
     cli::run(cli).await
+}
+
+fn init_logging() {
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("synergos_core=info"));
+
+    let format = std::env::var("SYNERGOS_LOG_FORMAT")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    match format.as_str() {
+        "json" => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_current_span(true)
+                .with_span_list(false)
+                .with_env_filter(env_filter)
+                .init();
+        }
+        // 既定値 (空文字 / "text" / "pretty" / その他) はヒューマンリーダブル
+        _ => {
+            tracing_subscriber::fmt().with_env_filter(env_filter).init();
+        }
+    }
 }

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -116,9 +116,11 @@ impl IpcCommand {
     /// - 識別子の空文字 (project_id / peer_id / file_id 等)
     /// - 過大な長さ (DoS 防止: 1 KiB を超える文字列はカット)
     /// - PublishUpdate.file_paths は空でないこと、上限 1024 件
+    /// - パスに `..` 等のディレクトリ脱出 component が含まれないこと (CWE-22)
     pub fn validate(&self) -> Result<(), String> {
         const MAX_ID_LEN: usize = 1024;
         const MAX_PATHS_PER_PUBLISH: usize = 1024;
+        const MAX_PATH_LEN: usize = 4096;
 
         let check_id = |label: &str, s: &str| -> Result<(), String> {
             if s.trim().is_empty() {
@@ -130,6 +132,32 @@ impl IpcCommand {
             }
         };
 
+        // PathBuf の component をスキャンし、`..` (ParentDir) を拒否する。
+        // 絶対パス (root_path 等) はそのまま許容、相対パス (publish file_paths) も
+        // OK だが、いずれにせよ親階層への脱出は許さない。
+        let check_path = |label: &str, path: &PathBuf| -> Result<(), String> {
+            if path.as_os_str().is_empty() {
+                return Err(format!("{label} must not be empty"));
+            }
+            let s = path.to_string_lossy();
+            if s.len() > MAX_PATH_LEN {
+                return Err(format!("{label} too long ({} > {MAX_PATH_LEN})", s.len()));
+            }
+            for component in path.components() {
+                if matches!(component, std::path::Component::ParentDir) {
+                    return Err(format!(
+                        "{label} must not contain '..' component: {}",
+                        path.display()
+                    ));
+                }
+            }
+            // 文字列上での `..` 単独 component / `\0` 含みも弾く (Windows / Unix 両方)
+            if s.contains('\0') {
+                return Err(format!("{label} must not contain NUL byte"));
+            }
+            Ok(())
+        };
+
         match self {
             Self::Ping
             | Self::Shutdown
@@ -137,14 +165,28 @@ impl IpcCommand {
             | Self::NetworkStatus
             | Self::ProjectList => Ok(()),
 
-            Self::ProjectOpen { project_id, .. }
-            | Self::ProjectClose { project_id }
+            Self::ProjectOpen {
+                project_id,
+                root_path,
+                ..
+            } => {
+                check_id("project_id", project_id)?;
+                check_path("root_path", root_path)
+            }
+            Self::ProjectClose { project_id }
             | Self::ProjectGet { project_id }
             | Self::ProjectCreateInvite { project_id, .. }
             | Self::PeerList { project_id }
             | Self::ProjectUpdate { project_id, .. } => check_id("project_id", project_id),
 
-            Self::ProjectJoin { invite_token, .. } => check_id("invite_token", invite_token),
+            Self::ProjectJoin {
+                invite_token,
+                root_path,
+                ..
+            } => {
+                check_id("invite_token", invite_token)?;
+                check_path("root_path", root_path)
+            }
 
             Self::PeerConnect {
                 project_id,
@@ -185,6 +227,9 @@ impl IpcCommand {
                         "too many file_paths ({} > {MAX_PATHS_PER_PUBLISH})",
                         file_paths.len()
                     ));
+                }
+                for p in file_paths {
+                    check_path("file_paths[*]", p)?;
                 }
                 Ok(())
             }

--- a/synergos-net/Cargo.toml
+++ b/synergos-net/Cargo.toml
@@ -29,6 +29,10 @@ rand = "0.8"
 hex = "0.4"
 x509-parser = "0.16"
 
+# Identity at-rest encryption (passphrase 経由で AES-256-GCM + Argon2id)
+aes-gcm = "0.10"
+argon2 = "0.5"
+
 # DNS
 hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls"] }
 

--- a/synergos-net/src/identity.rs
+++ b/synergos-net/src/identity.rs
@@ -1,25 +1,49 @@
 //! ノード固有の暗号鍵と PeerId の束
 //!
 //! Synergos のピアは起動時に ed25519 キーペアを 1 つ持つ:
-//!   - 秘密鍵は `identity.key` に保存 (0600 パーミッション)
+//!   - 秘密鍵は `identity.key` に保存 (Unix では 0600 パーミッション)
 //!   - 公開鍵は BLAKE3 でハッシュして PeerId を導出する
 //!
-//! これにより以下のセキュリティ課題をまとめて改善する:
-//!   - S1 QUIC 自己署名 + no_client_auth  → 公開鍵を TLS cert に埋め、
-//!     peer 側でハッシュを `PeerId` と照合して MITM / なりすましを防ぐ
-//!   - S2 PeerId が裸文字列で鍵と未結合 → PeerId = BLAKE3(pubkey)[:20] (hex)
-//!   - S3 Gossip 無署名          → 送信者鍵で署名 + 受信側で検証
-//!   - S4 ChainBlock 無署名      → author 鍵で署名 + 受信側で検証
+//! ## 保存形式 (v0.1.x)
+//!
+//! ファイルは以下 2 形式のいずれか。先頭の magic で自動判別する。
+//!
+//! 1. **plaintext**: 32 byte 生バイト列 (互換性のため引き続きサポート)
+//! 2. **encrypted (V1)**: `b"SYNERGOS-ID-V1\0"` (15 byte magic) + salt(16) +
+//!    nonce(12) + ciphertext(32) + AES-GCM tag(16) = 91 byte
+//!
+//! 暗号化は **環境変数 `SYNERGOS_IDENTITY_PASSPHRASE` が設定されているときだけ**
+//! 有効になる (opt-in、既存ノードを壊さないため)。passphrase から Argon2id で
+//! 32 byte の鍵を導出して AES-256-GCM で暗号化する。
+//!
+//! 設計上の制約:
+//!   - passphrase は memory に常駐するが秘匿対象は disk のみなので許容
+//!   - Argon2id 計算は ~100 ms 程度で起動時に 1 回だけ走る
+//!   - passphrase が変わると当然復号できないので、運用側でローテーション必要時は
+//!     旧 passphrase で復号 → 新 passphrase で保存し直す
 
 use std::path::{Path, PathBuf};
 
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use argon2::Argon2;
 use ed25519_dalek::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey, SECRET_KEY_LENGTH};
+use rand::RngCore;
 
 use crate::types::PeerId;
 
 /// 公開鍵から導出する PeerId の byte 長 (BLAKE3 を 20 byte に切り詰め)
 pub const PEER_ID_PREFIX_LEN: usize = 20;
+
+/// passphrase 受け渡し用の環境変数名
+pub const PASSPHRASE_ENV: &str = "SYNERGOS_IDENTITY_PASSPHRASE";
+
+/// 暗号化フォーマット V1 の magic
+const ENC_MAGIC_V1: &[u8] = b"SYNERGOS-ID-V1\0";
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
 
 /// 暗号鍵の操作に関するエラー
 #[derive(Debug, thiserror::Error)]
@@ -32,6 +56,15 @@ pub enum IdentityError {
 
     #[error("signature verification failed")]
     VerifyFailed,
+
+    #[error("identity is encrypted but {} is not set", PASSPHRASE_ENV)]
+    PassphraseRequired,
+
+    #[error("identity decryption failed: {reason}")]
+    DecryptFailed { reason: String },
+
+    #[error("identity encryption failed: {reason}")]
+    EncryptFailed { reason: String },
 }
 
 /// ノード自身の暗号アイデンティティ。署名鍵 + 公開鍵 + 派生 PeerId をまとめ持つ。
@@ -44,6 +77,9 @@ pub struct Identity {
 impl Identity {
     /// 指定パスに `identity.key` があれば読み込み、無ければ生成して保存する。
     /// 親ディレクトリが存在しない場合は作成する。Unix では `0600` に chmod する。
+    ///
+    /// 環境変数 `SYNERGOS_IDENTITY_PASSPHRASE` が設定されていれば暗号化形式で保存し、
+    /// 既存ファイルが暗号化形式なら同じ passphrase で復号する。
     pub fn load_or_generate(path: &Path) -> Result<Self, IdentityError> {
         if path.exists() {
             Self::load_from_file(path)
@@ -70,19 +106,10 @@ impl Identity {
         }
     }
 
-    /// 秘密鍵 32 bytes をファイルから読み出す。
+    /// 秘密鍵をファイルから読み出す。plaintext / encrypted を自動判別する。
     pub fn load_from_file(path: &Path) -> Result<Self, IdentityError> {
         let bytes = std::fs::read(path)?;
-        if bytes.len() != SECRET_KEY_LENGTH {
-            return Err(IdentityError::InvalidKeyFile {
-                reason: format!(
-                    "expected {SECRET_KEY_LENGTH}-byte secret key, got {} bytes",
-                    bytes.len()
-                ),
-            });
-        }
-        let mut secret = [0u8; SECRET_KEY_LENGTH];
-        secret.copy_from_slice(&bytes);
+        let secret = decode_key_bytes(&bytes)?;
         let signing = SigningKey::from_bytes(&secret);
         let verifying = signing.verifying_key();
         let peer_id = peer_id_from_verifying(&verifying);
@@ -93,9 +120,15 @@ impl Identity {
         })
     }
 
-    /// 秘密鍵 32 bytes をファイルに保存する。Unix では `0600` に chmod。
+    /// 秘密鍵をファイルに保存する。`SYNERGOS_IDENTITY_PASSPHRASE` が設定されていれば
+    /// 暗号化、それ以外は plaintext。Unix では `0600` に chmod。
     pub fn save_to_file(&self, path: &Path) -> Result<(), IdentityError> {
-        std::fs::write(path, self.signing.to_bytes())?;
+        let secret = self.signing.to_bytes();
+        let payload = match passphrase_from_env() {
+            Some(pw) => encode_encrypted(&secret, pw.as_bytes())?,
+            None => secret.to_vec(),
+        };
+        std::fs::write(path, payload)?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -186,6 +219,115 @@ impl Identity {
     }
 }
 
+fn passphrase_from_env() -> Option<String> {
+    std::env::var(PASSPHRASE_ENV).ok().filter(|s| !s.is_empty())
+}
+
+/// ファイル先頭バイトを見て plaintext / encrypted を判別し、生 secret 32 byte を返す。
+fn decode_key_bytes(bytes: &[u8]) -> Result<[u8; SECRET_KEY_LENGTH], IdentityError> {
+    if bytes.starts_with(ENC_MAGIC_V1) {
+        let pw = passphrase_from_env().ok_or(IdentityError::PassphraseRequired)?;
+        return decode_encrypted(bytes, pw.as_bytes());
+    }
+    if bytes.len() != SECRET_KEY_LENGTH {
+        return Err(IdentityError::InvalidKeyFile {
+            reason: format!(
+                "expected {SECRET_KEY_LENGTH}-byte secret key (or encrypted V1 file), got {} bytes",
+                bytes.len()
+            ),
+        });
+    }
+    let mut secret = [0u8; SECRET_KEY_LENGTH];
+    secret.copy_from_slice(bytes);
+    Ok(secret)
+}
+
+fn encode_encrypted(
+    secret: &[u8; SECRET_KEY_LENGTH],
+    passphrase: &[u8],
+) -> Result<Vec<u8>, IdentityError> {
+    let mut salt = [0u8; SALT_LEN];
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut salt);
+    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+
+    let key = derive_key(passphrase, &salt)?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let mut ciphertext_with_tag =
+        cipher
+            .encrypt(nonce, secret.as_slice())
+            .map_err(|e| IdentityError::EncryptFailed {
+                reason: e.to_string(),
+            })?;
+    if ciphertext_with_tag.len() != SECRET_KEY_LENGTH + TAG_LEN {
+        return Err(IdentityError::EncryptFailed {
+            reason: format!("unexpected ciphertext length {}", ciphertext_with_tag.len()),
+        });
+    }
+
+    let mut out =
+        Vec::with_capacity(ENC_MAGIC_V1.len() + SALT_LEN + NONCE_LEN + SECRET_KEY_LENGTH + TAG_LEN);
+    out.extend_from_slice(ENC_MAGIC_V1);
+    out.extend_from_slice(&salt);
+    out.extend_from_slice(&nonce_bytes);
+    out.append(&mut ciphertext_with_tag);
+    Ok(out)
+}
+
+fn decode_encrypted(
+    bytes: &[u8],
+    passphrase: &[u8],
+) -> Result<[u8; SECRET_KEY_LENGTH], IdentityError> {
+    let expected_len = ENC_MAGIC_V1.len() + SALT_LEN + NONCE_LEN + SECRET_KEY_LENGTH + TAG_LEN;
+    if bytes.len() != expected_len {
+        return Err(IdentityError::InvalidKeyFile {
+            reason: format!(
+                "encrypted V1 length should be {expected_len}, got {}",
+                bytes.len()
+            ),
+        });
+    }
+    let mut cursor = ENC_MAGIC_V1.len();
+    let salt = &bytes[cursor..cursor + SALT_LEN];
+    cursor += SALT_LEN;
+    let nonce_bytes = &bytes[cursor..cursor + NONCE_LEN];
+    cursor += NONCE_LEN;
+    let ciphertext_with_tag = &bytes[cursor..];
+
+    let key = derive_key(passphrase, salt)?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let plaintext =
+        cipher
+            .decrypt(nonce, ciphertext_with_tag)
+            .map_err(|e| IdentityError::DecryptFailed {
+                reason: e.to_string(),
+            })?;
+    if plaintext.len() != SECRET_KEY_LENGTH {
+        return Err(IdentityError::DecryptFailed {
+            reason: format!(
+                "decrypted length {} != {SECRET_KEY_LENGTH}",
+                plaintext.len()
+            ),
+        });
+    }
+    let mut secret = [0u8; SECRET_KEY_LENGTH];
+    secret.copy_from_slice(&plaintext);
+    Ok(secret)
+}
+
+fn derive_key(passphrase: &[u8], salt: &[u8]) -> Result<[u8; 32], IdentityError> {
+    let argon = Argon2::default();
+    let mut out = [0u8; 32];
+    argon
+        .hash_password_into(passphrase, salt, &mut out)
+        .map_err(|e| IdentityError::EncryptFailed {
+            reason: format!("argon2: {e}"),
+        })?;
+    Ok(out)
+}
+
 /// 公開鍵から PeerId を導出する (BLAKE3(pubkey) の先頭 20 bytes を hex 化)。
 ///
 /// PeerId をこの関数で導出した peer はネットワーク上で「鍵所有を示せる」
@@ -216,6 +358,12 @@ pub fn verify(
 mod tests {
     use super::*;
 
+    fn unset_passphrase_for_test() {
+        // 環境変数を一時的に外す。serial_test 等は使わず、各テストで明示的に
+        // set/unset することで干渉を避ける。
+        std::env::remove_var(PASSPHRASE_ENV);
+    }
+
     #[test]
     fn sign_and_verify_roundtrip() {
         let id = Identity::generate();
@@ -233,6 +381,7 @@ mod tests {
 
     #[test]
     fn load_or_generate_persists_same_peer_id() {
+        unset_passphrase_for_test();
         let tmp = std::env::temp_dir().join(format!("synergos-id-{}.key", uuid::Uuid::new_v4()));
         let a = Identity::load_or_generate(&tmp).unwrap();
         let pid_a = a.peer_id().clone();
@@ -247,5 +396,59 @@ mod tests {
         let id = Identity::generate();
         let pid = peer_id_from_public_bytes(&id.public_key_bytes());
         assert_eq!(&pid, id.peer_id());
+    }
+
+    #[test]
+    fn encrypted_roundtrip_with_passphrase() {
+        let secret = [7u8; SECRET_KEY_LENGTH];
+        let blob = encode_encrypted(&secret, b"correct horse battery staple").unwrap();
+        // magic prefix を確認
+        assert!(blob.starts_with(ENC_MAGIC_V1));
+        // 復号
+        let recovered = decode_encrypted(&blob, b"correct horse battery staple").unwrap();
+        assert_eq!(recovered, secret);
+    }
+
+    #[test]
+    fn wrong_passphrase_rejected() {
+        let secret = [3u8; SECRET_KEY_LENGTH];
+        let blob = encode_encrypted(&secret, b"good").unwrap();
+        let err = decode_encrypted(&blob, b"bad").unwrap_err();
+        assert!(matches!(err, IdentityError::DecryptFailed { .. }));
+    }
+
+    #[test]
+    fn plaintext_file_still_loadable_when_no_passphrase() {
+        unset_passphrase_for_test();
+        let tmp = std::env::temp_dir().join(format!("synergos-id-pt-{}.key", uuid::Uuid::new_v4()));
+        // 32 byte plaintext を直接書く (旧フォーマット相当)
+        std::fs::write(&tmp, [9u8; SECRET_KEY_LENGTH]).unwrap();
+        let id = Identity::load_from_file(&tmp).unwrap();
+        // peer_id が deterministic に算出されている (空でないこと)
+        assert!(!id.peer_id().0.is_empty());
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn encrypted_file_requires_passphrase_to_load() {
+        let tmp =
+            std::env::temp_dir().join(format!("synergos-id-enc-{}.key", uuid::Uuid::new_v4()));
+        let blob = encode_encrypted(&[1u8; SECRET_KEY_LENGTH], b"hunter2").unwrap();
+        std::fs::write(&tmp, blob).unwrap();
+
+        // 環境変数なし → エラー (Result の Err 側を pattern match で確認、Debug 要求を回避)
+        unset_passphrase_for_test();
+        match Identity::load_from_file(&tmp) {
+            Err(IdentityError::PassphraseRequired) => {}
+            Err(other) => panic!("expected PassphraseRequired, got {other:?}"),
+            Ok(_) => panic!("expected Err but got Ok"),
+        }
+
+        // 環境変数あり → ロード成功
+        std::env::set_var(PASSPHRASE_ENV, "hunter2");
+        let id = Identity::load_from_file(&tmp).unwrap();
+        assert!(!id.peer_id().0.is_empty());
+        std::env::remove_var(PASSPHRASE_ENV);
+        let _ = std::fs::remove_file(&tmp);
     }
 }


### PR DESCRIPTION
## Summary

明日 (2026-04-29) の 4 PC 運用テストに向けて Critical / High セキュリティ Issue を集約対応。

| Issue | 内容 | 修正 |
|---|---|---|
| #33 (Critical) | Identity private key 平文保存 | \`SYNERGOS_IDENTITY_PASSPHRASE\` で AES-256-GCM + Argon2id (opt-in) |
| #32 (Critical) | Windows IPC ACL なし (CWE-269) | 接続時 caller SID を daemon owner SID と比較、不一致なら切断 |
| #35 (High) | Path traversal (CWE-22) | IpcCommand::validate() で \`..\` / NUL / 4KiB 超 を拒否 |
| #36 (High) | 構造化ログ未導入 | \`SYNERGOS_LOG_FORMAT=json\` で JSON 1 行 1 イベント出力 |

## 取り扱わない件 (Issue 継続)

- **#34 TURN 実装**: 数週間規模。OPERATIONAL-TEST.md は LAN + synergos-relay 経路をカバーしており、明日のテストには非ブロッカー
- **#37 GUI pixel snapshot test**: daemon-level 運用テストには非ブロッカー

## 設計詳細

### #33 暗号化フォーマット V1

\`\`\`
b\"SYNERGOS-ID-V1\0\" (15B magic) + salt(16) + nonce(12) + ciphertext(32) + tag(16) = 91 byte
\`\`\`

- 環境変数未設定なら plaintext (互換性のため opt-in)
- 先頭 magic で plaintext / 暗号化を自動判別 (旧フォーマットの 32 byte 生鍵もそのまま読める)
- 暗号化ファイルを passphrase なしで開こうとすると \`PassphraseRequired\` エラー

### #32 caller SID 検証

\`GetNamedPipeClientProcessId\` → \`OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)\` →
\`OpenProcessToken(TOKEN_QUERY)\` → \`GetTokenInformation(TokenUser)\` で caller SID 取得、
\`GetCurrentProcess\` で自プロセスの SID 取得、\`EqualSid\` で比較。
\`windows-sys\` 0.59 を windows target のみで追加。

### #35 拒否するパス

- \`Component::ParentDir\` (\`..\`) 含み
- \`PathBuf\` 文字列長が 4096 超
- NUL byte 含み

対象: \`ProjectOpen.root_path\`, \`ProjectJoin.root_path\`, \`PublishUpdate.file_paths[*]\`

### #36 ログ書式切替

\`\`\`bash
# JSON で出す (production / log 集約用)
SYNERGOS_LOG_FORMAT=json synergos-core start

# 既定 (text、開発用)
synergos-core start
\`\`\`

\`RUST_LOG=synergos_core=debug\` のレベル指定は両形式で従来通り効く。

## ビルド検証

- \`cargo check --workspace\` ✓
- \`cargo test --workspace\` ✓ **175 tests / 0 failures** (元 171 + identity 新規 4)
  - encrypted_roundtrip_with_passphrase
  - wrong_passphrase_rejected
  - plaintext_file_still_loadable_when_no_passphrase
  - encrypted_file_requires_passphrase_to_load

## Test plan (明日の運用テスト前)

- [ ] 各 PC で \`cargo build --release\` が通る
- [ ] \`SYNERGOS_LOG_FORMAT=json\` 起動で JSON ログが流れる
- [ ] passphrase 設定 → identity 生成 → 再起動 → 同じ peer_id で復元
- [ ] passphrase 未設定の plaintext identity がそのまま起動する (互換性)
- [ ] Windows でテスト用に別ユーザーから接続 → \`caller SID mismatch\` で reject (#32 検証)
- [ ] 不正パス \`{ "type": "PublishUpdate", "file_paths": ["../etc/passwd"] }\` を IPC 経由で送る → validate エラー (#35 検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)