### PR TITLE
feat(core,ipc): peer stream extension hook for upper services

### DIFF
--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -581,6 +581,7 @@ fn spawn_quic_accept_loop(
                             let content_store = ctx.content_store.clone();
                             let sender = acc.peer_id.clone();
                             let connection = acc.connection;
+                            let event_bus = ctx.event_bus.clone();
                             tokio::spawn(async move {
                                 dispatch_peer_streams(
                                     connection,
@@ -589,6 +590,7 @@ fn spawn_quic_accept_loop(
                                     gossip,
                                     exchange,
                                     content_store,
+                                    event_bus,
                                 )
                                 .await;
                             });
@@ -617,7 +619,12 @@ async fn dispatch_peer_streams(
     gossip: Arc<GossipNode>,
     exchange: Arc<crate::exchange::Exchange>,
     content_store: Arc<MemoryContentStore>,
+    event_bus: SharedEventBus,
 ) {
+    /// 拡張 magic ストリームの payload 上限 (1 MiB)。 IPC transport の
+    /// MAX_MESSAGE_SIZE と整合。 これ以上来たら drop する。
+    const MAX_EXTENSION_PAYLOAD: usize = 1024 * 1024;
+
     loop {
         let (send, mut recv) = match connection.accept_bi().await {
             Ok(pair) => pair,
@@ -638,6 +645,7 @@ async fn dispatch_peer_streams(
         let exchange = exchange.clone();
         let content_store = content_store.clone();
         let sender_cloned = sender.clone();
+        let event_bus_cloned = event_bus.clone();
         tokio::spawn(async move {
             if &magic == DHT_STREAM_MAGIC {
                 if let Err(e) = handle_dht_stream(dht, send, recv).await {
@@ -657,7 +665,26 @@ async fn dispatch_peer_streams(
                     tracing::debug!("Bitswap stream handler error: {e}");
                 }
             } else {
-                tracing::debug!("unknown stream magic {:?}", magic);
+                // 拡張 magic: 残バイトを (上限付きで) 読み出して PeerStreamReceivedEvent emit。
+                drop(send);
+                let payload = match recv.read_to_end(MAX_EXTENSION_PAYLOAD).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::debug!(
+                            "extension stream {:?} payload read failed: {e}", magic
+                        );
+                        return;
+                    }
+                };
+                tracing::trace!(
+                    "extension stream magic {:?} from {}: {} bytes",
+                    magic, sender_cloned.short(), payload.len()
+                );
+                event_bus_cloned.emit(crate::event_bus::PeerStreamReceivedEvent {
+                    peer_id: sender_cloned.to_string(),
+                    magic,
+                    payload,
+                });
             }
         });
     }

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -670,15 +670,15 @@ async fn dispatch_peer_streams(
                 let payload = match recv.read_to_end(MAX_EXTENSION_PAYLOAD).await {
                     Ok(p) => p,
                     Err(e) => {
-                        tracing::debug!(
-                            "extension stream {:?} payload read failed: {e}", magic
-                        );
+                        tracing::debug!("extension stream {:?} payload read failed: {e}", magic);
                         return;
                     }
                 };
                 tracing::trace!(
                     "extension stream magic {:?} from {}: {} bytes",
-                    magic, sender_cloned.short(), payload.len()
+                    magic,
+                    sender_cloned.short(),
+                    payload.len()
                 );
                 event_bus_cloned.emit(crate::event_bus::PeerStreamReceivedEvent {
                     peer_id: sender_cloned.to_string(),

--- a/synergos-core/src/event_bus.rs
+++ b/synergos-core/src/event_bus.rs
@@ -204,6 +204,22 @@ impl CoreEvent for NetworkStatusEvent {
     }
 }
 
+/// 拡張 magic ストリーム受信イベント。 既存 magic (HLO1/DHT1/TXFR/GSP1/BSW1) 以外を
+/// `dispatch_peer_streams` が拾った時に emit される。 上位サービス (例: Susurrus)
+/// が IPC 経由で購読してリアルタイムイベントを配るために使う。
+#[derive(Debug, Clone)]
+pub struct PeerStreamReceivedEvent {
+    pub peer_id: String,
+    pub magic: [u8; 4],
+    pub payload: Vec<u8>,
+}
+
+impl CoreEvent for PeerStreamReceivedEvent {
+    fn event_name() -> &'static str {
+        "peer_stream_received"
+    }
+}
+
 /// EventBus の共有参照型
 pub type SharedEventBus = Arc<CoreEventBus>;
 

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -1296,24 +1296,24 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
                 }
             };
             let res = async {
-                let (mut send, _recv) = conn
-                    .open_bi()
-                    .await
-                    .map_err(|e| format!("open_bi: {e}"))?;
+                let (mut send, _recv) =
+                    conn.open_bi().await.map_err(|e| format!("open_bi: {e}"))?;
                 send.write_all(&magic)
                     .await
                     .map_err(|e| format!("write magic: {e}"))?;
                 send.write_all(&payload)
                     .await
                     .map_err(|e| format!("write payload: {e}"))?;
-                send.finish()
-                    .map_err(|e| format!("finish: {e}"))?;
+                send.finish().map_err(|e| format!("finish: {e}"))?;
                 Ok::<_, String>(())
             }
             .await;
             match res {
                 Ok(()) => IpcResponse::Ok,
-                Err(e) => IpcResponse::Error { code: 5, message: e },
+                Err(e) => IpcResponse::Error {
+                    code: 5,
+                    message: e,
+                },
             }
         }
     }

--- a/synergos-core/src/ipc_server.rs
+++ b/synergos-core/src/ipc_server.rs
@@ -577,6 +577,9 @@ where
     let mut rx_transfer_completed = ctx.event_bus.subscribe::<TransferCompletedEvent>();
     let mut rx_conflict = ctx.event_bus.subscribe::<ConflictDetectedEvent>();
     let mut rx_network = ctx.event_bus.subscribe::<NetworkStatusEvent>();
+    let mut rx_peer_stream = ctx
+        .event_bus
+        .subscribe::<crate::event_bus::PeerStreamReceivedEvent>();
 
     loop {
         let event: Option<IpcEvent> = tokio::select! {
@@ -659,6 +662,17 @@ where
                         total_bandwidth_bps: ev.total_bandwidth_bps,
                         used_bandwidth_bps: ev.used_bandwidth_bps,
                         avg_latency_ms: ev.avg_latency_ms,
+                    },
+                ),
+                Err(_) => continue,
+            },
+            r = rx_peer_stream.recv() => match r {
+                Ok(ev) => filter_events(
+                    filters_ref, EventCategory::PeerStream, None,
+                    IpcEvent::PeerStreamReceived {
+                        peer_id: ev.peer_id,
+                        magic: ev.magic,
+                        payload: ev.payload,
                     },
                 ),
                 Err(_) => continue,
@@ -1265,6 +1279,42 @@ pub async fn dispatch_command(command: IpcCommand, ctx: &ServiceContext) -> IpcR
             // デーモンを再起動するかどうかは呼び出し側が決定する。
             tracing::info!("ConfigUpdate received; no hot-swap implemented yet");
             IpcResponse::Ok
+        }
+        IpcCommand::PeerSendStream {
+            peer_id,
+            magic,
+            payload,
+        } => {
+            let pid = PeerId::new(peer_id);
+            let conn = match ctx.quic.raw_connection(&pid) {
+                Some(c) => c,
+                None => {
+                    return IpcResponse::Error {
+                        code: 5,
+                        message: format!("peer {pid} not connected"),
+                    }
+                }
+            };
+            let res = async {
+                let (mut send, _recv) = conn
+                    .open_bi()
+                    .await
+                    .map_err(|e| format!("open_bi: {e}"))?;
+                send.write_all(&magic)
+                    .await
+                    .map_err(|e| format!("write magic: {e}"))?;
+                send.write_all(&payload)
+                    .await
+                    .map_err(|e| format!("write payload: {e}"))?;
+                send.finish()
+                    .map_err(|e| format!("finish: {e}"))?;
+                Ok::<_, String>(())
+            }
+            .await;
+            match res {
+                Ok(()) => IpcResponse::Ok,
+                Err(e) => IpcResponse::Error { code: 5, message: e },
+            }
         }
     }
 }

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -281,7 +281,9 @@ impl IpcCommand {
             }
             Self::ConfigUpdate { .. } => Ok(()),
 
-            Self::PeerSendStream { peer_id, payload, .. } => {
+            Self::PeerSendStream {
+                peer_id, payload, ..
+            } => {
                 check_id("peer_id", peer_id)?;
                 // payload 上限 1 MiB (DoS 対策、 transport.MAX_MESSAGE_SIZE と整合)
                 const MAX_PAYLOAD: usize = 1024 * 1024;

--- a/synergos-ipc/src/command.rs
+++ b/synergos-ipc/src/command.rs
@@ -110,6 +110,20 @@ pub enum IpcCommand {
     Subscribe { events: Vec<EventFilter> },
     /// イベント購読解除
     Unsubscribe { subscription_id: String },
+
+    // ── 拡張ストリーム (#peer-stream-extension) ──
+    /// 任意 magic の uni-directional QUIC stream を 1 本送る。
+    /// upper-layer service (例: Susurrus) がリアルタイムイベントを
+    /// peer に届けるためのエスケープハッチ。
+    ///
+    /// 受信側の magic ディスパッチ:
+    /// - 既存 magic (HLO1/DHT1/TXFR/GSP1/BSW1) は既存のハンドラへ
+    /// - それ以外は `IpcEvent::PeerStreamReceived` として購読クライアントに配信
+    PeerSendStream {
+        peer_id: String,
+        magic: [u8; 4],
+        payload: Vec<u8>,
+    },
 }
 
 impl IpcCommand {
@@ -266,6 +280,19 @@ impl IpcCommand {
                 }
             }
             Self::ConfigUpdate { .. } => Ok(()),
+
+            Self::PeerSendStream { peer_id, payload, .. } => {
+                check_id("peer_id", peer_id)?;
+                // payload 上限 1 MiB (DoS 対策、 transport.MAX_MESSAGE_SIZE と整合)
+                const MAX_PAYLOAD: usize = 1024 * 1024;
+                if payload.len() > MAX_PAYLOAD {
+                    return Err(format!(
+                        "payload too large ({} > {MAX_PAYLOAD})",
+                        payload.len()
+                    ));
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -313,6 +340,26 @@ mod validate_tests {
             project_id: "p".into(),
             file_id: "f".into(),
             peer_id: "x".into(),
+        };
+        cmd.validate().unwrap();
+    }
+
+    #[test]
+    fn peer_send_stream_oversize_rejected() {
+        let cmd = IpcCommand::PeerSendStream {
+            peer_id: "p".into(),
+            magic: *b"SUM1",
+            payload: vec![0u8; 2 * 1024 * 1024], // 2 MiB
+        };
+        assert!(cmd.validate().is_err());
+    }
+
+    #[test]
+    fn peer_send_stream_within_limit_passes() {
+        let cmd = IpcCommand::PeerSendStream {
+            peer_id: "p".into(),
+            magic: *b"SUM1",
+            payload: vec![0u8; 1024], // 1 KiB
         };
         cmd.validate().unwrap();
     }

--- a/synergos-ipc/src/event.rs
+++ b/synergos-ipc/src/event.rs
@@ -72,6 +72,14 @@ pub enum IpcEvent {
         used_bandwidth_bps: u64,
         avg_latency_ms: u32,
     },
+
+    /// 既存 magic 以外の QUIC bidi/uni stream を受信した。 上位層 (例: Susurrus) が
+    /// 自前 magic 集合をディスパッチするためのエスケープハッチ。
+    PeerStreamReceived {
+        peer_id: String,
+        magic: [u8; 4],
+        payload: Vec<u8>,
+    },
 }
 
 /// イベントフィルタ（購読時に指定）
@@ -92,4 +100,6 @@ pub enum EventCategory {
     Transfer,
     Conflict,
     Network,
+    /// 拡張 magic ストリーム ([`IpcEvent::PeerStreamReceived`])
+    PeerStream,
 }


### PR DESCRIPTION
## Summary

Synergos の QUIC 上に「拡張 magic ストリーム」 経路を追加し、 上位サービス (Susurrus, 将来のツール) が `synergos-core` を改造せずに **任意 magic** の stream を peer 間で送受信できるエスケープハッチを提供。

主な動機:
- [Susurrus](https://github.com/LUDIARS/Susurrus) が ACTIVE 時の typing / message notification / spatial position 等を SUM1 / SUT1 / SUR1 / SUX1 / SUP1 / SUS1 という独自 magic で運びたい
- 既存 magic dispatch (`DHT1` / `TXFR` / `GSP1` / `BSW1` / `HLO1`) には影響を与えない

## 変更点

**synergos-ipc**
- \`IpcCommand::PeerSendStream { peer_id, magic: [u8;4], payload: Vec<u8> }\` (payload 上限 1 MiB)
- \`IpcEvent::PeerStreamReceived { peer_id, magic, payload }\`
- \`EventCategory::PeerStream\` (購読 filter)

**synergos-core**
- \`event_bus\` に \`PeerStreamReceivedEvent\` 追加
- \`dispatch_peer_streams\` で **既知 magic 以外** を read_to_end (1 MiB cap) → event emit
- \`ipc_server\` の \`handle_command\` に \`PeerSendStream\` 実装 (QuicManager::raw_connection → open_bi → write)
- \`relay_events\` に PeerStreamReceived の中継を追加

## 互換性

- 既存 magic dispatch は無変更
- 既存クライアントはサブスクライブしなければ何も影響を受けない

## Test plan

- [x] cargo test -p synergos-ipc → 14 / 14 pass (新規 2 件含む)
- [x] cargo test -p synergos-core --lib → 21 / 21 pass
- [x] cargo check -p synergos-core / -p synergos-ipc クリーン
- [ ] 実機 (Susurrus 経由) で SUM1 stream 送受信 (受け側 PR 後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)