### PR TITLE
feat(core,tauri): expose peer synergos_version in /peer-info + Peers UI

### DIFF
--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -352,23 +352,32 @@ impl Daemon {
                     )
                     .await
                     {
-                        Ok(peer_id) => {
+                        Ok(result) => {
                             tracing::info!(
-                                "bootstrap connected to {url}: peer_id={}",
-                                peer_id.short()
+                                "bootstrap connected to {url}: peer_id={} synergos_version={}",
+                                result.peer_id.short(),
+                                if result.synergos_version.is_empty() {
+                                    "unknown"
+                                } else {
+                                    &result.synergos_version
+                                }
                             );
                             let registration = crate::presence::NodeRegistration {
-                                peer_id: peer_id.clone(),
-                                display_name: peer_id.to_string(),
+                                peer_id: result.peer_id.clone(),
+                                display_name: result.peer_id.to_string(),
                                 endpoints: vec![],
                                 project_ids: vec![],
+                                synergos_version: result.synergos_version,
                             };
                             if let Err(e) = presence.register_node(registration).await {
                                 tracing::warn!("bootstrap {url}: register_node failed: {e}");
                                 continue;
                             }
                             let _ = presence
-                                .update_node_state(&peer_id, crate::presence::PeerState::Connected)
+                                .update_node_state(
+                                    &result.peer_id,
+                                    crate::presence::PeerState::Connected,
+                                )
                                 .await;
                         }
                         Err(e) => {

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -897,6 +897,7 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     rtt_ms: n.rtt_ms.unwrap_or(0),
                     bandwidth_bps: n.bandwidth_bps,
                     state: format!("{:?}", n.state),
+                    synergos_version: n.synergos_version,
                 })
                 .collect();
             IpcResponse::PeerList(peers)
@@ -911,6 +912,7 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                 display_name: peer_id.clone(),
                 endpoints: vec![],
                 project_ids: vec![project_id],
+                synergos_version: String::new(),
             };
             match ctx.presence.register_node(registration).await {
                 Ok(_) => {
@@ -947,14 +949,14 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                 };
             }
             // /peer-info GET → QUIC connect (S1 真性認証込み)
-            let peer_id = match crate::peer_bootstrap::bootstrap_from_url(
+            let result = match crate::peer_bootstrap::bootstrap_from_url(
                 &url,
                 &ctx.quic,
                 std::time::Duration::from_secs(10),
             )
             .await
             {
-                Ok(pid) => pid,
+                Ok(r) => r,
                 Err(e) => {
                     return IpcResponse::Error {
                         code: 2,
@@ -962,12 +964,14 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                     };
                 }
             };
+            let peer_id = result.peer_id.clone();
             // PresenceService に登録 → Connected に遷移
             let registration = crate::presence::NodeRegistration {
                 peer_id: peer_id.clone(),
                 display_name: peer_id.to_string(),
                 endpoints: vec![],
                 project_ids: vec![project_id],
+                synergos_version: result.synergos_version,
             };
             if let Err(e) = ctx.presence.register_node(registration).await {
                 return IpcResponse::Error {

--- a/synergos-core/src/peer_bootstrap.rs
+++ b/synergos-core/src/peer_bootstrap.rs
@@ -22,7 +22,15 @@ use synergos_net::types::PeerId;
 
 use crate::peer_info_server::PEER_INFO_PROTOCOL_VERSION;
 
-/// peer add-url の bootstrap 結果。成功時は確立した peer_id を返す。
+/// peer add-url の bootstrap 結果。成功時は学習した peer_id と相手の synergos
+/// バージョンを返す。
+#[derive(Debug, Clone)]
+pub struct BootstrapResult {
+    pub peer_id: PeerId,
+    /// 相手 daemon の `CARGO_PKG_VERSION`。古い peer から `""` を返されることもある
+    pub synergos_version: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum BootstrapError {
     #[error("invalid url: {0}")]
@@ -44,17 +52,20 @@ struct RemotePeerInfo {
     peer_id: String,
     quic_endpoint: Option<String>,
     protocol_version: u32,
+    #[serde(default)]
+    synergos_version: String,
 }
 
 /// URL から peer-info を取得して QUIC 接続を張る。
 ///
-/// 成功時は学習した `PeerId` を返し、`QuicManager` の internal pool に接続が登録された状態。
+/// 成功時は学習した `PeerId` と相手の synergos バージョンを `BootstrapResult` で
+/// 返し、`QuicManager` の internal pool に接続が登録された状態。
 /// 呼び出し側は presence service への登録などを別途行う。
 pub async fn bootstrap_from_url(
     base_url: &str,
     quic: &QuicManager,
     timeout: Duration,
-) -> Result<PeerId, BootstrapError> {
+) -> Result<BootstrapResult, BootstrapError> {
     // 1. URL parse + /peer-info path 付与
     let parsed =
         reqwest::Url::parse(base_url).map_err(|e| BootstrapError::InvalidUrl(format!("{e}")))?;
@@ -110,7 +121,10 @@ pub async fn bootstrap_from_url(
         .await
         .map_err(|e| BootstrapError::QuicConnect(format!("{e}")))?;
 
-    Ok(expected_peer_id)
+    Ok(BootstrapResult {
+        peer_id: expected_peer_id,
+        synergos_version: info.synergos_version,
+    })
 }
 
 fn build_peer_info_url(base: &reqwest::Url) -> reqwest::Url {

--- a/synergos-core/src/peer_info_server.rs
+++ b/synergos-core/src/peer_info_server.rs
@@ -40,10 +40,18 @@ pub struct PeerInfoResponse {
     pub protocol_version: u32,
     /// オプションのサーバ表示名 (UI 用)。匿名性が要るなら空文字に。
     pub server_name: String,
+    /// このノードの synergos-core build version (`CARGO_PKG_VERSION`)。
+    /// クライアントが互換性確認 / GUI 表示用に使う。古い peer は省略するので
+    /// `#[serde(default)]` で `""` にフォールバック。
+    #[serde(default)]
+    pub synergos_version: String,
 }
 
 /// 現在のプロトコルバージョン (bump はクライアントとの互換性を切るときのみ)
 pub const PEER_INFO_PROTOCOL_VERSION: u32 = 1;
+
+/// このバイナリの synergos-core build version。`Cargo.toml` の `[package].version` 由来。
+pub const SYNERGOS_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// servlet 共有 state。axum の `with_state` で各 handler に注入する。
 #[derive(Clone)]
@@ -73,6 +81,7 @@ async fn handle_peer_info(State(s): State<AppState>) -> Json<PeerInfoResponse> {
         quic_endpoint: endpoint,
         protocol_version: PEER_INFO_PROTOCOL_VERSION,
         server_name: s.server_name.clone(),
+        synergos_version: SYNERGOS_VERSION.to_string(),
     })
 }
 

--- a/synergos-core/src/presence/mod.rs
+++ b/synergos-core/src/presence/mod.rs
@@ -46,15 +46,21 @@ pub struct RegisteredNode {
     pub project_ids: Vec<String>,
     pub bandwidth_bps: u64,
     pub last_seen: Instant,
+    /// 相手 daemon の `CARGO_PKG_VERSION` (peer-info 経由で学習)。
+    /// 学習経路が無い peer (gossip / DHT のみ) は空文字。
+    pub synergos_version: String,
 }
 
 /// ノード登録リクエスト
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct NodeRegistration {
     pub peer_id: PeerId,
     pub display_name: String,
     pub endpoints: Vec<Route>,
     pub project_ids: Vec<String>,
+    /// 相手 daemon の `CARGO_PKG_VERSION` (peer-info 経由で取得)。
+    /// 不明な経路で得た peer (gossip 等) は空文字。
+    pub synergos_version: String,
 }
 
 /// ノード登録/削除エラー
@@ -232,6 +238,7 @@ impl PresenceService {
                     project_ids: r.active_projects,
                     bandwidth_bps: 0,
                     last_seen: r.published_at,
+                    synergos_version: String::new(),
                 })
                 .collect()
         } else {
@@ -317,6 +324,7 @@ impl NodeRegistry for PresenceService {
             project_ids: registration.project_ids.clone(),
             bandwidth_bps: 0,
             last_seen: Instant::now(),
+            synergos_version: registration.synergos_version.clone(),
         };
         self.nodes.insert(registration.peer_id.clone(), node);
 
@@ -367,6 +375,7 @@ impl NodeRegistry for PresenceService {
             project_ids: registration.project_ids.clone(),
             bandwidth_bps: 0,
             last_seen: Instant::now(),
+            synergos_version: registration.synergos_version.clone(),
         };
 
         self.nodes.insert(peer_id.clone(), node.clone());

--- a/synergos-core/tests/gossip_handlers.rs
+++ b/synergos-core/tests/gossip_handlers.rs
@@ -24,6 +24,7 @@ async fn handle_peer_status_updates_registered_node() {
         display_name: "z".into(),
         endpoints: vec![],
         project_ids: vec![],
+        synergos_version: String::new(),
     })
     .await
     .unwrap();
@@ -51,6 +52,7 @@ async fn handle_peer_status_offline_sets_disconnected() {
         display_name: "w".into(),
         endpoints: vec![],
         project_ids: vec![],
+        synergos_version: String::new(),
     })
     .await
     .unwrap();

--- a/synergos-gui/tests/ui_snapshot.rs
+++ b/synergos-gui/tests/ui_snapshot.rs
@@ -116,6 +116,7 @@ fn peers_lists_rows() {
             rtt_ms: 42,
             bandwidth_bps: 1_000_000,
             state: "Connected".into(),
+            synergos_version: "0.1.0".into(),
         }];
     });
     let mut harness = egui_kittest::Harness::new_ui(|ui| {

--- a/synergos-ipc/src/response.rs
+++ b/synergos-ipc/src/response.rs
@@ -111,6 +111,11 @@ pub struct PeerInfo {
     pub rtt_ms: u32,
     pub bandwidth_bps: u64,
     pub state: String,
+    /// 相手 daemon の `CARGO_PKG_VERSION` (peer-info 経由で学習)。
+    /// 不明な経路の peer (gossip / DHT のみ) は空文字。
+    /// 後方互換のため `#[serde(default)]` で旧 daemon にも追従。
+    #[serde(default)]
+    pub synergos_version: String,
 }
 
 /// 転送情報

--- a/synergos-tauri/frontend/src/lib/tauri.ts
+++ b/synergos-tauri/frontend/src/lib/tauri.ts
@@ -28,6 +28,8 @@ export type PeerInfo = {
   rtt_ms: number;
   bandwidth_bps: number;
   state: string;
+  /** 相手 daemon の `CARGO_PKG_VERSION` (peer-info 経由で学習)。未学習なら `""` */
+  synergos_version: string;
 };
 
 export type NetworkStatusInfo = {

--- a/synergos-tauri/frontend/src/pages/Dashboard.tsx
+++ b/synergos-tauri/frontend/src/pages/Dashboard.tsx
@@ -226,6 +226,14 @@ function PeersSection({
                 <div className="meta">
                   <div className="title">
                     {p.display_name || p.peer_id.slice(0, 12) + "…"}
+                    {p.synergos_version ? (
+                      <span
+                        className="badge gray"
+                        style={{ marginLeft: "0.5rem", fontSize: "0.65rem" }}
+                      >
+                        v{p.synergos_version}
+                      </span>
+                    ) : null}
                   </div>
                   <div className="sub">
                     {p.route} · {p.rtt_ms} ms · {formatBps(p.bandwidth_bps)}


### PR DESCRIPTION
## Summary

各 daemon の `CARGO_PKG_VERSION` を peer-info サーブレットの JSON で公開し、Peer 一覧で表示する。互換性確認 + 運用上の "対象 peer のバージョン把握" 用途。

## Changes

- **synergos-core**: `PeerInfoResponse.synergos_version` 追加、`SYNERGOS_VERSION = env!("CARGO_PKG_VERSION")`、`BootstrapResult { peer_id, synergos_version }`、`NodeRegistration` / `RegisteredNode` も version 保持
- **synergos-ipc**: `PeerInfo.synergos_version` 追加 (`#[serde(default)]`)
- **synergos-tauri**: GUI Peers タブで `v0.1.0` 等のバッジ表示。空 (= 不明) なら非表示
- 後方互換: `#[serde(default)]` で旧 peer / 旧 daemon にもフォールバック

## Test plan

- [x] fmt / clippy / cargo test --lib --workspace 全 pass
- [x] cargo build --workspace --all-targets clean
- [x] tsc -b
- [ ] CI green
- [ ] 実機: Win → AWS で peer add-url → PeerRow に `v0.1.0` バッジ

🤖 Generated with [Claude Code](https://claude.com/claude-code)