### PR TITLE
feat(cli): add project publish subcommand

### DIFF
--- a/synergos-core/src/cli.rs
+++ b/synergos-core/src/cli.rs
@@ -103,6 +103,14 @@ pub enum ProjectCommand {
         /// ローカルのプロジェクトルートパス
         path: PathBuf,
     },
+    /// ファイル更新を publish (FileOffer + CatalogUpdate を gossip)
+    Publish {
+        /// プロジェクトID
+        id: String,
+        /// publish するファイル (プロジェクトルート相対 or 絶対)
+        #[arg(required = true)]
+        files: Vec<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -315,6 +323,24 @@ async fn handle_project(cmd: ProjectCommand) -> anyhow::Result<()> {
                 .await?;
             match resp {
                 synergos_ipc::IpcResponse::Ok => println!("Joined project."),
+                synergos_ipc::IpcResponse::Error { message, .. } => {
+                    eprintln!("Error: {}", message);
+                }
+                _ => println!("Unexpected response"),
+            }
+        }
+        ProjectCommand::Publish { id, files } => {
+            let count = files.len();
+            let resp = client
+                .send(synergos_ipc::IpcCommand::PublishUpdate {
+                    project_id: id,
+                    file_paths: files,
+                })
+                .await?;
+            match resp {
+                synergos_ipc::IpcResponse::Ok => {
+                    println!("Published {} file(s).", count);
+                }
                 synergos_ipc::IpcResponse::Error { message, .. } => {
                     eprintln!("Error: {}", message);
                 }


### PR DESCRIPTION
## Summary

- `synergos-core project publish <id> <files...>` を新設し、`IpcCommand::PublishUpdate` へブリッジする
- `OPERATIONAL-TEST.md` は元々この CLI 形を前提にしていたが、wire-up が抜けていた

## Why

`PublishUpdate` IPC は `ipc_server.rs` に既に実装済 (project root 配下チェック → metadata + 内容読み取り → CRC 計算 → ledger Offer + gossip CatalogUpdate)。CLI から発火できないと外部運用テストが回せない。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib -p synergos-core --release` (6 pass)
- [x] `synergos-core project publish --help` でヘルプ確認
- [ ] CI (Linux/macOS/Windows test matrix) で full test suite green
- [ ] 実機 2 ノード間で `project publish` → `CatalogSyncCompletedEvent` を観測 (別タスク)

🤖 Generated with [Claude Code](https://claude.com/claude-code)