### PR TITLE
chore: add service favicon

### DIFF
--- a/synergos-tauri/frontend/index.html
+++ b/synergos-tauri/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Synergos</title>
   </head>

--- a/synergos-tauri/frontend/public/favicon.svg
+++ b/synergos-tauri/frontend/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="22" fill="#0891B2"/>
+  <text x="50" y="50"
+    font-family="system-ui,-apple-system,'Segoe UI','Helvetica Neue',Arial,sans-serif"
+    font-size="46"
+    font-weight="800"
+    fill="#1E293B"
+    text-anchor="middle"
+    dominant-baseline="central"
+    letter-spacing="-1">Sy</text>
+</svg>


### PR DESCRIPTION
Add service favicon SVG (2-letter bold icon) for web tab visibility.

- `public/favicon.svg` を配置
- `<link rel="icon" type="image/svg+xml">` を `index.html` に追加

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>