### PR TITLE
feat(net): force_relay_only + auto_promote — relay-only 強制 / NAT 越え自動診断

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,9 +2403,17 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
+ "async-trait",
  "attohttpc",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "log",
  "rand 0.9.2",
+ "tokio",
  "url",
  "xmltree",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "epaint"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2385,29 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "attohttpc",
+ "log",
+ "rand 0.9.2",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -4683,6 +4724,8 @@ dependencies = [
  "futures-util",
  "hex",
  "hickory-resolver",
+ "if-addrs",
+ "igd-next",
  "pretty_assertions",
  "prost",
  "prost-build",
@@ -4701,6 +4744,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
+ "which",
  "x509-parser",
 ]
 
@@ -5781,6 +5825,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6218,6 +6274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6400,6 +6462,15 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
 
 [[package]]
 name = "yansi"

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -96,11 +96,12 @@ impl Daemon {
         tracing::info!("QUIC listening on {}", actual_addr);
         let tunnel = Arc::new(TunnelManager::new(&net_config.tunnel));
         let mesh = Arc::new(Mesh::new(net_config.mesh.clone()));
-        let conduit = Arc::new(Conduit::new(
+        let conduit = Arc::new(Conduit::with_relay_only(
             quic.clone(),
             tunnel.clone(),
             mesh.clone(),
             Duration::from_secs(15),
+            net_config.force_relay_only,
         ));
 
         let net = Arc::new(NetworkHandles {

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -18,6 +18,7 @@ use synergos_net::{
     },
     identity::Identity,
     mesh::Mesh,
+    promotion::{NetCapabilities, PromotionMode},
     quic::{QuicManager, StreamType},
     transfer::TRANSFER_STREAM_MAGIC,
     tunnel::TunnelManager,
@@ -96,12 +97,42 @@ impl Daemon {
         tracing::info!("QUIC listening on {}", actual_addr);
         let tunnel = Arc::new(TunnelManager::new(&net_config.tunnel));
         let mesh = Arc::new(Mesh::new(net_config.mesh.clone()));
+
+        // 起動時 NAT 越え probe → effective relay-only を決定する。
+        //   - force_relay_only=true なら問答無用で relay-only
+        //   - auto_promote=true (既定) かつ probe で direct/tunnel いずれも不可
+        //     なら relay-only として起動 (= 「ノード昇格できない」状態を自己診断)
+        //   - それ以外は通常モード (Direct→Tunnel→Relay の優先試行)
+        let effective_relay_only = if net_config.force_relay_only {
+            tracing::info!("force_relay_only=true → relay-only mode (probe skipped)");
+            true
+        } else if net_config.auto_promote {
+            let caps = NetCapabilities::detect(
+                Duration::from_secs(3),
+                !net_config.tunnel.api_token_ref.is_empty(),
+                false, // relay endpoint 設定有無 (現状は判定不能、後続 PR で正確化)
+            )
+            .await;
+            tracing::info!("net capabilities: {}", caps.summary());
+            match caps.recommended_mode() {
+                PromotionMode::FullNode => false,
+                PromotionMode::RelayOnly => {
+                    tracing::warn!(
+                        "auto_promote: no direct/tunnel reachable → starting in relay-only mode"
+                    );
+                    true
+                }
+            }
+        } else {
+            false
+        };
+
         let conduit = Arc::new(Conduit::with_relay_only(
             quic.clone(),
             tunnel.clone(),
             mesh.clone(),
             Duration::from_secs(15),
-            net_config.force_relay_only,
+            effective_relay_only,
         ));
 
         let net = Arc::new(NetworkHandles {
@@ -169,10 +200,11 @@ impl Daemon {
         let shared_content_store = Arc::new(synergos_net::content::MemoryContentStore::new());
         exchange_inner.attach_content_store(shared_content_store.clone());
         let exchange = Arc::new(exchange_inner);
-        let presence = Arc::new(PresenceService::with_network(
+        let presence = Arc::new(PresenceService::with_network_and_mode(
             event_bus.clone(),
             Some(dht.clone()),
             Some(gossip.clone()),
+            effective_relay_only,
         ));
         let conflict_manager = Arc::new(ConflictManager::new(event_bus.clone()));
         let (shutdown_tx, _) = broadcast::channel(1);

--- a/synergos-core/src/presence/mod.rs
+++ b/synergos-core/src/presence/mod.rs
@@ -117,6 +117,8 @@ pub struct PresenceService {
     dht: Option<Arc<DhtNode>>,
     /// Gossipsub ノード（オプション）
     gossip: Option<Arc<GossipNode>>,
+    /// relay-only モードフラグ。true なら自ノードの Direct route を広告から外す。
+    is_relay_only: bool,
 }
 
 impl PresenceService {
@@ -125,11 +127,25 @@ impl PresenceService {
         Self::with_network(event_bus, None, None)
     }
 
-    /// ネットワーク依存を注入して構築する本番向けコンストラクタ
+    /// ネットワーク依存を注入して構築する本番向けコンストラクタ。
+    /// `is_relay_only` フラグはここでは false 固定。relay-only モードを
+    /// 有効化するには `with_network_and_mode` を使う。
     pub fn with_network(
         event_bus: SharedEventBus,
         dht: Option<Arc<DhtNode>>,
         gossip: Option<Arc<GossipNode>>,
+    ) -> Self {
+        Self::with_network_and_mode(event_bus, dht, gossip, false)
+    }
+
+    /// `is_relay_only=true` で構築すると、自ノードの route 通知から
+    /// `Route::Direct` を **必ず除外** する (匿名性: 自宅 IP を peer に
+    /// 通知しないため)。Tunnel/Relay 経路はそのまま広告する。
+    pub fn with_network_and_mode(
+        event_bus: SharedEventBus,
+        dht: Option<Arc<DhtNode>>,
+        gossip: Option<Arc<GossipNode>>,
+        is_relay_only: bool,
     ) -> Self {
         Self {
             event_bus,
@@ -137,7 +153,25 @@ impl PresenceService {
             local_node: tokio::sync::RwLock::new(None),
             dht,
             gossip,
+            is_relay_only,
         }
+    }
+
+    /// relay-only モードかどうかを参照する (status 表示用)。
+    pub fn is_relay_only(&self) -> bool {
+        self.is_relay_only
+    }
+
+    /// 自ノードが他ピアに広告すべき route だけを残す。relay-only なら
+    /// `Route::Direct` を完全に除外し、Tunnel / Relay のみ通す。
+    fn sanitize_local_routes(&self, routes: Vec<Route>) -> Vec<Route> {
+        if !self.is_relay_only {
+            return routes;
+        }
+        routes
+            .into_iter()
+            .filter(|r| !matches!(r, Route::Direct { .. }))
+            .collect()
     }
 
     /// Gossipsub 経由でピアステータスをブロードキャスト
@@ -245,18 +279,35 @@ impl PresenceService {
 
 #[async_trait]
 impl NodeRegistry for PresenceService {
-    async fn register_self(&self, registration: NodeRegistration) -> Result<(), NodeRegistryError> {
+    async fn register_self(
+        &self,
+        mut registration: NodeRegistration,
+    ) -> Result<(), NodeRegistryError> {
+        // 匿名性: relay-only モードでは Direct route を **必ず外して** 広告する。
+        // 呼出側が誤って Direct を埋めても DHT / gossip / 内部テーブルに直接の
+        // 自宅 IP が漏れない。
+        let original_count = registration.endpoints.len();
+        registration.endpoints = self.sanitize_local_routes(registration.endpoints);
+        let stripped = original_count - registration.endpoints.len();
+
         tracing::info!(
-            "Registering self as '{}' (peer_id={})",
+            "Registering self as '{}' (peer_id={}, relay_only={}, advertised_routes={}{})",
             registration.display_name,
-            registration.peer_id
+            registration.peer_id,
+            self.is_relay_only,
+            registration.endpoints.len(),
+            if stripped > 0 {
+                format!(", stripped Direct={}", stripped)
+            } else {
+                String::new()
+            },
         );
 
-        // ローカルノード情報を保存
+        // ローカルノード情報を保存 (フィルタ済み)
         let mut local = self.local_node.write().await;
         *local = Some(registration.clone());
 
-        // 自分自身も nodes テーブルに登録
+        // 自分自身も nodes テーブルに登録 (フィルタ済み endpoints)
         let node = RegisteredNode {
             peer_id: registration.peer_id.clone(),
             display_name: registration.display_name.clone(),
@@ -269,7 +320,7 @@ impl NodeRegistry for PresenceService {
         };
         self.nodes.insert(registration.peer_id.clone(), node);
 
-        // DHT に announce
+        // DHT に announce (フィルタ済み)
         self.dht_announce(&registration).await;
 
         // Gossipsub でステータスをブロードキャスト

--- a/synergos-net/Cargo.toml
+++ b/synergos-net/Cargo.toml
@@ -50,6 +50,11 @@ dashmap = "6"
 crc32fast = "1"
 thiserror = "2"
 rcgen = "0.13"
+which = "7"
+
+# NAT 越え probe (起動時に環境を自動診断)
+if-addrs = "0.13"
+igd-next = "0.16"
 
 [build-dependencies]
 prost-build = "0.13"

--- a/synergos-net/Cargo.toml
+++ b/synergos-net/Cargo.toml
@@ -54,7 +54,7 @@ which = "7"
 
 # NAT 越え probe (起動時に環境を自動診断)
 if-addrs = "0.13"
-igd-next = "0.16"
+igd-next = { version = "0.16", features = ["aio_tokio"] }
 
 [build-dependencies]
 prost-build = "0.13"

--- a/synergos-net/src/conduit/mod.rs
+++ b/synergos-net/src/conduit/mod.rs
@@ -49,6 +49,9 @@ struct ManagedPeer {
 ///
 /// 各ピアへの最適な接続経路を選択し、接続の確立・維持・切り替えを管理する。
 /// IPv6 Direct → Tunnel → Relay の優先度で接続を試行する。
+///
+/// `force_relay_only` を有効にすると、IPv6 Direct と Tunnel の試行を完全に
+/// スキップし、Relay 経路のみで接続する (案 B 「relay-only モード」)。
 pub struct Conduit {
     /// 管理中のピア（PeerId → ManagedPeer）
     peers: DashMap<PeerId, ManagedPeer>,
@@ -58,6 +61,8 @@ pub struct Conduit {
     tunnel: Arc<TunnelManager>,
     /// Mesh マネージャ (probe_ipv6 等で使う)
     mesh: Arc<Mesh>,
+    /// Relay 経由のみに制限するフラグ
+    force_relay_only: bool,
 }
 
 impl Conduit {
@@ -67,12 +72,30 @@ impl Conduit {
         mesh: Arc<Mesh>,
         _keepalive_interval: Duration,
     ) -> Self {
+        Self::with_relay_only(quic, tunnel, mesh, _keepalive_interval, false)
+    }
+
+    /// `force_relay_only` を明示する版。既存呼び出し互換のため `new` は残し、
+    /// 新規コードは relay 強制したいケースでこちらを使う。
+    pub fn with_relay_only(
+        quic: Arc<QuicManager>,
+        tunnel: Arc<TunnelManager>,
+        mesh: Arc<Mesh>,
+        _keepalive_interval: Duration,
+        force_relay_only: bool,
+    ) -> Self {
         Self {
             peers: DashMap::new(),
             quic,
             tunnel,
             mesh,
+            force_relay_only,
         }
+    }
+
+    /// Relay 強制モードかどうか。route 通知や監視のため外部から参照可。
+    pub fn is_relay_only(&self) -> bool {
+        self.force_relay_only
     }
 
     /// ピアを登録し、経路を検出する
@@ -280,6 +303,24 @@ impl Conduit {
 
     /// 経路を検出する
     async fn detect_route(&self, endpoint: &PeerEndpoint) -> DetectionResult {
+        // Relay-only モードならプローブを完全にスキップ。Direct/Tunnel の到達性は
+        // 「不到達」として扱い、recommended は Relay 固定にする。
+        if self.force_relay_only {
+            return DetectionResult {
+                ipv6: ProbeResult {
+                    reachable: false,
+                    rtt_ms: None,
+                    error: Some("force_relay_only enabled".into()),
+                    addr: None,
+                },
+                tunnel: TunnelProbeResult {
+                    available: false,
+                    rtt_ms: None,
+                },
+                recommended: RouteKind::Relay,
+            };
+        }
+
         // IPv6 と Tunnel のプローブを並列実行
         let ipv6_probe = self.probe_ipv6_route(endpoint);
         let tunnel_probe = self.probe_tunnel_route();
@@ -326,6 +367,23 @@ impl Conduit {
 
     /// 経路の優先度順に接続を試行
     async fn try_connect_routes(&self, peer_id: &PeerId, routes: &[Route]) -> Result<RouteKind> {
+        // Relay-only モードでは Direct / Tunnel をすっ飛ばして Relay のみ試す。
+        if self.force_relay_only {
+            for route in routes {
+                if let Route::Relay { server_url, .. } = route {
+                    tracing::debug!(
+                        "[relay-only] Attempting relay connection to {} via {}",
+                        peer_id.short(),
+                        server_url
+                    );
+                    return Ok(RouteKind::Relay);
+                }
+            }
+            return Err(SynergosNetError::Quic(
+                "force_relay_only enabled but no Route::Relay advertised by peer".into(),
+            ));
+        }
+
         // 1. IPv6 Direct を試行
         for route in routes {
             if let Route::Direct { addr, fqdn } = route {

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -39,6 +39,17 @@ pub struct NetConfig {
     /// 中継サーバ経由に強制したいときに有効化する。
     #[serde(default)]
     pub force_relay_only: bool,
+    /// **自動昇格モード**。既定 `true`。
+    /// 起動時に IPv6 / UPnP / Cloudflare Tunnel の到達性を probe し、
+    /// いずれも不可なら effective relay-only として動作する。`force_relay_only`
+    /// が true の場合は probe を実行せず常に relay-only。
+    /// 手動で「probe しない」運用にしたいときだけ false に。
+    #[serde(default = "default_true_auto_promote")]
+    pub auto_promote: bool,
+}
+
+fn default_true_auto_promote() -> bool {
+    true
 }
 
 /// CatalogManager のチューニングパラメータ。
@@ -281,6 +292,7 @@ impl Default for NetConfig {
             peer_info_listen_addr: None,
             bootstrap_urls: Vec::new(),
             force_relay_only: false,
+            auto_promote: true,
         }
     }
 }
@@ -351,6 +363,12 @@ mod tests {
     }
 
     #[test]
+    fn auto_promote_defaults_to_true() {
+        let cfg = NetConfig::default();
+        assert!(cfg.auto_promote);
+    }
+
+    #[test]
     fn force_relay_only_serde_roundtrip() {
         // 旧 config (force_relay_only フィールドが無い JSON) からも読めること。
         // 同様に PR-1〜4 で追加された listen_addr / peer_info_listen_addr /
@@ -368,6 +386,7 @@ mod tests {
         }"#;
         let cfg: NetConfig = serde_json::from_str(legacy).expect("legacy config should parse");
         assert!(!cfg.force_relay_only);
+        assert!(cfg.auto_promote, "legacy config should default auto_promote to true");
 
         // 明示的に true を指定した JSON も読める
         let with_flag = r#"{
@@ -382,7 +401,8 @@ mod tests {
             "monitor": {"snapshot_interval_ms": 1000, "history_size": 3600, "graph_sample_interval_secs": 1},
             "force_relay_only": true
         }"#;
-        let cfg: NetConfig = serde_json::from_str(with_flag).expect("config with flag should parse");
+        let cfg: NetConfig =
+            serde_json::from_str(with_flag).expect("config with flag should parse");
         assert!(cfg.force_relay_only);
     }
 }

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -386,7 +386,10 @@ mod tests {
         }"#;
         let cfg: NetConfig = serde_json::from_str(legacy).expect("legacy config should parse");
         assert!(!cfg.force_relay_only);
-        assert!(cfg.auto_promote, "legacy config should default auto_promote to true");
+        assert!(
+            cfg.auto_promote,
+            "legacy config should default auto_promote to true"
+        );
 
         // 明示的に true を指定した JSON も読める
         let with_flag = r#"{

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -30,6 +30,15 @@ pub struct NetConfig {
     /// 例: `["https://node1.example.com", "https://node2.example.com"]`
     #[serde(default)]
     pub bootstrap_urls: Vec<String>,
+    /// **Relay-only モード**。`true` のとき:
+    ///   - ピア接続時に IPv6 Direct / Tunnel を試さず、必ず WebSocket Relay
+    ///     (`synergos-relay`) を経由する。
+    ///   - 自ノードは direct 経路を route 通知に含めない (匿名化)。
+    ///
+    /// 自宅 PC が peer 一覧で見えないようにしたい / すべての通信を AWS 等の
+    /// 中継サーバ経由に強制したいときに有効化する。
+    #[serde(default)]
+    pub force_relay_only: bool,
 }
 
 /// CatalogManager のチューニングパラメータ。
@@ -271,6 +280,7 @@ impl Default for NetConfig {
             catalog: CatalogConfig::default(),
             peer_info_listen_addr: None,
             bootstrap_urls: Vec::new(),
+            force_relay_only: false,
         }
     }
 }
@@ -332,5 +342,47 @@ mod tests {
     fn peer_info_listen_addr_defaults_to_none() {
         let cfg = NetConfig::default();
         assert!(cfg.peer_info_listen_addr.is_none());
+    }
+
+    #[test]
+    fn force_relay_only_defaults_to_false() {
+        let cfg = NetConfig::default();
+        assert!(!cfg.force_relay_only);
+    }
+
+    #[test]
+    fn force_relay_only_serde_roundtrip() {
+        // 旧 config (force_relay_only フィールドが無い JSON) からも読めること。
+        // 同様に PR-1〜4 で追加された listen_addr / peer_info_listen_addr /
+        // bootstrap_urls も `#[serde(default)]` でこの legacy JSON から読めるはず。
+        let legacy = r#"{
+            "tunnel": {"api_token_ref": "", "hostname": ""},
+            "mesh": {"doh_endpoint": "", "dns_servers": [], "turn_servers": [], "stun_servers": [], "probe_timeout_ms": 3000},
+            "quic": {"max_concurrent_streams": 100, "idle_timeout_ms": 30000, "max_udp_payload_size": 1452, "enable_0rtt": false},
+            "dht": {"k_bucket_size": 20, "routing_refresh_secs": 60, "peer_ttl_secs": 120},
+            "gossipsub": {"mesh_n": 6, "mesh_n_low": 4, "mesh_n_high": 12, "heartbeat_interval_ms": 1000, "message_cache_size": 1000},
+            "stream_allocation": {"large_ratio": 60, "medium_ratio": 30, "small_ratio": 10},
+            "speed_test": {"enabled": true, "retest_interval_secs": 300, "probe_count": 10},
+            "peer_selection": {"bandwidth_weight": 0.7, "stability_weight": 0.3, "recalculate_interval_secs": 60},
+            "monitor": {"snapshot_interval_ms": 1000, "history_size": 3600, "graph_sample_interval_secs": 1}
+        }"#;
+        let cfg: NetConfig = serde_json::from_str(legacy).expect("legacy config should parse");
+        assert!(!cfg.force_relay_only);
+
+        // 明示的に true を指定した JSON も読める
+        let with_flag = r#"{
+            "tunnel": {"api_token_ref": "", "hostname": ""},
+            "mesh": {"doh_endpoint": "", "dns_servers": [], "turn_servers": [], "stun_servers": [], "probe_timeout_ms": 3000},
+            "quic": {"max_concurrent_streams": 100, "idle_timeout_ms": 30000, "max_udp_payload_size": 1452, "enable_0rtt": false},
+            "dht": {"k_bucket_size": 20, "routing_refresh_secs": 60, "peer_ttl_secs": 120},
+            "gossipsub": {"mesh_n": 6, "mesh_n_low": 4, "mesh_n_high": 12, "heartbeat_interval_ms": 1000, "message_cache_size": 1000},
+            "stream_allocation": {"large_ratio": 60, "medium_ratio": 30, "small_ratio": 10},
+            "speed_test": {"enabled": true, "retest_interval_secs": 300, "probe_count": 10},
+            "peer_selection": {"bandwidth_weight": 0.7, "stability_weight": 0.3, "recalculate_interval_secs": 60},
+            "monitor": {"snapshot_interval_ms": 1000, "history_size": 3600, "graph_sample_interval_secs": 1},
+            "force_relay_only": true
+        }"#;
+        let cfg: NetConfig = serde_json::from_str(with_flag).expect("config with flag should parse");
+        assert!(cfg.force_relay_only);
     }
 }

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod gossip;
 pub mod identity;
 pub mod mesh;
+pub mod promotion;
 pub mod quic;
 pub mod relay;
 pub mod transfer;
@@ -31,6 +32,7 @@ pub use identity::{
     peer_id_from_public_bytes, verify as verify_signature, Identity, IdentityError,
 };
 pub use mesh::Mesh;
+pub use promotion::{NetCapabilities, PromotionMode, UpnpInfo};
 pub use quic::{CalibratedParams, ConnectionCalibrator, QuicManager, SpeedTestResult};
 pub use tunnel::{TunnelManager, TunnelState};
 pub use types::*;

--- a/synergos-net/src/lib.rs
+++ b/synergos-net/src/lib.rs
@@ -88,11 +88,12 @@ impl SynergosNet {
         let quic = Arc::new(QuicManager::new(config.quic.clone(), identity));
         let tunnel = Arc::new(TunnelManager::new(&config.tunnel));
         let mesh = Arc::new(Mesh::new(config.mesh.clone()));
-        let conduit = Conduit::new(
+        let conduit = Conduit::with_relay_only(
             quic.clone(),
             tunnel.clone(),
             mesh.clone(),
             std::time::Duration::from_secs(15),
+            config.force_relay_only,
         );
 
         Self {

--- a/synergos-net/src/promotion.rs
+++ b/synergos-net/src/promotion.rs
@@ -64,8 +64,10 @@ impl NetCapabilities {
     ) -> Self {
         let ipv6_fut = tokio::time::timeout(per_probe_timeout, probe_ipv6_global());
         let upnp_fut = tokio::time::timeout(per_probe_timeout, probe_upnp());
-        let tunnel_fut =
-            tokio::time::timeout(per_probe_timeout, probe_cloudflared(tunnel_token_configured));
+        let tunnel_fut = tokio::time::timeout(
+            per_probe_timeout,
+            probe_cloudflared(tunnel_token_configured),
+        );
 
         let (ipv6_res, upnp_res, tunnel_res) = tokio::join!(ipv6_fut, upnp_fut, tunnel_fut);
 
@@ -183,7 +185,7 @@ async fn probe_upnp() -> Option<UpnpInfo> {
             return None;
         }
     };
-    let gateway_url = gateway.root_url();
+    let gateway_url = gateway.root_url.to_string();
     Some(UpnpInfo {
         external_ip: external_ip.to_string(),
         gateway_url,
@@ -217,9 +219,7 @@ mod tests {
         assert!(!is_global_ipv6(&"::1".parse::<Ipv6Addr>().unwrap()));
         assert!(!is_global_ipv6(&"fe80::1".parse::<Ipv6Addr>().unwrap()));
         assert!(!is_global_ipv6(&"fc00::1".parse::<Ipv6Addr>().unwrap()));
-        assert!(!is_global_ipv6(
-            &"2001:db8::1".parse::<Ipv6Addr>().unwrap()
-        ));
+        assert!(!is_global_ipv6(&"2001:db8::1".parse::<Ipv6Addr>().unwrap()));
         assert!(!is_global_ipv6(&"::".parse::<Ipv6Addr>().unwrap()));
     }
 
@@ -261,10 +261,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn detect_does_not_panic_on_offline() {
-        // ネットワーク不通でも detect が成立すること (timeout で抜ける)
-        let caps = NetCapabilities::detect(Duration::from_millis(200), false, false).await;
-        // false の組合せで relay_configured も false → RelayOnly
-        assert_eq!(caps.recommended_mode(), PromotionMode::RelayOnly);
+    async fn detect_does_not_panic_on_short_timeout() {
+        // 短い timeout でも detect が完走 (panic なし) すること。
+        // 結果のモードは実行環境依存 (IPv6 global がある PC なら FullNode、
+        // 無ければ RelayOnly)。ここでは「呼んでも落ちない」だけを保証する。
+        let caps = NetCapabilities::detect(Duration::from_millis(100), false, false).await;
+        let _ = caps.recommended_mode();
+        let _ = caps.summary();
     }
 }

--- a/synergos-net/src/promotion.rs
+++ b/synergos-net/src/promotion.rs
@@ -1,0 +1,270 @@
+//! NAT 越え能力の自動 probe + ノード昇格判定
+//!
+//! 起動時に **以下を並列に試して**、ノードが direct/tunnel 経路を持てるかを判定する:
+//!
+//! 1. **IPv6 グローバルアドレス**: `if-addrs` で OS のインターフェースを列挙、
+//!    link-local / loopback / unique-local を除外した global IPv6 が 1 つでも
+//!    あれば direct 可。
+//! 2. **UPnP / NAT-PMP**: `igd-next` で Internet Gateway Device に discover を
+//!    投げる。応答があれば家庭用ルータでポート開放可能 → direct 可。
+//! 3. **Cloudflare Tunnel**: `cloudflared` バイナリが PATH にあり、
+//!    NetConfig に api_token_ref が設定されていれば tunnel 経路あり。
+//! 4. **Relay**: NetConfig に relay endpoint が設定されているか。
+//!
+//! 結果に応じて **effective_relay_only** を決定する:
+//!   - `force_relay_only=true` → ユーザ強制、probe 結果問わず relay only
+//!   - `auto_promote=true` (既定) かつ direct/tunnel いずれも不可 → relay only
+//!   - direct or tunnel 可能 → full node モード
+//!
+//! probe 自体は best-effort。ネットワーク不通や timeout は「不可」扱い。
+
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, Ipv6Addr};
+use std::time::Duration;
+
+/// 環境調査の結果
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetCapabilities {
+    /// グローバル IPv6 アドレスを 1 つ以上保持しているか
+    pub has_ipv6_global: bool,
+    /// 検出した global IPv6 アドレス一覧 (デバッグ表示用)
+    pub ipv6_addresses: Vec<String>,
+    /// UPnP / NAT-PMP で port mapping できるか + 公開 IP
+    pub upnp: Option<UpnpInfo>,
+    /// `cloudflared` バイナリが PATH にあり tunnel 設定が揃っているか
+    pub tunnel_available: bool,
+    /// NetConfig に relay endpoint が設定されているか (relay は最終 fallback)
+    pub relay_configured: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpnpInfo {
+    pub external_ip: String,
+    pub gateway_url: String,
+}
+
+/// 推奨される運用モード。auto_promote の判定結果として返る。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PromotionMode {
+    /// IPv6 / UPnP / Tunnel いずれかで外部到達可能 → 通常ノード
+    FullNode,
+    /// 直接到達手段なし → relay 経由のみで稼働
+    RelayOnly,
+}
+
+impl NetCapabilities {
+    /// 各 probe をタイムアウト付きで並列に走らせる。
+    ///
+    /// `tunnel_token_configured`: Tunnel 設定 (`api_token_ref` が空でないか) を
+    /// 呼出側で判定して渡す。`relay_endpoint_configured`: 同様に relay 設定の有無。
+    pub async fn detect(
+        per_probe_timeout: Duration,
+        tunnel_token_configured: bool,
+        relay_endpoint_configured: bool,
+    ) -> Self {
+        let ipv6_fut = tokio::time::timeout(per_probe_timeout, probe_ipv6_global());
+        let upnp_fut = tokio::time::timeout(per_probe_timeout, probe_upnp());
+        let tunnel_fut =
+            tokio::time::timeout(per_probe_timeout, probe_cloudflared(tunnel_token_configured));
+
+        let (ipv6_res, upnp_res, tunnel_res) = tokio::join!(ipv6_fut, upnp_fut, tunnel_fut);
+
+        let ipv6 = ipv6_res.unwrap_or_else(|_| Vec::new());
+        let upnp = upnp_res.unwrap_or(None);
+        let tunnel_available = tunnel_res.unwrap_or(false);
+
+        Self {
+            has_ipv6_global: !ipv6.is_empty(),
+            ipv6_addresses: ipv6.iter().map(|a| a.to_string()).collect(),
+            upnp,
+            tunnel_available,
+            relay_configured: relay_endpoint_configured,
+        }
+    }
+
+    /// FullNode / RelayOnly のどちらが推奨かを返す。
+    pub fn recommended_mode(&self) -> PromotionMode {
+        if self.has_ipv6_global || self.upnp.is_some() || self.tunnel_available {
+            PromotionMode::FullNode
+        } else {
+            PromotionMode::RelayOnly
+        }
+    }
+
+    /// 人間向けの 1 行サマリ (ログ / status 表示用)。
+    pub fn summary(&self) -> String {
+        let mode = self.recommended_mode();
+        format!(
+            "promotion={:?} ipv6_global={} upnp={} tunnel={} relay_configured={}",
+            mode,
+            self.has_ipv6_global,
+            self.upnp.is_some(),
+            self.tunnel_available,
+            self.relay_configured,
+        )
+    }
+}
+
+/// global IPv6 アドレスを列挙する。link-local / loopback / unique-local は除外。
+async fn probe_ipv6_global() -> Vec<Ipv6Addr> {
+    // if-addrs は同期 API なので spawn_blocking で逃がす
+    tokio::task::spawn_blocking(|| {
+        if_addrs::get_if_addrs()
+            .ok()
+            .map(|ifs| {
+                ifs.into_iter()
+                    .filter_map(|i| match i.ip() {
+                        IpAddr::V6(v6) if is_global_ipv6(&v6) => Some(v6),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+    .await
+    .unwrap_or_default()
+}
+
+/// IPv6 が「外部到達可能なグローバル」かを判定。
+///
+/// 除外:
+///   - loopback (`::1`)
+///   - link-local (`fe80::/10`)
+///   - unique-local (`fc00::/7`) — VPN/メッシュ用なのでグローバル扱いしない
+///   - documentation (`2001:db8::/32`)
+///   - unspecified (`::`)
+///
+/// 採用:
+///   - global unicast (主に `2000::/3` の範囲)
+fn is_global_ipv6(addr: &Ipv6Addr) -> bool {
+    if addr.is_loopback() || addr.is_unspecified() || addr.is_multicast() {
+        return false;
+    }
+    let segments = addr.segments();
+    // link-local fe80::/10
+    if segments[0] & 0xffc0 == 0xfe80 {
+        return false;
+    }
+    // unique-local fc00::/7
+    if segments[0] & 0xfe00 == 0xfc00 {
+        return false;
+    }
+    // documentation 2001:db8::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0db8 {
+        return false;
+    }
+    // 2000::/3 が global unicast (= 先頭 3 bit が 001)
+    (segments[0] & 0xe000) == 0x2000
+}
+
+/// UPnP IGD discover を試みる。応答があれば external IP を返す。
+async fn probe_upnp() -> Option<UpnpInfo> {
+    // igd-next は async API を持つ (search_gateway / get_external_ip)
+    use igd_next::aio::tokio as igd_tokio;
+    use igd_next::SearchOptions;
+
+    // discover タイムアウトは内部で 3 秒既定だが、明示的に短く設定
+    let opts = SearchOptions {
+        timeout: Some(Duration::from_secs(2)),
+        ..Default::default()
+    };
+
+    let gateway = match igd_tokio::search_gateway(opts).await {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::debug!("UPnP discover failed: {e}");
+            return None;
+        }
+    };
+    let external_ip = match gateway.get_external_ip().await {
+        Ok(ip) => ip,
+        Err(e) => {
+            tracing::debug!("UPnP get_external_ip failed: {e}");
+            return None;
+        }
+    };
+    let gateway_url = gateway.root_url();
+    Some(UpnpInfo {
+        external_ip: external_ip.to_string(),
+        gateway_url,
+    })
+}
+
+/// `cloudflared` がインストールされているかと、token が設定されているかをチェック。
+async fn probe_cloudflared(token_configured: bool) -> bool {
+    if !token_configured {
+        return false;
+    }
+    tokio::task::spawn_blocking(|| which::which("cloudflared").is_ok())
+        .await
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv6_global_classification() {
+        // global
+        assert!(is_global_ipv6(
+            &"2606:4700:4700::1111".parse::<Ipv6Addr>().unwrap()
+        ));
+        assert!(is_global_ipv6(
+            &"2001:4860:4860::8888".parse::<Ipv6Addr>().unwrap()
+        ));
+        // not global
+        assert!(!is_global_ipv6(&"::1".parse::<Ipv6Addr>().unwrap()));
+        assert!(!is_global_ipv6(&"fe80::1".parse::<Ipv6Addr>().unwrap()));
+        assert!(!is_global_ipv6(&"fc00::1".parse::<Ipv6Addr>().unwrap()));
+        assert!(!is_global_ipv6(
+            &"2001:db8::1".parse::<Ipv6Addr>().unwrap()
+        ));
+        assert!(!is_global_ipv6(&"::".parse::<Ipv6Addr>().unwrap()));
+    }
+
+    #[test]
+    fn recommended_mode_logic() {
+        // 何も無いと relay
+        let empty = NetCapabilities {
+            has_ipv6_global: false,
+            ipv6_addresses: vec![],
+            upnp: None,
+            tunnel_available: false,
+            relay_configured: false,
+        };
+        assert_eq!(empty.recommended_mode(), PromotionMode::RelayOnly);
+
+        // IPv6 だけで full
+        let ipv6_only = NetCapabilities {
+            has_ipv6_global: true,
+            ..empty.clone()
+        };
+        assert_eq!(ipv6_only.recommended_mode(), PromotionMode::FullNode);
+
+        // UPnP だけで full
+        let upnp_only = NetCapabilities {
+            upnp: Some(UpnpInfo {
+                external_ip: "203.0.113.1".into(),
+                gateway_url: "http://192.168.1.1:5000/rootDesc.xml".into(),
+            }),
+            ..empty.clone()
+        };
+        assert_eq!(upnp_only.recommended_mode(), PromotionMode::FullNode);
+
+        // tunnel だけで full
+        let tunnel_only = NetCapabilities {
+            tunnel_available: true,
+            ..empty.clone()
+        };
+        assert_eq!(tunnel_only.recommended_mode(), PromotionMode::FullNode);
+    }
+
+    #[tokio::test]
+    async fn detect_does_not_panic_on_offline() {
+        // ネットワーク不通でも detect が成立すること (timeout で抜ける)
+        let caps = NetCapabilities::detect(Duration::from_millis(200), false, false).await;
+        // false の組合せで relay_configured も false → RelayOnly
+        assert_eq!(caps.recommended_mode(), PromotionMode::RelayOnly);
+    }
+}


### PR DESCRIPTION
## Summary

ネットワーク経路選択を **2 つの直交フラグ** で制御できるようにする。

| フラグ | 既定 | 効果 |
|---|---|---|
| `force_relay_only` | false | true なら IPv6/Tunnel をスキップして relay のみ (ユーザ強制) |
| `auto_promote`     | true  | true なら起動時 probe → 結果に応じて relay-only or full-node を自動選択 |

両者を同時に true にした場合は `force_relay_only` 優先 (probe しない)。

## 動作モデル

```
起動
 │
 ▼
force_relay_only=true ──→ relay-only (probe skip)
 │
 ├ false かつ auto_promote=true ─→ NetCapabilities::detect()
 │                                  │
 │                                  ├ IPv6/UPnP/Tunnel いずれか可 → full-node
 │                                  └ 全部不可 ──────────────→ relay-only
 │
 └ false かつ auto_promote=false → 従来動作 (3 段フォールバック試行)
```

## 何で probe するか

| 経路 | クレート | 検出方法 |
|---|---|---|
| IPv6 global | `if-addrs` | OS インターフェース列挙、link-local/loopback/unique-local/doc 除外 |
| UPnP / NAT-PMP | `igd-next` | IGD discover (2 秒 timeout) → external IP 取得 |
| Cloudflare Tunnel | `which` | \`cloudflared\` が PATH にあり \`tunnel.api_token_ref\` が設定済 |

各 probe は 3 秒 timeout、並列実行。失敗 / timeout は \"不可\" 扱い。

## ユースケース

| シナリオ | 設定 |
|---|---|
| **何も考えず動かす (推奨)** | 既定値 (auto_promote=true) — 環境に応じて自動 |
| **匿名運用 / 全通信を AWS 経由に強制** | `force_relay_only = true` |
| **probe を信用せず手動で 3 段試行** | `auto_promote = false`、`force_relay_only = false` |

## 互換性

- 全フィールド \`#[serde(default = ...)]\` で旧 config からも読める
- 旧 `Conduit::new` 等の既存 API は内部で `with_relay_only(false)` を呼ぶので caller 修正不要
- `SynergosNet::new` (embed-host 用 helper) は `force_relay_only` のみ尊重し probe しない

## ビルド検証

- `cargo fmt --all` ✓
- `cargo check --workspace` ✓
- `cargo test --workspace` ✓ **178 tests / 0 failures**

新規テスト:
- `force_relay_only_defaults_to_false`
- `auto_promote_defaults_to_true`
- `force_relay_only_serde_roundtrip` (legacy + flag-set 両方)
- `is_global_ipv6` 分類 (Cloudflare/Google/loopback/link-local/unique-local/doc)
- `recommended_mode_logic`
- `detect_does_not_panic_on_offline`

## Test plan (明日の運用テスト前)

- [ ] 既定設定で起動 → ログに `net capabilities: ...` が出る (probe 結果可視化)
- [ ] `force_relay_only=true` で起動 → ログに `force_relay_only=true → relay-only mode (probe skipped)`
- [ ] IPv6 がある環境 → \`promotion=FullNode ipv6_global=true\` で full-node 起動
- [ ] 全部塞いだ環境 → \`promotion=RelayOnly\` で relay-only に降格

## 残タスク (別 issue で)

- [ ] gossip 経路情報からの自ノード Direct 排除 (匿名性強化)
- [ ] **動的昇格** (起動時だけでなく N 分ごとに再 probe して relay→direct 昇格)
- [ ] STUN / TURN クライアント (#34 — 対称 NAT 環境での fallback 完成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)