### PR TITLE
feat(net,core): bind QUIC server endpoint at daemon startup

### DIFF
--- a/synergos-core/src/catalog_sync.rs
+++ b/synergos-core/src/catalog_sync.rs
@@ -205,6 +205,7 @@ mod tests {
             idle_timeout_ms: 5_000,
             max_udp_payload_size: 1350,
             enable_0rtt: false,
+            listen_addr: None,
         }
     }
 

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -2,6 +2,7 @@
 //!
 //! synergos-core デーモンの起動・常駐・シャットダウンを制御する。
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -81,6 +82,18 @@ impl Daemon {
             Arc::new(g)
         };
         let quic = Arc::new(QuicManager::new(net_config.quic.clone(), identity.clone()));
+        // QUIC server をバインド (これが無いと accept ループは未開通でピアを受けられない)。
+        // 既定は `[::]:0` (IPv6 デュアルスタックでカーネル割当ポート)。
+        // 公開ノードでは `quic.listen_addr = "[::]:7777"` 等を config で指定する。
+        let bind_addr: SocketAddr = net_config
+            .quic
+            .listen_addr
+            .unwrap_or_else(|| "[::]:0".parse().expect("static literal"));
+        let actual_addr = quic
+            .bind(bind_addr)
+            .await
+            .map_err(|e| anyhow::anyhow!("QUIC bind failed on {bind_addr}: {e}"))?;
+        tracing::info!("QUIC listening on {}", actual_addr);
         let tunnel = Arc::new(TunnelManager::new(&net_config.tunnel));
         let mesh = Arc::new(Mesh::new(net_config.mesh.clone()));
         let conduit = Arc::new(Conduit::new(

--- a/synergos-core/tests/auto_transfer_e2e.rs
+++ b/synergos-core/tests/auto_transfer_e2e.rs
@@ -30,6 +30,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-core/tests/catalog_sync_e2e.rs
+++ b/synergos-core/tests/catalog_sync_e2e.rs
@@ -28,6 +28,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-core/tests/gossip_mesh_e2e.rs
+++ b/synergos-core/tests/gossip_mesh_e2e.rs
@@ -25,6 +25,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-core/tests/transfer_e2e.rs
+++ b/synergos-core/tests/transfer_e2e.rs
@@ -20,6 +20,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-core/tests/two_node_full_e2e.rs
+++ b/synergos-core/tests/two_node_full_e2e.rs
@@ -34,6 +34,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 10_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use serde::{Deserialize, Serialize};
 
 /// synergos-net の全設定
@@ -108,6 +110,12 @@ pub struct QuicConfig {
     pub max_udp_payload_size: u16,
     /// 0-RTT を有効にするか
     pub enable_0rtt: bool,
+    /// QUIC server がバインドする listen アドレス。
+    /// `None` (既定) は `[::]:0` 相当 (IPv6/IPv4 デュアルスタックでカーネル割当ポート)。
+    /// 公開ノードでは `[::]:7777` 等の固定ポートを設定する。
+    /// 後方互換のため `#[serde(default)]` で旧 config からも読める。
+    #[serde(default)]
+    pub listen_addr: Option<SocketAddr>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -214,6 +222,7 @@ impl Default for NetConfig {
                 // 0-RTT はリプレイ攻撃の余地があるため既定は OFF。
                 // 明示的にリスクを受容する運用のみ true に設定する。
                 enable_0rtt: false,
+                listen_addr: None,
             },
             dht: DhtConfig {
                 k_bucket_size: 20,
@@ -258,5 +267,44 @@ impl NetConfig {
     pub fn validate(&self) -> Result<(), String> {
         self.stream_allocation.validate()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quic_listen_addr_defaults_to_none() {
+        let cfg = NetConfig::default();
+        assert!(cfg.quic.listen_addr.is_none());
+    }
+
+    #[test]
+    fn quic_listen_addr_serde_roundtrip_explicit() {
+        // listen_addr が指定された QuicConfig は string -> SocketAddr で読み戻せること。
+        let json = r#"{
+            "max_concurrent_streams": 100,
+            "idle_timeout_ms": 30000,
+            "max_udp_payload_size": 1452,
+            "enable_0rtt": false,
+            "listen_addr": "[::]:7777"
+        }"#;
+        let qcfg: QuicConfig = serde_json::from_str(json).expect("json parse");
+        let addr = qcfg.listen_addr.expect("listen_addr present");
+        assert_eq!(addr.to_string(), "[::]:7777");
+    }
+
+    #[test]
+    fn quic_listen_addr_serde_roundtrip_omitted() {
+        // listen_addr フィールドが無い旧 config (serde default) からも読めること。
+        let json = r#"{
+            "max_concurrent_streams": 100,
+            "idle_timeout_ms": 30000,
+            "max_udp_payload_size": 1452,
+            "enable_0rtt": false
+        }"#;
+        let qcfg: QuicConfig = serde_json::from_str(json).expect("json parse");
+        assert!(qcfg.listen_addr.is_none());
     }
 }

--- a/synergos-net/src/content/session.rs
+++ b/synergos-net/src/content/session.rs
@@ -255,6 +255,7 @@ mod tests {
                 idle_timeout_ms: 5000,
                 max_udp_payload_size: 1350,
                 enable_0rtt: false,
+                listen_addr: None,
             },
             id.clone(),
         ));
@@ -277,6 +278,7 @@ mod tests {
                 idle_timeout_ms: 5000,
                 max_udp_payload_size: 1350,
                 enable_0rtt: false,
+                listen_addr: None,
             },
             id.clone(),
         ));

--- a/synergos-net/tests/bitswap_e2e.rs
+++ b/synergos-net/tests/bitswap_e2e.rs
@@ -19,6 +19,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-net/tests/bitswap_v2.rs
+++ b/synergos-net/tests/bitswap_v2.rs
@@ -19,6 +19,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-net/tests/dht_over_quic.rs
+++ b/synergos-net/tests/dht_over_quic.rs
@@ -19,6 +19,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-net/tests/quic_control_stream.rs
+++ b/synergos-net/tests/quic_control_stream.rs
@@ -15,6 +15,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 

--- a/synergos-net/tests/quic_peer_auth.rs
+++ b/synergos-net/tests/quic_peer_auth.rs
@@ -18,6 +18,7 @@ fn qcfg() -> QuicConfig {
         idle_timeout_ms: 5_000,
         max_udp_payload_size: 1350,
         enable_0rtt: false,
+        listen_addr: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- `synergos-core` の daemon が `QuicManager::bind` を呼んでおらず、accept loop が無効化されていた致命的ギャップを修正
- `QuicConfig` に `listen_addr: Option<SocketAddr>` を追加して、公開ノードでポート固定できるように
- 既定 `[::]:0` で IPv6 デュアルスタック listening

## Why

`spawn_quic_accept_loop` は `net.quic.accept()` をループしているが、bind 前の endpoint は accept できず、エラーで sleep を繰り返すだけだった。結果としてクロスマシンの peer 接続が一切確立できない (gossip / DHT / Bitswap 全部不能)。171 tests が pass しているのは tests が個別に `quic.bind()` を呼んでいるため。

## Changes

- `synergos-net/src/config.rs`
  - `QuicConfig` に `listen_addr: Option<SocketAddr>` (`#[serde(default)]`) を追加
  - 既定値で `listen_addr: None`
  - 単体テスト 3 本追加 (default None / serde explicit / serde omitted)
- `synergos-core/src/daemon.rs`
  - `Daemon::new` で `QuicManager::new` 直後に `quic.bind(listen_addr.unwrap_or([::]:0))` を await
  - 失敗時は `anyhow::Result` で daemon 起動を abort
  - `tracing::info!("QUIC listening on {}", actual_addr)` で起動可視化
- `QuicConfig` リテラル構築を行っていた全テスト (synergos-net x5 / synergos-core x5) に `listen_addr: None` を追加
- `synergos-net/src/content/session.rs` の単体テスト 2 箇所も同上

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib -p synergos-net --release` → 63 pass (60 + 3 新規)
- [x] `cargo test --lib -p synergos-core --release` → 6 pass
- [x] `cargo check --workspace` clean
- [ ] CI (Linux/macOS/Windows) で full integration test green
- [ ] 実機検証: AWS daemon 起動ログに `QUIC listening on [::]:7777` が出ること (PR-3 / PR-4 後に)

🤖 Generated with [Claude Code](https://claude.com/claude-code)