### PR TITLE
feat(core): quic_advertised_addr "auto" — discover public IPv6 via HTTPS

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,371 @@
+# AWS Graviton (ARM64) セットアップガイド
+
+Synergos を AWS の ARM64 (Graviton) インスタンス上に立ち上げるための完全手順。
+Linux ARM64 専用ビルドは配布していないが、ARM 阻害コードは無いのでネイティブビルドで動作する。
+
+`synergos-relay` (中継だけ) と `synergos-core` (フルピア) で目的が違うので両方記載。
+
+> **前提**: Cloudflare Tunnel は Web ダッシュボード (Zero Trust → Networks → Tunnels) で
+> 作成済み。hostname → ingress のルーティング設定は §2.5 を参照。
+> 本ガイドは EC2 側で **コネクタトークンを使って cloudflared を接続するだけ**。
+
+---
+
+## 0. EC2 を用意
+
+- **インスタンス**: `t4g.small` (relay) / `t4g.medium` (core, ビルド時)
+  - 必ず Graviton 系 (`t4g` / `c7g` / `m7g`)
+- **AMI**: Ubuntu 22.04 LTS (arm64) 推奨
+  - Amazon Linux 2023 でも可だが、本ガイドは Ubuntu 前提
+- **Security Group**: SSH (22) のみ inbound 許可
+  - 他は全部 cloudflared 経由なので閉じてよい
+
+```bash
+ssh ubuntu@<EC2 public ip>
+```
+
+---
+
+## 1. ビルド (両シナリオ共通)
+
+```bash
+# --- 依存パッケージ ---
+sudo apt update
+sudo apt install -y build-essential pkg-config libssl-dev git
+
+# --- Rust toolchain ---
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+. "$HOME/.cargo/env"
+
+# --- Synergos clone (private repo の場合は deploy key/PAT を仕込む) ---
+git clone https://github.com/<your-org>/Synergos.git
+cd Synergos
+
+# --- ビルド (relay と core だけ。GUI は不要なので省略) ---
+cargo build --release -p synergos-relay -p synergos-core
+
+# 成果物
+ls target/release/synergos-{relay,core}
+```
+
+t4g.medium で初回 ~10-15 分。完了後はインスタンスタイプを `t4g.small` に下げてもよい
+(実行は軽い)。
+
+---
+
+## 2. cloudflared をコネクタとしてインストール
+
+Cloudflare ダッシュボードから **コネクタトークン** を取得済み前提:
+
+1. Zero Trust → Networks → Tunnels → 該当 Tunnel を開く
+2. "Install connector" ペインで **Linux / arm64 / Debian** を選ぶ
+3. 表示される `cloudflared service install <TOKEN>` の `<TOKEN>` 部分をコピー
+
+EC2 上で:
+
+```bash
+# --- cloudflared インストール (Cloudflare 公式 deb, arm64) ---
+curl -L --output cloudflared.deb \
+  https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64.deb
+sudo dpkg -i cloudflared.deb
+cloudflared --version
+
+# --- コネクタとして登録 (ダッシュボードのトークンを貼る) ---
+sudo cloudflared service install <TOKEN>
+```
+
+これで `cloudflared.service` が systemd に登録され、自動起動済み。動作確認:
+
+```bash
+systemctl status cloudflared
+journalctl -u cloudflared -f          # "Registered tunnel connection" が見えれば OK
+cloudflared tunnel list               # ダッシュボードに登録された tunnel が並ぶ
+```
+
+> ingress (どの hostname をどのローカルポートに繋ぐか) は **すべてダッシュボード側で管理**。
+> EC2 上に `config.yml` を置く必要は無い。
+
+---
+
+## 2.5 ダッシュボードで URL (Public Hostname) を設定する
+
+EC2 側のコネクタが緑色 (HEALTHY) になったら、Cloudflare ダッシュボードで
+hostname → ローカルサービスのルーティングを設定する。
+
+### 手順
+
+1. **Zero Trust → Networks → Tunnels** で対象 Tunnel を開く
+2. **Public Hostname** タブ → **Add a public hostname** をクリック
+3. 以下を入力:
+
+| 項目 | 値 (シナリオ A: relay) | 値 (シナリオ B: core) |
+|---|---|---|
+| **Subdomain** | `relay` (任意) | `node1` (任意) |
+| **Domain** | Cloudflare DNS に登録済みのドメインを選択 (例 `example.com`) | 同左 |
+| **Path** | 空 | 空 |
+| **Service Type** | `HTTP` | `TCP` |
+| **URL** | `localhost:8080` | `localhost:7777` |
+
+4. **Save hostname** で保存
+
+これだけで `https://relay.example.com` (TLS は Cloudflare 終端) → EC2 上の
+`http://localhost:8080` に到達する経路ができる。DNS レコードもダッシュボードが
+自動で `CNAME` を張ってくれるので別途 DNS 設定は不要。
+
+### 補足: Additional application settings
+
+WebSocket を扱う場合 (relay 用途) は `Additional application settings` →
+`TLS` → `No TLS Verify: Off` のままで OK (localhost 平文 HTTP なので)。
+`Connection` → デフォルトのままで WebSocket upgrade は自動透過する。
+
+### 反映確認
+
+```bash
+# ローカル PC から
+curl -i https://relay.example.com/
+# → 426 Upgrade Required (= relay は WS 待ち) が返れば疎通 OK
+```
+
+ダッシュボード側の変更は **EC2 の cloudflared を再起動しなくても即時反映**される
+(コネクタが Cloudflare Edge から ingress 設定を pull する設計)。
+
+---
+
+## 3-A. シナリオ A: synergos-relay を立てる (推奨)
+
+ダッシュボード側の ingress 設定: 例えば `relay.example.com → http://localhost:8080`。
+
+### 3-A-1. systemd unit を作る
+
+`/etc/systemd/system/synergos-relay.service` を作成 (コピペでそのまま実行):
+
+```bash
+sudo tee /etc/systemd/system/synergos-relay.service > /dev/null <<'EOF'
+[Unit]
+Description=Synergos WebSocket Relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/Synergos
+Environment=RUST_LOG=synergos_relay=info
+ExecStart=/home/ubuntu/Synergos/target/release/synergos-relay
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+### 3-A-2. 起動
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now synergos-relay
+
+# 状態確認
+ls -l /etc/systemd/system/synergos-relay.service   # ファイルが存在するか
+systemctl status synergos-relay
+journalctl -u synergos-relay -f
+```
+
+> `Failed to enable unit: Unit file synergos-relay.service does not exist.` が出る場合、
+> 上記 `sudo tee` ステップが実行されていない。`ls -l` でファイル存在を確認すること。
+
+成功ログ: `relay ready on 0.0.0.0:8080`
+
+### 3-A-3. クライアント側の設定
+
+ローカルの Synergos `config.toml` で relay 経由を強制したいなら:
+
+```toml
+force_relay_only = true        # AWS 経由を強制したい場合
+```
+
+クライアントが relay に WebSocket 接続するエンドポイントは
+`wss://<ダッシュボードで設定した hostname>/` (Cloudflare Tunnel が TLS を終端)。
+
+---
+
+## 3-B. シナリオ B: synergos-core (フルピア) を立てる
+
+ダッシュボード側の ingress 設定: 例えば `node1.example.com → tcp://localhost:7777`。
+
+> **重要**: `synergos-core` の `tunnel.hostname` を空でない値に設定すると、daemon が
+> 内部で `cloudflared tunnel run --hostname <name>` を spawn する設計になっている
+> (`synergos-net/src/tunnel/mod.rs:336-340`)。これは **cert.pem ベースの旧 named tunnel
+> 方式** を前提としており、Web ダッシュボード管理 (コネクタトークン) と併用すると
+> 二重起動・二重接続になる。
+>
+> 本セットアップでは:
+>
+> 1. `tunnel.hostname = ""` にして core 内蔵の cloudflared spawn を無効化
+> 2. 外部の `cloudflared.service` (手順 2) が token 経由で全 ingress を担う
+>
+> という分離構成にする。
+
+### 3-B-1. 設定ファイル
+
+**`/home/ubuntu/.config/synergos/synergos-net.toml`**
+
+```toml
+[tunnel]
+api_token_ref = ""
+hostname = ""                         # 空: 内蔵 cloudflared 起動を抑止
+allow_simulation = false
+auto_restart = true
+restart_base_ms = 1000
+restart_max_ms = 60000
+
+[mesh]
+doh_endpoint = "https://cloudflare-dns.com/dns-query"
+dns_servers = []
+turn_servers = []
+stun_servers = []
+probe_timeout_ms = 3000
+
+[quic]
+max_concurrent_streams = 100
+idle_timeout_ms = 30000
+max_udp_payload_size = 1452
+enable_0rtt = false
+
+[dht]
+k_bucket_size = 20
+routing_refresh_secs = 60
+peer_ttl_secs = 120
+
+[gossipsub]
+mesh_n = 6
+mesh_n_low = 4
+mesh_n_high = 12
+heartbeat_interval_ms = 1000
+message_cache_size = 1000
+
+[stream_allocation]
+large_ratio = 60
+medium_ratio = 30
+small_ratio = 10
+
+[speed_test]
+enabled = true
+retest_interval_secs = 300
+probe_count = 10
+
+[peer_selection]
+bandwidth_weight = 0.7
+stability_weight = 0.3
+recalculate_interval_secs = 60
+
+[monitor]
+snapshot_interval_ms = 1000
+history_size = 3600
+graph_sample_interval_secs = 1
+```
+
+### 3-B-2. systemd unit
+
+`/etc/systemd/system/synergos-core.service` を作成:
+
+```bash
+# ubuntu ユーザの /run/user/1000 を SSH 切断後も保持 (重要)
+sudo loginctl enable-linger ubuntu
+
+sudo tee /etc/systemd/system/synergos-core.service > /dev/null <<'EOF'
+[Unit]
+Description=Synergos Core Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/Synergos
+Environment=RUST_LOG=synergos_core=info,synergos_net=info
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+ExecStart=/home/ubuntu/Synergos/target/release/synergos-core start --config /home/ubuntu/.config/synergos/synergos-net.toml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now synergos-core
+journalctl -u synergos-core -f
+```
+
+> **重要**: `Environment=XDG_RUNTIME_DIR=/run/user/1000` と `loginctl enable-linger`
+> はセットで必須。これが無いと daemon の IPC ソケットが `/tmp/synergos/synergos.sock`
+> に作られ、対話 SSH の CLI (`XDG_RUNTIME_DIR=/run/user/1000`) からは
+> `Daemon not running` で見えない。
+>
+> `id ubuntu` で UID が 1000 でない場合は `/run/user/<実 UID>` に書き換えること。
+
+成功ログ: `Synergos core daemon started (PID: ..., peer_id=...)`
+
+### 3-B-3. プロジェクト作成 → 招待 token 発行
+
+```bash
+# AWS 側 (host)
+./target/release/synergos-core project open myproj /home/ubuntu/projects/myproj -n "MyProj"
+./target/release/synergos-core project invite myproj
+# → "Invite token: inv-xxxxxxxxxxxxx" を控える
+
+# ローカル側
+./target/release/synergos-core project join inv-xxxxxxxxxxxxx /path/to/local/myproj
+./target/release/synergos-core peer list myproj    # AWS ノードが見えれば成功
+```
+
+---
+
+## 動作確認チートシート
+
+```bash
+# cloudflared コネクタの接続状況
+systemctl status cloudflared
+journalctl -u cloudflared --since "5 min ago"
+
+# relay の WS が外から見えるか (ローカル PC から)
+curl -i https://<dashboard で設定した hostname>/   # 426 Upgrade Required が出れば OK
+
+# core daemon が応答するか (AWS 上)
+./target/release/synergos-core status
+./target/release/synergos-core network
+```
+
+---
+
+## つまずきやすい点
+
+| 症状 | 対処 |
+|---|---|
+| `Daemon not running` (CLI から) | systemd で立てた daemon は `XDG_RUNTIME_DIR` 未設定だと socket を `/tmp/synergos/synergos.sock` に作る。一方 SSH 越しの CLI は `/run/user/<uid>/synergos/synergos.sock` を見る → 不一致。unit に `Environment=XDG_RUNTIME_DIR=/run/user/1000` + `loginctl enable-linger ubuntu` を入れる (3-B-2 参照) |
+| `cloudflared service install` が "already installed" で失敗 | 既に登録済み。`sudo systemctl restart cloudflared` で再接続。トークン更新時は `sudo cloudflared service uninstall` → 再 install |
+| ダッシュボードに connector が "inactive" のまま | `journalctl -u cloudflared -n 50` を確認。多くは時刻ズレ (chrony 確認) か、SG outbound 443 が閉じている |
+| シナリオ B で接続が二重に見える | `tunnel.hostname = ""` になっているか再確認。空でないと core が独自 cloudflared を spawn する |
+| `quinn` の UDP が通らない | Cloudflare Tunnel は HTTP/WebSocket primary。純 UDP/QUIC を Tunnel 越しに通すのは設計上不向き。AWS では **relay (WS) シナリオ A が現実解** |
+| EC2 t4g.small でビルドが OOM kill | swap 追加 (`fallocate -l 4G /swapfile` ...) かビルド時だけ medium 以上に上げる |
+
+---
+
+## 推奨
+
+最初は **シナリオ A (relay) だけ** で動かすのが安定。クライアント間 P2P は
+IPv6 / UPnP / Tunnel で互いに繋がり、AWS は「直接繋がらないペアの中継」だけを担う設計
+(`force_relay_only` を使うと全ピアが必ず AWS 経由)。
+シナリオ B (core を AWS に常設) は QUIC を Cloudflare Tunnel 経由で通す筋が悪いので、
+必要になってからで良い。
+
+---
+
+## 関連ドキュメント
+
+- [docs/getting-started.md](docs/getting-started.md): ローカルでの最小 2 ノード手順
+- [docs/platforms.md](docs/platforms.md): OS ごとの前提条件
+- [docs/projects-and-peers.md](docs/projects-and-peers.md): CLI リファレンス
+- [DESIGN.md](DESIGN.md): 内部アーキテクチャ

--- a/synergos-core/src/peer_info_server.rs
+++ b/synergos-core/src/peer_info_server.rs
@@ -58,9 +58,16 @@ struct AppState {
 }
 
 async fn handle_peer_info(State(s): State<AppState>) -> Json<PeerInfoResponse> {
-    let endpoint = match &s.advertised_addr {
-        Some(a) => Some(a.clone()),
-        None => s.quic.local_addr().await.map(|a| a.to_string()),
+    let local = s.quic.local_addr().await;
+    let endpoint = match s.advertised_addr.as_deref() {
+        // "auto" → if-addrs で global IPv6 を 1 件選び、bind ポートと組み合わせる。
+        // 見つからなければ bind addr (= local_addr) を返す safe fallback。
+        Some("auto") => match (auto_advertise_ipv6().await, local) {
+            (Some(v6), Some(la)) => Some(format!("[{}]:{}", v6, la.port())),
+            _ => local.map(|a| a.to_string()),
+        },
+        Some(literal) => Some(literal.to_string()),
+        None => local.map(|a| a.to_string()),
     };
     Json(PeerInfoResponse {
         peer_id: s.peer_id.to_string(),
@@ -68,6 +75,79 @@ async fn handle_peer_info(State(s): State<AppState>) -> Json<PeerInfoResponse> {
         protocol_version: PEER_INFO_PROTOCOL_VERSION,
         server_name: s.server_name.clone(),
     })
+}
+
+/// `quic_advertised_addr = "auto"` 時に呼ばれる。
+///
+/// 戦略:
+///   1. **HTTPS 経由で外部 echo サービスに公開 IP を問い合わせる** (Win/Linux/macOS 共通)。
+///      NAT/LB/CGNAT 越しでも "外から見えるアドレス" が取れる。
+///   2. fallback: ローカル NIC を列挙して global scope IPv6 を採用 (`if-addrs`)。
+///      EC2 のように global IPv6 が直接 NIC に振られている環境向け。
+///   3. どちらも失敗 → `None` (handler 側で local_addr に fallback)。
+async fn auto_advertise_ipv6() -> Option<std::net::Ipv6Addr> {
+    if let Some(v6) = discover_public_ipv6_via_https().await {
+        tracing::info!("auto-advertise: discovered public IPv6 via HTTPS: {}", v6);
+        return Some(v6);
+    }
+    if let Some(v6) = synergos_net::promotion::probe_ipv6_global()
+        .await
+        .into_iter()
+        .next()
+    {
+        tracing::info!(
+            "auto-advertise: HTTPS probe failed, using local NIC IPv6: {}",
+            v6
+        );
+        return Some(v6);
+    }
+    tracing::warn!("auto-advertise: no public IPv6 discoverable; falling back to bind addr");
+    None
+}
+
+/// HTTPS で IP echo サービスに問い合わせる。
+///
+/// IPv6 を強制したいので IPv6-only な hostname を優先 (ipv6.icanhazip.com)。
+/// 1 件でも取れたら即返す。すべて失敗で `None`。
+async fn discover_public_ipv6_via_https() -> Option<std::net::Ipv6Addr> {
+    use std::time::Duration;
+
+    // IPv6-only / dual-stack の echo endpoints。順番に試行。
+    const ENDPOINTS: &[&str] = &[
+        "https://ipv6.icanhazip.com",
+        "https://api6.ipify.org",
+        "https://v6.ident.me",
+    ];
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("auto-advertise: reqwest client build failed: {e}");
+            return None;
+        }
+    };
+
+    for url in ENDPOINTS {
+        match client.get(*url).send().await {
+            Ok(resp) if resp.status().is_success() => match resp.text().await {
+                Ok(body) => {
+                    let trimmed = body.trim();
+                    if let Ok(std::net::IpAddr::V6(v6)) = trimmed.parse::<std::net::IpAddr>() {
+                        return Some(v6);
+                    } else {
+                        tracing::debug!("auto-advertise: {url} returned non-IPv6: {trimmed:?}");
+                    }
+                }
+                Err(e) => tracing::debug!("auto-advertise: {url} body read failed: {e}"),
+            },
+            Ok(resp) => tracing::debug!("auto-advertise: {url} status {}", resp.status()),
+            Err(e) => tracing::debug!("auto-advertise: {url} send failed: {e}"),
+        }
+    }
+    None
 }
 
 async fn handle_health() -> (StatusCode, &'static str) {
@@ -244,6 +324,41 @@ mod tests {
         let url = format!("http://{}/peer-info", addr);
         let resp = reqwest_get_json(&url).await;
         assert_eq!(resp.quic_endpoint, Some(advertised));
+    }
+
+    /// `advertised_addr = "auto"` で probe_ipv6_global が hit しないテスト環境
+    /// (CI 等) では fallback で local_addr が返ること。auto でも壊れず安全に
+    /// 動くことの確認。global IPv6 が引ける環境では別 endpoint が返るが、
+    /// 値の確認はそちら側 (probe_ipv6_global の単体テスト) に任せる。
+    #[tokio::test]
+    async fn peer_info_auto_falls_back_to_local_addr_when_no_global_ipv6() {
+        use std::net::Ipv4Addr;
+        let identity = Arc::new(Identity::generate());
+        let peer_id = identity.peer_id().clone();
+        let quic = Arc::new(QuicManager::new(qcfg(), identity));
+        let bound = quic.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+
+        let app = build_router(AppState {
+            peer_id: peer_id.clone(),
+            quic: quic.clone(),
+            server_name: "test".into(),
+            advertised_addr: Some("auto".into()),
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("http://{}/peer-info", addr);
+        let resp = reqwest_get_json(&url).await;
+        // auto は global IPv6 を引ければそれを返す。CI runner で持ってない場合は
+        // local_addr (= 127.0.0.1:port) に fallback する。どちらにしても None には
+        // ならない (bind 済みなので) ことだけ確認する。
+        assert!(resp.quic_endpoint.is_some());
+        // ポートは bind ポートと一致していること (auto / fallback どちらでも)
+        let endpoint = resp.quic_endpoint.unwrap();
+        assert!(endpoint.ends_with(&format!(":{}", bound.port())));
     }
 
     /// reqwest を入れたくないので tokio + 手書き HTTP/1.1 で GET する小ヘルパ。

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -28,7 +28,15 @@ pub struct NetConfig {
     /// Cloudflare Tunnel が Cloudflare proxied DNS の裏でホストする公開ノードでは、
     /// proxy が UDP/QUIC を通さない (HTTPS のみ) ため、ここに EC2 の **real public
     /// IPv6 / IPv4** を入れて、クライアントがそこに直接 QUIC 接続できるようにする。
-    /// 形式は `host:port` 文字列 (IP:port も hostname:port も可)。
+    ///
+    /// 形式:
+    ///   - `Some("[2406:da14:...]:7777")` — リテラル IP:port
+    ///   - `Some("hostname.example.com:7777")` — hostname:port
+    ///   - `Some("auto")` — **公開 IPv6 を自動検出**。HTTPS echo サービス
+    ///     (`ipv6.icanhazip.com` 等) に問い合わせて NAT/LB 越しでも世界から見える
+    ///     アドレスを取得する。失敗時は OS NIC の global IPv6 列挙にフォールバック。
+    ///     ポートは `quic.listen_addr` のものを使う。Win/Linux/macOS 共通動作
+    ///   - `None` — `quic.local_addr()` (bind addr) をそのまま返す
     #[serde(default)]
     pub quic_advertised_addr: Option<String>,
     /// 起動時に自動 bootstrap する peer-info サーブレット URL 群。

--- a/synergos-net/src/promotion.rs
+++ b/synergos-net/src/promotion.rs
@@ -108,7 +108,10 @@ impl NetCapabilities {
 }
 
 /// global IPv6 アドレスを列挙する。link-local / loopback / unique-local は除外。
-async fn probe_ipv6_global() -> Vec<Ipv6Addr> {
+///
+/// 公開 helper として `peer_info_server` の auto-advertise や connectivity
+/// probe から呼ばれる。
+pub async fn probe_ipv6_global() -> Vec<Ipv6Addr> {
     // if-addrs は同期 API なので spawn_blocking で逃がす
     tokio::task::spawn_blocking(|| {
         if_addrs::get_if_addrs()


### PR DESCRIPTION
## Summary

`quic_advertised_addr` に **`auto`** を指定すると、daemon 起動時に HTTPS で公開 IPv6 を自動取得する。リテラル IP:port を人手で書く運用 (PR #51) は EC2 の IPv6 が変わるたびに編集が要るので、`auto` で自動化。

## 戦略 (Win/Linux/macOS 共通)

1. **HTTPS echo サービスに問い合わせ** — 外から見えるアドレスを取得。NAT/LB/CGNAT 越しでも正しい値が取れる。
   - `https://ipv6.icanhazip.com` → `https://api6.ipify.org` → `https://v6.ident.me` を順次試行 (5s timeout)
2. **fallback**: `if-addrs` で NIC を列挙し global IPv6 を採用
3. どちらも不可 → handler 側で `quic.local_addr()` (bind addr) を返す safe fallback

## Changes

- `synergos-net/src/promotion.rs`: `probe_ipv6_global` を `pub` に (fallback 用)
- `synergos-core/src/peer_info_server.rs`:
  - `auto_advertise_ipv6()` 追加 (HTTPS → NIC enum の 2 段 fallback)
  - `discover_public_ipv6_via_https()` 追加 (3 endpoint 順次試行)
  - 新テスト `peer_info_auto_falls_back_to_local_addr_when_no_global_ipv6`
- `synergos-net/src/config.rs`: `quic_advertised_addr` の docstring 更新

## Use case

```toml
peer_info_listen_addr = "127.0.0.1:7780"
quic_advertised_addr = "auto"

[quic]
listen_addr = "[::]:7777"
```

## Test plan

- [x] fmt / clippy / lib tests (core: 17 / net: 71)
- [ ] CI green
- [ ] 実機: EC2 で auto 設定 → /peer-info の JSON に EC2 の real public IPv6 が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)