### PR TITLE
feat(core): クライアント側 IPv4 fallback in peer_bootstrap

### DIFF
--- a/synergos-core/src/peer_bootstrap.rs
+++ b/synergos-core/src/peer_bootstrap.rs
@@ -112,19 +112,42 @@ pub async fn bootstrap_from_url(
         .parse()
         .map_err(|e| BootstrapError::InvalidResponse(format!("invalid quic_endpoint: {e}")))?;
 
-    // 4. unspecified IP は URL host で置換
-    let connect_addr = resolve_connect_addr(&host, advertised).await?;
+    // 4. 接続候補アドレスを列挙する。
+    //    - advertised がそのまま使える場合は primary 候補に
+    //    - hostname 解決の他ファミリ (v6→v4 または v4→v6) を fallback に
+    //    片側 (典型は v6) の経路が ISP / 家庭ルータ起因で死んでいる
+    //    非対称ネットワークでも、もう片側で繋がる経路を残す。
+    let candidates = resolve_candidate_addrs(&host, advertised).await?;
 
-    // 5. QUIC connect (S1 仕様で peer_id 検証つき)
+    // 5. 各候補に順番に QUIC connect (S1 仕様で peer_id 検証つき)
     let expected_peer_id = PeerId::new(&info.peer_id);
-    quic.connect(expected_peer_id.clone(), connect_addr, "synergos")
-        .await
-        .map_err(|e| BootstrapError::QuicConnect(format!("{e}")))?;
-
-    Ok(BootstrapResult {
-        peer_id: expected_peer_id,
-        synergos_version: info.synergos_version,
-    })
+    let mut last_err: Option<BootstrapError> = None;
+    for addr in &candidates {
+        tracing::info!(
+            "bootstrap candidate {} ({}/{} for {host})",
+            addr,
+            if addr.is_ipv6() { "v6" } else { "v4" },
+            candidates.len()
+        );
+        match quic
+            .connect(expected_peer_id.clone(), *addr, "synergos")
+            .await
+        {
+            Ok(()) => {
+                return Ok(BootstrapResult {
+                    peer_id: expected_peer_id,
+                    synergos_version: info.synergos_version,
+                });
+            }
+            Err(e) => {
+                tracing::warn!("bootstrap candidate {addr} failed: {e}");
+                last_err = Some(BootstrapError::QuicConnect(format!("{addr}: {e}")));
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        BootstrapError::QuicConnect(format!("no usable address resolved for {host}"))
+    }))
 }
 
 fn build_peer_info_url(base: &reqwest::Url) -> reqwest::Url {
@@ -141,32 +164,78 @@ fn build_peer_info_url(base: &reqwest::Url) -> reqwest::Url {
     u
 }
 
-async fn resolve_connect_addr(
+/// 接続候補アドレスを優先順で列挙する。
+///
+/// - advertised が specific IP (host literal) なら、それを primary に。
+///   さらに hostname を DNS resolve して、advertised と **異なるファミリ**
+///   のアドレスがあれば fallback として末尾に追加する。
+/// - advertised が unspecified (`0.0.0.0` / `[::]`) なら、hostname を DNS
+///   resolve した全アドレス。advertised が `[::]:p` なら IPv6 を、`0.0.0.0:p`
+///   なら IPv4 を優先する。
+///
+/// これにより:
+/// - サーバの advertised が IPv6 でも、クライアントの v6 経路が壊れている
+///   場合に v4 で再試行できる
+/// - 旧来の「IPv6-first」挙動は維持される
+async fn resolve_candidate_addrs(
     host: &str,
     advertised: SocketAddr,
-) -> Result<SocketAddr, BootstrapError> {
+) -> Result<Vec<SocketAddr>, BootstrapError> {
+    let port = advertised.port();
+    let target = format!("{host}:{port}");
+
+    // DNS lookup (失敗しても advertised があれば続行する)
+    let dns: Vec<SocketAddr> = match tokio::net::lookup_host(&target).await {
+        Ok(iter) => iter.collect(),
+        Err(e) => {
+            // advertised が specific なら DNS なしでも進める
+            if !advertised.ip().is_unspecified() {
+                tracing::debug!(
+                    "DNS lookup of {host} failed but advertised is specific ({advertised}); proceeding: {e}"
+                );
+                vec![]
+            } else {
+                return Err(BootstrapError::DnsFailure {
+                    host: host.to_string(),
+                    details: format!("{e}"),
+                });
+            }
+        }
+    };
+
+    let mut out: Vec<SocketAddr> = Vec::new();
+
     if !advertised.ip().is_unspecified() {
-        return Ok(advertised);
+        // advertised の IP をそのまま primary に
+        out.push(advertised);
+        // 異なるファミリの DNS 解決があれば fallback として後ろに
+        for a in &dns {
+            if a.is_ipv6() != advertised.is_ipv6() && !out.contains(a) {
+                out.push(*a);
+            }
+        }
+        // 同ファミリでも別 IP を持っていれば末尾に積む (multi-A レコード対応)
+        for a in &dns {
+            if !out.contains(a) {
+                out.push(*a);
+            }
+        }
+    } else {
+        // unspecified の場合は DNS の結果に頼る
+        let prefer_v6 = advertised.is_ipv6();
+        let (primary, secondary): (Vec<_>, Vec<_>) =
+            dns.iter().partition(|a| a.is_ipv6() == prefer_v6);
+        out.extend(primary.iter().copied().copied());
+        out.extend(secondary.iter().copied().copied());
     }
-    let target = format!("{host}:{}", advertised.port());
-    let mut iter =
-        tokio::net::lookup_host(&target)
-            .await
-            .map_err(|e| BootstrapError::DnsFailure {
-                host: host.to_string(),
-                details: format!("{e}"),
-            })?;
-    // IPv6 を優先 (LUDIARS は IPv6-first 設計)
-    let collected: Vec<SocketAddr> = iter.by_ref().collect();
-    let chosen = collected
-        .iter()
-        .find(|a| a.is_ipv6())
-        .or_else(|| collected.first())
-        .ok_or_else(|| BootstrapError::DnsFailure {
+
+    if out.is_empty() {
+        return Err(BootstrapError::DnsFailure {
             host: host.to_string(),
             details: "no addresses returned".into(),
-        })?;
-    Ok(*chosen)
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -203,21 +272,43 @@ mod tests {
 
     /// `[::]:port` (unspecified IPv6) なら hostname 解決にフォールバックする。
     #[tokio::test]
-    async fn resolve_connect_addr_replaces_unspecified_ipv6() {
+    async fn resolve_candidates_replaces_unspecified_ipv6() {
         let advertised: SocketAddr = "[::]:7777".parse().unwrap();
         // localhost は ::1 / 127.0.0.1 に解決される
-        let resolved = resolve_connect_addr("localhost", advertised).await.unwrap();
-        assert_eq!(resolved.port(), 7777);
-        assert!(!resolved.ip().is_unspecified());
-    }
-
-    /// 具体的な IP の場合はそのまま返す (DNS lookup しない)。
-    #[tokio::test]
-    async fn resolve_connect_addr_keeps_specific() {
-        let advertised: SocketAddr = "127.0.0.1:7777".parse().unwrap();
-        let resolved = resolve_connect_addr("does-not-matter", advertised)
+        let candidates = resolve_candidate_addrs("localhost", advertised)
             .await
             .unwrap();
-        assert_eq!(resolved, advertised);
+        assert!(!candidates.is_empty());
+        assert!(candidates.iter().all(|a| a.port() == 7777));
+        assert!(candidates.iter().all(|a| !a.ip().is_unspecified()));
+        // ファミリ別の優先: advertised が v6 → v6 を先頭に
+        assert!(candidates[0].is_ipv6() || candidates.iter().all(|a| !a.is_ipv6()));
+    }
+
+    /// 具体的な IPv4 の場合は primary は advertised そのまま。
+    /// hostname 解決の v6 アドレスがあれば fallback に末尾追加される。
+    #[tokio::test]
+    async fn resolve_candidates_keeps_specific_then_alt_family() {
+        let advertised: SocketAddr = "127.0.0.1:7777".parse().unwrap();
+        let candidates = resolve_candidate_addrs("localhost", advertised)
+            .await
+            .unwrap();
+        assert!(!candidates.is_empty());
+        assert_eq!(candidates[0], advertised);
+        // localhost が ::1 を resolve すれば fallback で含まれるはず
+        // (環境差で v6 解決できないこともあるので present-or-absent のいずれも許容)
+        if candidates.len() > 1 {
+            assert!(candidates[1..].iter().any(|a| a.is_ipv6()));
+        }
+    }
+
+    /// 解決不能な host でも advertised が specific なら primary だけ返る。
+    #[tokio::test]
+    async fn resolve_candidates_specific_advertised_survives_dns_failure() {
+        let advertised: SocketAddr = "127.0.0.1:7777".parse().unwrap();
+        let candidates = resolve_candidate_addrs("does-not-resolve.invalid", advertised)
+            .await
+            .unwrap();
+        assert!(candidates.contains(&advertised));
     }
 }


### PR DESCRIPTION
## Summary

- サーバ側 advertised は #53 で v4 fallback したが、**クライアント側** の `peer_bootstrap` で v6 endpoint へ connect 失敗時に v4 で再試行する経路が無かった
- 非対称ネットワーク (Win→AWS の v6 outbound が ISP/家庭ルータ起因で死) で advertised が v6 だと bootstrap が即詰む
- `resolve_connect_addr` → `resolve_candidate_addrs` に置き換え、優先順付き候補リストを返す
- `bootstrap_from_url` は候補を順に試行、最初に成功した QUIC connect で return

## Logic

| advertised | primary | fallback (順番) |
|---|---|---|
| \`203.0.113.5:7777\` (specific v4) | advertised | DNS lookup の v6 → 同ファミリ別 IP |
| \`[2001:db8::1]:7777\` (specific v6) | advertised | DNS lookup の v4 → 同ファミリ別 IP |
| \`[::]:7777\` (unspecified v6) | DNS lookup の v6 群 | DNS lookup の v4 群 |
| \`0.0.0.0:7777\` (unspecified v4) | DNS lookup の v4 群 | DNS lookup の v6 群 |

DNS lookup が失敗しても advertised が specific なら primary だけで進行する。

## Test

- [x] \`cargo test -p synergos-core --lib peer_bootstrap\` 7/7 pass (新規 3 件)
- [x] \`cargo test -p synergos-core\` 全 70 tests pass
- [x] \`cargo clippy -p synergos-core --all-targets -- -D warnings\` clean
- [ ] 実機 (Win←→AWS) で v6 経路ダウン時に v4 fallback で接続成立すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)