### PR TITLE
feat(core): peer-info HTTP servlet (bootstrap endpoint, no auth)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,10 +2147,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "icu_collections"
@@ -2541,6 +2657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,6 +2700,12 @@ dependencies = [
  "objc",
  "paste",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -4027,6 +4155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,12 +4481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synergos-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "axum",
  "blake3",
  "clap",
  "crc32fast",
@@ -4786,6 +4932,33 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/synergos-core/Cargo.toml
+++ b/synergos-core/Cargo.toml
@@ -17,6 +17,9 @@ synergos-ipc = { path = "../synergos-ipc" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 
+# HTTP servlet (peer-info bootstrap endpoint, 将来 auth/API 拡張のホスト)
+axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio"] }
+
 # QUIC (for transfer stream handling)
 quinn = "0.11"
 

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -275,6 +275,32 @@ impl Daemon {
             self.ctx.shutdown_tx.subscribe(),
         );
 
+        // Peer-info HTTP servlet (任意): bootstrap 公開ノード用。Cloudflare Tunnel
+        // 経由で /peer-info を外部に publish し、クライアントは GET → quic_endpoint
+        // を学習して直接 QUIC 接続する。`peer_info_listen_addr = None` ならスキップ。
+        let peer_info_task = self
+            .net
+            .net_config
+            .peer_info_listen_addr
+            .map(|listen_addr| {
+                let peer_id = self.net.local_peer_id.clone();
+                let quic = self.net.quic.clone();
+                let shutdown_rx = self.ctx.shutdown_tx.subscribe();
+                tokio::spawn(async move {
+                    if let Err(e) = crate::peer_info_server::run(
+                        listen_addr,
+                        peer_id,
+                        quic,
+                        "synergos-core".into(),
+                        shutdown_rx,
+                    )
+                    .await
+                    {
+                        tracing::warn!("peer-info servlet exited with error: {e}");
+                    }
+                })
+            });
+
         // IPC サーバーを実行（シャットダウンまでブロック）
         ipc_server.run().await?;
 
@@ -286,6 +312,9 @@ impl Daemon {
         gossip_sub_task.abort();
         gossip_fanout_task.abort();
         catalog_sync_task.abort();
+        if let Some(t) = peer_info_task {
+            t.abort();
+        }
 
         // グレースフルシャットダウン
         self.shutdown().await?;

--- a/synergos-core/src/lib.rs
+++ b/synergos-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod conflict;
 pub mod event_bus;
 pub mod exchange;
+pub mod peer_info_server;
 pub mod presence;
 pub mod project;
 

--- a/synergos-core/src/peer_info_server.rs
+++ b/synergos-core/src/peer_info_server.rs
@@ -1,0 +1,230 @@
+//! Peer-info HTTP servlet (bootstrap endpoint)
+//!
+//! Cloudflare Tunnel 等の HTTPS 公開を通じてピアが「この Synergos ノードへ
+//! 直接 QUIC 接続するための情報」を JSON で配信する小さな HTTP サーバ。
+//!
+//! ## 設計目的
+//!
+//! 1. Cloudflare AAAA を直接公開しない (= IPv6 を撒かない) アーキテクチャの
+//!    実現。Tunnel は HTTPS を proxy するので、EC2 の生 IPv6 はクライアントが
+//!    `/peer-info` を GET したときだけ JSON 応答に乗る。
+//! 2. 将来的な認証 / API 拡張のホスト。現状はテストのため認証なし。Tower 経由
+//!    の middleware で auth layer を後付けする想定。
+//! 3. invite token 機構の代替経路 (peer add-url の bootstrap データ源)。
+//!
+//! ## エンドポイント (現状)
+//!
+//! - `GET /peer-info` → `PeerInfoResponse` (JSON)
+//! - `GET /health` → 200 OK (`"ok"`)
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{extract::State, http::StatusCode, response::Json, routing::get, Router};
+use serde::{Deserialize, Serialize};
+use synergos_net::{quic::QuicManager, types::PeerId};
+use tokio::sync::broadcast;
+
+/// Peer-info JSON 応答。クライアント (peer add-url 経由の bootstrap) はこの値を
+/// もとに `expected_peer_id` を学習し、`quic_endpoint` に対して QUIC 接続する。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerInfoResponse {
+    /// Synergos ノードの PeerId (ed25519 派生)。クライアントは TLS handshake
+    /// 時に提示される自己署名証明書とこの ID を突き合わせて peer 真性を検証する。
+    pub peer_id: String,
+    /// クライアントが直接 QUIC 接続すべきエンドポイント
+    /// (例 `[2406:da14:...]:7777` / `203.0.113.1:7777`)。
+    /// `None` ならサーバはまだ QUIC bind を完了していない (起動初期)。
+    pub quic_endpoint: Option<String>,
+    /// プロトコルバージョン (semver-major)。クライアントが互換性チェックに使う。
+    pub protocol_version: u32,
+    /// オプションのサーバ表示名 (UI 用)。匿名性が要るなら空文字に。
+    pub server_name: String,
+}
+
+/// 現在のプロトコルバージョン (bump はクライアントとの互換性を切るときのみ)
+pub const PEER_INFO_PROTOCOL_VERSION: u32 = 1;
+
+/// servlet 共有 state。axum の `with_state` で各 handler に注入する。
+#[derive(Clone)]
+struct AppState {
+    peer_id: PeerId,
+    quic: Arc<QuicManager>,
+    server_name: String,
+}
+
+async fn handle_peer_info(State(s): State<AppState>) -> Json<PeerInfoResponse> {
+    let endpoint = s.quic.local_addr().await.map(|a| a.to_string());
+    Json(PeerInfoResponse {
+        peer_id: s.peer_id.to_string(),
+        quic_endpoint: endpoint,
+        protocol_version: PEER_INFO_PROTOCOL_VERSION,
+        server_name: s.server_name.clone(),
+    })
+}
+
+async fn handle_health() -> (StatusCode, &'static str) {
+    (StatusCode::OK, "ok")
+}
+
+/// servlet を構築する Router。テストから直接叩けるように切り出してある。
+fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/peer-info", get(handle_peer_info))
+        .route("/health", get(handle_health))
+        .with_state(state)
+}
+
+/// Peer-info servlet を起動する。`shutdown_rx` を受け取ったら graceful shutdown する。
+///
+/// `listen_addr` は通常 `127.0.0.1:7780` 等のローカル loopback で、Cloudflare
+/// Tunnel 経由で外部に publish される。直接 0.0.0.0 に bind しないこと
+/// (servlet 自体には auth が無いため、生で外に出すと info disclosure になる)。
+pub async fn run(
+    listen_addr: SocketAddr,
+    peer_id: PeerId,
+    quic: Arc<QuicManager>,
+    server_name: String,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) -> anyhow::Result<()> {
+    let state = AppState {
+        peer_id,
+        quic,
+        server_name,
+    };
+    let app = build_router(state);
+
+    let listener = tokio::net::TcpListener::bind(listen_addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("peer-info bind failed on {listen_addr}: {e}"))?;
+    let actual = listener
+        .local_addr()
+        .map_err(|e| anyhow::anyhow!("peer-info local_addr: {e}"))?;
+    tracing::info!("peer-info servlet listening on {}", actual);
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.recv().await;
+            tracing::debug!("peer-info servlet shutdown signal received");
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("peer-info serve error: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use synergos_net::config::QuicConfig;
+    use synergos_net::identity::Identity;
+
+    fn qcfg() -> QuicConfig {
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        }
+    }
+
+    /// QUIC が未 bind の状態でも /peer-info は 200 で `quic_endpoint=None` を返す。
+    #[tokio::test]
+    async fn peer_info_returns_none_endpoint_before_quic_bind() {
+        let identity = Arc::new(Identity::generate());
+        let peer_id = identity.peer_id().clone();
+        let quic = Arc::new(QuicManager::new(qcfg(), identity));
+
+        // bind しないまま GET /peer-info
+        let app = build_router(AppState {
+            peer_id: peer_id.clone(),
+            quic: quic.clone(),
+            server_name: "test".into(),
+        });
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("http://{}/peer-info", addr);
+        let resp = reqwest_get_json(&url).await;
+        assert_eq!(resp.peer_id, peer_id.to_string());
+        assert!(resp.quic_endpoint.is_none());
+        assert_eq!(resp.protocol_version, PEER_INFO_PROTOCOL_VERSION);
+        assert_eq!(resp.server_name, "test");
+    }
+
+    /// QUIC が bind 済みなら /peer-info は実際の listen address を返す。
+    #[tokio::test]
+    async fn peer_info_returns_quic_endpoint_after_bind() {
+        use std::net::Ipv4Addr;
+        let identity = Arc::new(Identity::generate());
+        let peer_id = identity.peer_id().clone();
+        let quic = Arc::new(QuicManager::new(qcfg(), identity));
+        let bound = quic.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+
+        let app = build_router(AppState {
+            peer_id: peer_id.clone(),
+            quic: quic.clone(),
+            server_name: "test".into(),
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("http://{}/peer-info", addr);
+        let resp = reqwest_get_json(&url).await;
+        assert_eq!(resp.quic_endpoint, Some(bound.to_string()));
+    }
+
+    /// /health は 200 を返す。
+    #[tokio::test]
+    async fn health_returns_200() {
+        let identity = Arc::new(Identity::generate());
+        let quic = Arc::new(QuicManager::new(qcfg(), identity.clone()));
+        let app = build_router(AppState {
+            peer_id: identity.peer_id().clone(),
+            quic,
+            server_name: String::new(),
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("http://{}/health", addr);
+        let body = reqwest_get_text(&url).await;
+        assert_eq!(body, "ok");
+    }
+
+    /// reqwest を入れたくないので tokio + 手書き HTTP/1.1 で GET する小ヘルパ。
+    /// テスト専用。
+    async fn reqwest_get_json(url: &str) -> PeerInfoResponse {
+        let body = reqwest_get_text(url).await;
+        serde_json::from_str(&body).expect("json parse")
+    }
+
+    async fn reqwest_get_text(url: &str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        // url = http://host:port/path
+        let stripped = url.strip_prefix("http://").expect("http:// prefix");
+        let slash = stripped.find('/').expect("path slash");
+        let host = &stripped[..slash];
+        let path = &stripped[slash..];
+        let mut s = tokio::net::TcpStream::connect(host).await.unwrap();
+        let req = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+        s.write_all(req.as_bytes()).await.unwrap();
+        let mut buf = Vec::new();
+        s.read_to_end(&mut buf).await.unwrap();
+        let resp = String::from_utf8_lossy(&buf).to_string();
+        // 最後の \r\n\r\n の後ろが body
+        let split = resp.find("\r\n\r\n").expect("header/body separator");
+        resp[split + 4..].to_string()
+    }
+}

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -18,6 +18,11 @@ pub struct NetConfig {
     /// `#[serde(default)]` で旧 config からも読める)。
     #[serde(default)]
     pub catalog: CatalogConfig,
+    /// Peer-info HTTP servlet (bootstrap endpoint) を起動する listen アドレス。
+    /// `None` (既定) ではサーブレットを起動しない。AWS 公開ノード等では
+    /// `127.0.0.1:7780` を設定し、Cloudflare Tunnel 等で外部に publish する想定。
+    #[serde(default)]
+    pub peer_info_listen_addr: Option<SocketAddr>,
 }
 
 /// CatalogManager のチューニングパラメータ。
@@ -257,6 +262,7 @@ impl Default for NetConfig {
                 graph_sample_interval_secs: 1,
             },
             catalog: CatalogConfig::default(),
+            peer_info_listen_addr: None,
         }
     }
 }

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -182,6 +182,13 @@ impl QuicManager {
         Ok(actual_addr)
     }
 
+    /// 現在 bind 済みの QUIC endpoint のローカルアドレスを返す。
+    /// `bind` が成功する前は `None`。peer-info servlet が advertised endpoint
+    /// として返すために使う。
+    pub async fn local_addr(&self) -> Option<SocketAddr> {
+        *self.local_addr.read().await
+    }
+
     /// 指定アドレスに QUIC 接続を確立する。
     ///
     /// `expected_peer_id` は接続先ピアから期待する PeerId。サーバ側から


### PR DESCRIPTION
## Summary

- 新しい HTTP サーブレット (`synergos-core/src/peer_info_server.rs`) を追加
- `GET /peer-info` → `{ peer_id, quic_endpoint, protocol_version, server_name }`
- `GET /health` → 200 OK
- Cloudflare Tunnel 経由 HTTPS 公開を前提。EC2 の IPv6 を AAAA で直接撒かず、HTTPS 応答内で渡す設計

## Why

invite token 系のクロスマシン handshake が現状動かない (別タスクで対処)。代替の bootstrap 経路として、ピアが GET 一発で接続情報を取れるエンドポイントを提供する。Cloudflare Tunnel が HTTPS proxy する → AAAA を撒かない → EC2 IPv6 が漏れない、というセキュリティモデル。

## Changes

- **synergos-net**
  - `QuicManager::local_addr() -> Option<SocketAddr>` 追加
  - `NetConfig::peer_info_listen_addr: Option<SocketAddr>` (`#[serde(default)]`)
- **synergos-core**
  - 新モジュール `peer_info_server` (axum 0.7 ベース、auth 層は将来 hook)
  - `Daemon::run` で `peer_info_listen_addr` が Some なら servlet task を spawn
  - shutdown 時に abort

## Security note

- servlet 自体に **auth は無い** (現状テスト目的)
- `0.0.0.0` には bind しないこと。`127.0.0.1:7780` などの loopback に bind して Cloudflare Tunnel 経由で外部公開する想定 (info disclosure 防止)
- 将来 Tower layer で API token / Cernere session 経由の auth を差し込める設計

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib -p synergos-core --release` → 9 pass (6 既存 + 3 新規)
- [x] `cargo test --lib -p synergos-net --release` → 63 pass (回帰なし)
- [ ] CI (Linux/macOS/Windows) で full integration test green
- [ ] 実機: AWS daemon で `peer_info_listen_addr = "127.0.0.1:7780"` を設定し `curl https://node1.example.com/peer-info` で JSON 取得 (PR-3 後にまとめて検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)