### PR TITLE
ci: install Tauri Linux deps for clippy/test/coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
       - name: Cache cargo registry & build
         uses: actions/cache@v4
         with:
@@ -56,6 +61,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install Tauri Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
       - name: Cache cargo registry & build
         uses: actions/cache@v4
         with:
@@ -83,6 +94,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
       - name: Install cargo-llvm-cov
         run: cargo install --locked cargo-llvm-cov
       - name: Cache cargo registry & build


### PR DESCRIPTION
## Summary

PR #49 で `synergos-tauri` を追加したが、Tauri 2 は Linux で `webkit2gtk-4.1` / `glib-2.0` / `gtk-3` / `libsoup-3.0` を要求する。Ubuntu CI runner にはこれらが含まれず `pkg-config` が失敗 → clippy / test (ubuntu) / coverage が落ちる。

各 Linux job の前に `apt-get install` ステップを追加。

## Affected jobs

- ✅ Clippy (always Linux)
- ✅ Test (matrix の `ubuntu-latest` のみ条件付きインストール)
- ✅ Coverage (always Linux)
- ➖ Test (windows / macos): 不要 (WebView2 / WKWebView がシステム側)
- ➖ Rustfmt: 不要 (compile しない)
- ➖ Security audit: 不要

## Why this wasn't caught locally

ローカルは Windows で開発しており、Windows の Tauri は WebView2 を使うため追加 system deps が要らない。Linux でビルドして初めて欠落に気付く構造。

## Test plan

- [ ] CI 全 job green に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)