### PR TITLE
chore: declare least-privilege permissions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
## Summary
- LUDIARS-wide security audit: declare explicit `permissions: contents: read` at the top of the CI workflow so least privilege is reviewable in code rather than relying on the GitHub org default.
- No behavior change.

## Test plan
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)