### PR TITLE
feat(core): peer add-url bootstrap (HTTPS /peer-info → QUIC connect)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,7 +2105,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "idna",
  "ipnet",
@@ -2191,6 +2210,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body",
  "httparse",
@@ -2199,6 +2219,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.37",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2207,13 +2244,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http 1.4.0",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2386,6 +2431,16 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3796,6 +3851,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,6 +4099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +4282,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -4485,6 +4597,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synergos-core"
@@ -4501,6 +4616,7 @@ dependencies = [
  "libc",
  "pretty_assertions",
  "quinn",
+ "reqwest",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -4949,6 +5065,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5055,6 +5189,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -5209,6 +5349,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/synergos-core/Cargo.toml
+++ b/synergos-core/Cargo.toml
@@ -20,6 +20,9 @@ async-trait = "0.1"
 # HTTP servlet (peer-info bootstrap endpoint, 将来 auth/API 拡張のホスト)
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio"] }
 
+# HTTP client (peer-add-by-url の bootstrap GET)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2"] }
+
 # QUIC (for transfer stream handling)
 quinn = "0.11"
 

--- a/synergos-core/src/cli.rs
+++ b/synergos-core/src/cli.rs
@@ -132,6 +132,14 @@ pub enum PeerCommand {
         /// ピアID
         peer: String,
     },
+    /// peer-info HTTP servlet 経由で bootstrap 接続する
+    /// (例: `peer add-url myproj https://node1.example.com`)
+    AddUrl {
+        /// プロジェクトID
+        project: String,
+        /// 相手 daemon の HTTPS URL (path 省略可、自動で /peer-info を付与)
+        url: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -387,6 +395,21 @@ async fn handle_peer(cmd: PeerCommand) -> anyhow::Result<()> {
                 .send(synergos_ipc::IpcCommand::PeerDisconnect { peer_id: peer })
                 .await?;
             println!("Peer disconnected.");
+        }
+        PeerCommand::AddUrl { project, url } => {
+            let resp = client
+                .send(synergos_ipc::IpcCommand::PeerAddByUrl {
+                    project_id: project,
+                    url,
+                })
+                .await?;
+            match resp {
+                synergos_ipc::IpcResponse::Ok => println!("Peer added via URL bootstrap."),
+                synergos_ipc::IpcResponse::Error { message, .. } => {
+                    eprintln!("Error: {}", message);
+                }
+                _ => println!("Unexpected response"),
+            }
         }
     }
     Ok(())

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -192,6 +192,7 @@ impl Daemon {
             net_config: Some(net.net_config.clone()),
             catalogs: Arc::new(dashmap::DashMap::new()),
             content_store: shared_content_store,
+            quic: net.quic.clone(),
         });
 
         // 永続化されていた project を restore した後、それぞれの

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -52,6 +52,8 @@ pub struct ServiceContext {
     /// RootCatalog スナップショットや DAG blocks はここに入り、相手ピアからの
     /// BSW1 リクエストで引き出される (#25 + #26)。
     pub content_store: Arc<synergos_net::content::MemoryContentStore>,
+    /// QUIC マネージャ (peer add-url / 直接接続用)。Daemon::new で bind 済み。
+    pub quic: Arc<synergos_net::quic::QuicManager>,
 }
 
 /// IPC サーバー
@@ -934,6 +936,50 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     message: e.to_string(),
                 },
             }
+        }
+
+        IpcCommand::PeerAddByUrl { project_id, url } => {
+            // プロジェクトが open 済みであることを確認 (URL 経由でも所属が必要)。
+            if ctx.project_manager.project_root(&project_id).is_none() {
+                return IpcResponse::Error {
+                    code: 3,
+                    message: format!("unknown project: {project_id}"),
+                };
+            }
+            // /peer-info GET → QUIC connect (S1 真性認証込み)
+            let peer_id = match crate::peer_bootstrap::bootstrap_from_url(
+                &url,
+                &ctx.quic,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            {
+                Ok(pid) => pid,
+                Err(e) => {
+                    return IpcResponse::Error {
+                        code: 2,
+                        message: format!("bootstrap failed: {e}"),
+                    };
+                }
+            };
+            // PresenceService に登録 → Connected に遷移
+            let registration = crate::presence::NodeRegistration {
+                peer_id: peer_id.clone(),
+                display_name: peer_id.to_string(),
+                endpoints: vec![],
+                project_ids: vec![project_id],
+            };
+            if let Err(e) = ctx.presence.register_node(registration).await {
+                return IpcResponse::Error {
+                    code: 2,
+                    message: format!("register_node failed: {e}"),
+                };
+            }
+            let _ = ctx
+                .presence
+                .update_node_state(&peer_id, PeerState::Connected)
+                .await;
+            IpcResponse::Ok
         }
 
         // ── ファイル転送 ──

--- a/synergos-core/src/lib.rs
+++ b/synergos-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod conflict;
 pub mod event_bus;
 pub mod exchange;
+pub mod peer_bootstrap;
 pub mod peer_info_server;
 pub mod presence;
 pub mod project;

--- a/synergos-core/src/peer_bootstrap.rs
+++ b/synergos-core/src/peer_bootstrap.rs
@@ -1,0 +1,209 @@
+//! URL ベースの peer bootstrap
+//!
+//! `peer add-url <https://node1.example.com>` から呼ばれ、相手 daemon の
+//! `/peer-info` HTTPS エンドポイントを GET → 取得した peer_id + QUIC endpoint
+//! で QUIC 接続を張る。invite token を必要としないクロスマシン peer 追加経路。
+//!
+//! ## 設計メモ
+//!
+//! - `quic_endpoint` の IP 部が unspecified (`0.0.0.0` / `[::]`) なら、URL の
+//!   hostname を DNS resolve した結果に置き換える。これにより daemon 側は
+//!   `[::]:7777` のような bind 表現で十分で、公開 IP を自前で知る必要がない。
+//! - protocol_version 不一致は早期に拒否する (将来 wire 変更時の安全弁)。
+//! - `quic.connect` は S1 仕様で `expected_peer_id` を必須、ed25519 派生の
+//!   ピンニング検証で偽サーバを弾く。
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use serde::Deserialize;
+use synergos_net::quic::QuicManager;
+use synergos_net::types::PeerId;
+
+use crate::peer_info_server::PEER_INFO_PROTOCOL_VERSION;
+
+/// peer add-url の bootstrap 結果。成功時は確立した peer_id を返す。
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapError {
+    #[error("invalid url: {0}")]
+    InvalidUrl(String),
+    #[error("http error: {0}")]
+    Http(String),
+    #[error("invalid peer-info response: {0}")]
+    InvalidResponse(String),
+    #[error("incompatible protocol_version: got {got}, expected {expected}")]
+    IncompatibleProtocol { got: u32, expected: u32 },
+    #[error("dns resolution failed for {host}: {details}")]
+    DnsFailure { host: String, details: String },
+    #[error("quic connect failed: {0}")]
+    QuicConnect(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct RemotePeerInfo {
+    peer_id: String,
+    quic_endpoint: Option<String>,
+    protocol_version: u32,
+}
+
+/// URL から peer-info を取得して QUIC 接続を張る。
+///
+/// 成功時は学習した `PeerId` を返し、`QuicManager` の internal pool に接続が登録された状態。
+/// 呼び出し側は presence service への登録などを別途行う。
+pub async fn bootstrap_from_url(
+    base_url: &str,
+    quic: &QuicManager,
+    timeout: Duration,
+) -> Result<PeerId, BootstrapError> {
+    // 1. URL parse + /peer-info path 付与
+    let parsed =
+        reqwest::Url::parse(base_url).map_err(|e| BootstrapError::InvalidUrl(format!("{e}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| BootstrapError::InvalidUrl("url has no host".into()))?
+        .to_string();
+    let info_url = build_peer_info_url(&parsed);
+
+    // 2. HTTPS GET /peer-info
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .map_err(|e| BootstrapError::Http(format!("client build: {e}")))?;
+    let resp = client
+        .get(info_url.clone())
+        .send()
+        .await
+        .map_err(|e| BootstrapError::Http(format!("GET {info_url} failed: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(BootstrapError::Http(format!(
+            "GET {info_url} returned {}",
+            resp.status()
+        )));
+    }
+    let info: RemotePeerInfo = resp
+        .json()
+        .await
+        .map_err(|e| BootstrapError::InvalidResponse(format!("json parse: {e}")))?;
+
+    // 3. protocol version check
+    if info.protocol_version != PEER_INFO_PROTOCOL_VERSION {
+        return Err(BootstrapError::IncompatibleProtocol {
+            got: info.protocol_version,
+            expected: PEER_INFO_PROTOCOL_VERSION,
+        });
+    }
+
+    let quic_endpoint = info
+        .quic_endpoint
+        .as_deref()
+        .ok_or_else(|| BootstrapError::InvalidResponse("remote has no quic_endpoint".into()))?;
+    let advertised: SocketAddr = quic_endpoint
+        .parse()
+        .map_err(|e| BootstrapError::InvalidResponse(format!("invalid quic_endpoint: {e}")))?;
+
+    // 4. unspecified IP は URL host で置換
+    let connect_addr = resolve_connect_addr(&host, advertised).await?;
+
+    // 5. QUIC connect (S1 仕様で peer_id 検証つき)
+    let expected_peer_id = PeerId::new(&info.peer_id);
+    quic.connect(expected_peer_id.clone(), connect_addr, "synergos")
+        .await
+        .map_err(|e| BootstrapError::QuicConnect(format!("{e}")))?;
+
+    Ok(expected_peer_id)
+}
+
+fn build_peer_info_url(base: &reqwest::Url) -> reqwest::Url {
+    let mut u = base.clone();
+    let path = u.path();
+    let new_path = if path.is_empty() || path == "/" {
+        "/peer-info".to_string()
+    } else if path.ends_with('/') {
+        format!("{path}peer-info")
+    } else {
+        format!("{}/peer-info", path.trim_end_matches('/'))
+    };
+    u.set_path(&new_path);
+    u
+}
+
+async fn resolve_connect_addr(
+    host: &str,
+    advertised: SocketAddr,
+) -> Result<SocketAddr, BootstrapError> {
+    if !advertised.ip().is_unspecified() {
+        return Ok(advertised);
+    }
+    let target = format!("{host}:{}", advertised.port());
+    let mut iter =
+        tokio::net::lookup_host(&target)
+            .await
+            .map_err(|e| BootstrapError::DnsFailure {
+                host: host.to_string(),
+                details: format!("{e}"),
+            })?;
+    // IPv6 を優先 (LUDIARS は IPv6-first 設計)
+    let collected: Vec<SocketAddr> = iter.by_ref().collect();
+    let chosen = collected
+        .iter()
+        .find(|a| a.is_ipv6())
+        .or_else(|| collected.first())
+        .ok_or_else(|| BootstrapError::DnsFailure {
+            host: host.to_string(),
+            details: "no addresses returned".into(),
+        })?;
+    Ok(*chosen)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_peer_info_url_root() {
+        let url = reqwest::Url::parse("https://node1.example.com").unwrap();
+        let info = build_peer_info_url(&url);
+        assert_eq!(info.as_str(), "https://node1.example.com/peer-info");
+    }
+
+    #[test]
+    fn build_peer_info_url_with_trailing_slash() {
+        let url = reqwest::Url::parse("https://node1.example.com/").unwrap();
+        let info = build_peer_info_url(&url);
+        assert_eq!(info.as_str(), "https://node1.example.com/peer-info");
+    }
+
+    #[test]
+    fn build_peer_info_url_with_subpath() {
+        let url = reqwest::Url::parse("https://relay.example.com/api").unwrap();
+        let info = build_peer_info_url(&url);
+        assert_eq!(info.as_str(), "https://relay.example.com/api/peer-info");
+    }
+
+    #[test]
+    fn build_peer_info_url_with_subpath_trailing_slash() {
+        let url = reqwest::Url::parse("https://relay.example.com/api/").unwrap();
+        let info = build_peer_info_url(&url);
+        assert_eq!(info.as_str(), "https://relay.example.com/api/peer-info");
+    }
+
+    /// `[::]:port` (unspecified IPv6) なら hostname 解決にフォールバックする。
+    #[tokio::test]
+    async fn resolve_connect_addr_replaces_unspecified_ipv6() {
+        let advertised: SocketAddr = "[::]:7777".parse().unwrap();
+        // localhost は ::1 / 127.0.0.1 に解決される
+        let resolved = resolve_connect_addr("localhost", advertised).await.unwrap();
+        assert_eq!(resolved.port(), 7777);
+        assert!(!resolved.ip().is_unspecified());
+    }
+
+    /// 具体的な IP の場合はそのまま返す (DNS lookup しない)。
+    #[tokio::test]
+    async fn resolve_connect_addr_keeps_specific() {
+        let advertised: SocketAddr = "127.0.0.1:7777".parse().unwrap();
+        let resolved = resolve_connect_addr("does-not-matter", advertised)
+            .await
+            .unwrap();
+        assert_eq!(resolved, advertised);
+    }
+}

--- a/synergos-core/tests/catalog_sync.rs
+++ b/synergos-core/tests/catalog_sync.rs
@@ -13,13 +13,26 @@ use synergos_core::ipc_server::ServiceContext;
 use synergos_core::presence::PresenceService;
 use synergos_core::project::ProjectManager;
 use synergos_net::catalog::CatalogManager;
+use synergos_net::config::QuicConfig;
 use synergos_net::gossip::GossipMessage;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
 use synergos_net::types::{ChunkId, PeerId, TopicId};
 use tokio::sync::broadcast;
 
 fn make_ctx() -> Arc<ServiceContext> {
     let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
     let (shutdown_tx, _) = broadcast::channel(1);
+    let quic = Arc::new(QuicManager::new(
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        },
+        Arc::new(Identity::generate()),
+    ));
     Arc::new(ServiceContext {
         event_bus: event_bus.clone(),
         project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
@@ -31,6 +44,7 @@ fn make_ctx() -> Arc<ServiceContext> {
         net_config: None,
         catalogs: Arc::new(DashMap::new()),
         content_store: Arc::new(synergos_net::content::MemoryContentStore::new()),
+        quic,
     })
 }
 

--- a/synergos-core/tests/ipc_client_events.rs
+++ b/synergos-core/tests/ipc_client_events.rs
@@ -15,12 +15,25 @@ use synergos_ipc::command::IpcCommand;
 use synergos_ipc::event::IpcEvent;
 use synergos_ipc::response::IpcResponse;
 use synergos_ipc::transport::{IpcTransport, ServerMessage};
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
 use tokio::io::duplex;
 use tokio::sync::{broadcast, Mutex};
 
 fn make_ctx() -> Arc<ServiceContext> {
     let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
     let (shutdown_tx, _) = broadcast::channel(1);
+    let quic = Arc::new(QuicManager::new(
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        },
+        Arc::new(Identity::generate()),
+    ));
     Arc::new(ServiceContext {
         event_bus: event_bus.clone(),
         project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
@@ -32,6 +45,7 @@ fn make_ctx() -> Arc<ServiceContext> {
         net_config: None,
         catalogs: Arc::new(dashmap::DashMap::new()),
         content_store: Arc::new(synergos_net::content::MemoryContentStore::new()),
+        quic,
     })
 }
 

--- a/synergos-core/tests/ipc_handlers.rs
+++ b/synergos-core/tests/ipc_handlers.rs
@@ -11,11 +11,24 @@ use synergos_core::presence::PresenceService;
 use synergos_core::project::ProjectManager;
 use synergos_ipc::command::IpcCommand;
 use synergos_ipc::response::IpcResponse;
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
 use tokio::sync::broadcast;
 
 fn make_ctx() -> Arc<ServiceContext> {
     let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
     let (shutdown_tx, _) = broadcast::channel(1);
+    let quic = Arc::new(QuicManager::new(
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        },
+        Arc::new(Identity::generate()),
+    ));
     Arc::new(ServiceContext {
         event_bus: event_bus.clone(),
         project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
@@ -27,6 +40,7 @@ fn make_ctx() -> Arc<ServiceContext> {
         net_config: None,
         catalogs: Arc::new(dashmap::DashMap::new()),
         content_store: Arc::new(synergos_net::content::MemoryContentStore::new()),
+        quic,
     })
 }
 

--- a/synergos-core/tests/ipc_integration.rs
+++ b/synergos-core/tests/ipc_integration.rs
@@ -14,12 +14,25 @@ use synergos_core::project::ProjectManager;
 use synergos_ipc::command::IpcCommand;
 use synergos_ipc::response::IpcResponse;
 use synergos_ipc::transport::IpcTransport;
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
 use tokio::io::duplex;
 use tokio::sync::broadcast;
 
 fn make_ctx() -> Arc<ServiceContext> {
     let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
     let (shutdown_tx, _) = broadcast::channel(1);
+    let quic = Arc::new(QuicManager::new(
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        },
+        Arc::new(Identity::generate()),
+    ));
     Arc::new(ServiceContext {
         event_bus: event_bus.clone(),
         project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
@@ -31,6 +44,7 @@ fn make_ctx() -> Arc<ServiceContext> {
         net_config: None,
         catalogs: Arc::new(dashmap::DashMap::new()),
         content_store: Arc::new(synergos_net::content::MemoryContentStore::new()),
+        quic,
     })
 }
 

--- a/synergos-core/tests/ipc_subscribe.rs
+++ b/synergos-core/tests/ipc_subscribe.rs
@@ -17,12 +17,25 @@ use synergos_ipc::command::IpcCommand;
 use synergos_ipc::event::{EventCategory, EventFilter, IpcEvent};
 use synergos_ipc::response::IpcResponse;
 use synergos_ipc::transport::{IpcTransport, ServerMessage};
+use synergos_net::config::QuicConfig;
+use synergos_net::identity::Identity;
+use synergos_net::quic::QuicManager;
 use tokio::io::duplex;
 use tokio::sync::{broadcast, Mutex};
 
 fn make_ctx() -> Arc<ServiceContext> {
     let event_bus: SharedEventBus = Arc::new(CoreEventBus::new());
     let (shutdown_tx, _) = broadcast::channel(1);
+    let quic = Arc::new(QuicManager::new(
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        },
+        Arc::new(Identity::generate()),
+    ));
     Arc::new(ServiceContext {
         event_bus: event_bus.clone(),
         project_manager: Arc::new(ProjectManager::new(event_bus.clone())),
@@ -34,6 +47,7 @@ fn make_ctx() -> Arc<ServiceContext> {
         net_config: None,
         catalogs: Arc::new(dashmap::DashMap::new()),
         content_store: Arc::new(synergos_net::content::MemoryContentStore::new()),
+        quic,
     })
 }
 

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -60,6 +60,10 @@ pub enum IpcCommand {
     PeerConnect { project_id: String, peer_id: String },
     /// 指定ピアを切断
     PeerDisconnect { peer_id: String },
+    /// peer-info HTTP servlet (URL) 経由で bootstrap 情報を取得 → QUIC 直結する。
+    /// `url` は `https://host[:port]` 形式 (path は自動で `/peer-info` を付与)。
+    /// invite token を必要としないクロスマシン peer 追加経路。
+    PeerAddByUrl { project_id: String, url: String },
 
     // ── ファイル転送 ──
     /// ファイル転送リクエスト
@@ -196,6 +200,14 @@ impl IpcCommand {
                 check_id("peer_id", peer_id)
             }
             Self::PeerDisconnect { peer_id } => check_id("peer_id", peer_id),
+            Self::PeerAddByUrl { project_id, url } => {
+                check_id("project_id", project_id)?;
+                check_id("url", url)?;
+                if !(url.starts_with("http://") || url.starts_with("https://")) {
+                    return Err("url must start with http:// or https://".into());
+                }
+                Ok(())
+            }
 
             Self::TransferRequest {
                 project_id,


### PR DESCRIPTION
## Summary

invite token を必要としないクロスマシン peer 追加経路。`peer add-url <https-url>` で peer-info サーブレット (#46) から bootstrap 情報を取得し、QUIC 直結する。

## Use case

```bash
# Windows 側 (host)
synergos-core peer add-url myproj https://node1.example.com
```

## Flow

1. `https://<host>/peer-info` に HTTPS GET (timeout 10s)
2. レスポンスから `peer_id` + `quic_endpoint` + `protocol_version` を取得
3. `protocol_version` 不一致なら拒否
4. `quic_endpoint` の IP が unspecified なら URL の hostname を DNS 解決して置換 (IPv6 優先)
5. `quic.connect(peer_id, addr, "synergos")` で S1 仕様の真性認証 + 接続確立
6. PresenceService に登録 → Connected 状態遷移

## Changes

### synergos-ipc
- `IpcCommand::PeerAddByUrl { project_id, url }` 追加
- `validate()` で URL prefix チェック

### synergos-core
- 新モジュール `peer_bootstrap` (BootstrapError + bootstrap_from_url)
- `dispatch_command` に PeerAddByUrl ハンドラ
- `ServiceContext.quic: Arc<QuicManager>` 追加
- CLI `peer add-url <project> <url>` 追加
- reqwest 0.12 依存追加 (rustls-tls)

## Security

- `quic.connect` は S1 仕様で expected_peer_id 必須 → サーブレットが偽の peer_id を返しても TLS handshake で拒否される
- /peer-info 自体の認証はまだ無し (PR-2 と整合、将来 Tower layer で対応)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib -p synergos-core --release` → 15 pass (9 既存 + 6 新規)
- [x] `cargo test --lib -p synergos-ipc --release` → 12 pass (回帰なし)
- [ ] CI (Linux/macOS/Windows) で full integration test green
- [ ] 実機: AWS daemon (PR-2 servlet 起動) ← Windows daemon の `peer add-url` で接続確立確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)