### PR TITLE
feat(core): bootstrap_urls peer を全 open project に attach

### DIFF
--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -339,10 +339,17 @@ impl Daemon {
 
         // bootstrap_urls: 起動時に config 指定の peer-info URL に自動接続する。
         // 失敗は warn で記録するだけで daemon 起動は継続する (best-effort)。
+        //
+        // bootstrap した peer は **既に open しているプロジェクト全部** に attach する。
+        // (`peer add-url` は引数 project_id を要求するが、bootstrap_urls はサーバ
+        //  自体の起動時設定なので「現時点で open している全プロジェクトの相手」と
+        //  して登録するのが妥当。これがないと `peer list myproj` に出ず、ユーザは
+        //  ノード接続済みなのに peer が見えない混乱に陥る。)
         let bootstrap_task = if !self.net.net_config.bootstrap_urls.is_empty() {
             let urls = self.net.net_config.bootstrap_urls.clone();
             let quic = self.net.quic.clone();
             let presence = self.ctx.presence.clone();
+            let project_manager = self.ctx.project_manager.clone();
             Some(tokio::spawn(async move {
                 for url in urls {
                     match crate::peer_bootstrap::bootstrap_from_url(
@@ -353,20 +360,28 @@ impl Daemon {
                     .await
                     {
                         Ok(result) => {
+                            let project_ids: Vec<String> =
+                                crate::project::ProjectConfiguration::list_projects(
+                                    &*project_manager,
+                                )
+                                .into_iter()
+                                .map(|info| info.project_id)
+                                .collect();
                             tracing::info!(
-                                "bootstrap connected to {url}: peer_id={} synergos_version={}",
+                                "bootstrap connected to {url}: peer_id={} synergos_version={} attached_projects={}",
                                 result.peer_id.short(),
                                 if result.synergos_version.is_empty() {
                                     "unknown"
                                 } else {
                                     &result.synergos_version
-                                }
+                                },
+                                project_ids.len()
                             );
                             let registration = crate::presence::NodeRegistration {
                                 peer_id: result.peer_id.clone(),
                                 display_name: result.peer_id.to_string(),
                                 endpoints: vec![],
-                                project_ids: vec![],
+                                project_ids,
                                 synergos_version: result.synergos_version,
                             };
                             if let Err(e) = presence.register_node(registration).await {


### PR DESCRIPTION
## Summary

- `bootstrap_urls` 経由で接続した peer の `NodeRegistration.project_ids` が空のまま登録されており、`peer list myproj` に出ない問題を解消
- 起動時 open している全プロジェクトに自動 attach するように `daemon.rs::run` の bootstrap タスクを修正
- `peer add-url` (引数 project_id 必須) と異なり、bootstrap_urls はサーバ起動時設定なので「現在 open している全プロジェクトの相手」として登録するのが妥当

## Background

2026-04-30 セッションの実機検証で発見された運用バグ。Win→AWS の QUIC bootstrap は確立しているが、`peer list myproj` で AWS が出ないため「ノード接続済みなのに peer が見えない」混乱が起きていた。

`bootstrap_urls` から呼ばれる `NodeRegistration` の `project_ids` が `vec![]` 固定で、`presence::list_nodes(Some(pid))` が `project_ids.contains(pid)` フィルタを通すため bootstrap peer が表示されなかった。

## Changes

`synergos-core/src/daemon.rs` の bootstrap タスクで `ProjectConfiguration::list_projects()` を呼び、open 中の全 project_id を `NodeRegistration.project_ids` に詰めて登録するようにした (+18 -3)。

## Test plan

- [x] `cargo check -p synergos-core` pass
- [x] `cargo clippy -p synergos-core --all-targets -- -D warnings` pass
- [x] `cargo test -p synergos-core --lib` 20/20 pass
- [ ] 実機: bootstrap_urls 経由で接続した peer が `peer list myproj` に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)