### PR TITLE
feat(net,core): bootstrap_urls config — auto peer-add on daemon startup

### DIFF
--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -302,6 +302,50 @@ impl Daemon {
                 })
             });
 
+        // bootstrap_urls: 起動時に config 指定の peer-info URL に自動接続する。
+        // 失敗は warn で記録するだけで daemon 起動は継続する (best-effort)。
+        let bootstrap_task = if !self.net.net_config.bootstrap_urls.is_empty() {
+            let urls = self.net.net_config.bootstrap_urls.clone();
+            let quic = self.net.quic.clone();
+            let presence = self.ctx.presence.clone();
+            Some(tokio::spawn(async move {
+                for url in urls {
+                    match crate::peer_bootstrap::bootstrap_from_url(
+                        &url,
+                        &quic,
+                        std::time::Duration::from_secs(10),
+                    )
+                    .await
+                    {
+                        Ok(peer_id) => {
+                            tracing::info!(
+                                "bootstrap connected to {url}: peer_id={}",
+                                peer_id.short()
+                            );
+                            let registration = crate::presence::NodeRegistration {
+                                peer_id: peer_id.clone(),
+                                display_name: peer_id.to_string(),
+                                endpoints: vec![],
+                                project_ids: vec![],
+                            };
+                            if let Err(e) = presence.register_node(registration).await {
+                                tracing::warn!("bootstrap {url}: register_node failed: {e}");
+                                continue;
+                            }
+                            let _ = presence
+                                .update_node_state(&peer_id, crate::presence::PeerState::Connected)
+                                .await;
+                        }
+                        Err(e) => {
+                            tracing::warn!("bootstrap {url} failed: {e}");
+                        }
+                    }
+                }
+            }))
+        } else {
+            None
+        };
+
         // IPC サーバーを実行（シャットダウンまでブロック）
         ipc_server.run().await?;
 
@@ -314,6 +358,9 @@ impl Daemon {
         gossip_fanout_task.abort();
         catalog_sync_task.abort();
         if let Some(t) = peer_info_task {
+            t.abort();
+        }
+        if let Some(t) = bootstrap_task {
             t.abort();
         }
 

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -23,6 +23,13 @@ pub struct NetConfig {
     /// `127.0.0.1:7780` を設定し、Cloudflare Tunnel 等で外部に publish する想定。
     #[serde(default)]
     pub peer_info_listen_addr: Option<SocketAddr>,
+    /// 起動時に自動 bootstrap する peer-info サーブレット URL 群。
+    /// 各 URL に対して `peer add-url` 相当 (`HTTPS GET /peer-info` → QUIC connect)
+    /// を非同期に発火し、成功・失敗とも `tracing::info` / `warn` で記録する。
+    /// 失敗しても daemon 起動は継続する (best-effort)。
+    /// 例: `["https://node1.example.com", "https://node2.example.com"]`
+    #[serde(default)]
+    pub bootstrap_urls: Vec<String>,
 }
 
 /// CatalogManager のチューニングパラメータ。
@@ -263,6 +270,7 @@ impl Default for NetConfig {
             },
             catalog: CatalogConfig::default(),
             peer_info_listen_addr: None,
+            bootstrap_urls: Vec::new(),
         }
     }
 }
@@ -312,5 +320,17 @@ mod tests {
         }"#;
         let qcfg: QuicConfig = serde_json::from_str(json).expect("json parse");
         assert!(qcfg.listen_addr.is_none());
+    }
+
+    #[test]
+    fn bootstrap_urls_defaults_to_empty() {
+        let cfg = NetConfig::default();
+        assert!(cfg.bootstrap_urls.is_empty());
+    }
+
+    #[test]
+    fn peer_info_listen_addr_defaults_to_none() {
+        let cfg = NetConfig::default();
+        assert!(cfg.peer_info_listen_addr.is_none());
     }
 }


### PR DESCRIPTION
## Summary

config に `bootstrap_urls: Vec<String>` を追加。daemon 起動時に各 URL に対して `peer add-url` 相当の bootstrap (HTTPS GET /peer-info → QUIC connect) を実行する。

## Use case

```toml
# synergos-net.toml
bootstrap_urls = [
  "https://node1.example.com",
  "https://node2.example.com",
]
```

クライアント PC が再起動するたびに `peer add-url` を手動で叩かなくて済む。失敗は warn ログだけで daemon 起動は継続 (best-effort)。

## Changes

- `NetConfig::bootstrap_urls: Vec<String>` (`#[serde(default)]`)
- `Daemon::run` で task を spawn して順番に bootstrap、PresenceService 登録、Connected 状態へ
- shutdown 時に abort
- 単体テスト追加 (`bootstrap_urls_defaults_to_empty` / `peer_info_listen_addr_defaults_to_none`)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --lib -p synergos-net --release` → 65 pass (回帰なし、+2 新規)
- [x] `cargo test --lib -p synergos-core --release` → 15 pass (回帰なし)
- [ ] CI green
- [ ] 実機: Windows daemon に `bootstrap_urls = ["https://node1.example.com"]` 設定して再起動 → ログ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)