### PR TITLE
PR-1: harden Synergos security boundary

### DIFF
--- a/synergos-core/src/catalog_sync.rs
+++ b/synergos-core/src/catalog_sync.rs
@@ -118,6 +118,7 @@ async fn process_sync_event(
     match fetch_root_catalog(
         quic.clone(),
         publisher.clone(),
+        &evt.project_id,
         content_store.clone(),
         &catalog_cid,
     )
@@ -144,6 +145,7 @@ async fn process_sync_event(
 async fn fetch_root_catalog(
     quic: Arc<QuicManager>,
     publisher: PeerId,
+    project_id: &str,
     content_store: Arc<MemoryContentStore>,
     catalog_cid: &Cid,
 ) -> Result<u32, String> {
@@ -152,7 +154,12 @@ async fn fetch_root_catalog(
         return Ok(0);
     }
 
-    let session = BitswapSession::new(quic, publisher, content_store.clone());
+    let session = BitswapSession::new(
+        quic,
+        publisher,
+        project_id.to_string(),
+        content_store.clone(),
+    );
     let outcomes = session
         .fetch_blocks(std::slice::from_ref(catalog_cid))
         .await

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -82,7 +82,11 @@ impl Daemon {
             g.set_identity(identity.clone());
             Arc::new(g)
         };
-        let quic = Arc::new(QuicManager::new(net_config.quic.clone(), identity.clone()));
+        let quic = Arc::new(QuicManager::with_resource_limits(
+            net_config.quic.clone(),
+            net_config.resource_limits.clone(),
+            identity.clone(),
+        ));
         // QUIC server をバインド (これが無いと accept ループは未開通でピアを受けられない)。
         // 既定は `[::]:0` (IPv6 デュアルスタックでカーネル割当ポート)。
         // 公開ノードでは `quic.listen_addr = "[::]:7777"` 等を config で指定する。
@@ -569,10 +573,29 @@ fn spawn_quic_accept_loop(
     mut shutdown_rx: broadcast::Receiver<()>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        let concurrency = net.quic.resource_limits().hello_concurrency;
+        let (accepted_tx, mut accepted_rx) = tokio::sync::mpsc::channel(concurrency);
+        let mut workers = Vec::with_capacity(concurrency);
+        for _ in 0..concurrency {
+            let quic = net.quic.clone();
+            let tx = accepted_tx.clone();
+            workers.push(tokio::spawn(async move {
+                loop {
+                    let accepted = quic.accept().await;
+                    let endpoint_closed = matches!(accepted, Ok(None));
+                    if tx.send(accepted).await.is_err() || endpoint_closed {
+                        break;
+                    }
+                }
+            }));
+        }
+        drop(accepted_tx);
+
         loop {
             tokio::select! {
                 _ = shutdown_rx.recv() => break,
-                accepted = net.quic.accept() => {
+                accepted = accepted_rx.recv() => {
+                    let Some(accepted) = accepted else { break; };
                     match accepted {
                         Ok(Some(acc)) => {
                             acc.session.authorize_projects(
@@ -590,6 +613,11 @@ fn spawn_quic_accept_loop(
                                 content_store: ctx.content_store.clone(),
                                 event_bus: ctx.event_bus.clone(),
                                 session: acc.session,
+                                quic: net.quic.clone(),
+                                max_concurrent_streams: net.net_config.quic.max_concurrent_streams as usize,
+                                stream_body_timeout: Duration::from_millis(
+                                    net.net_config.resource_limits.stream_body_timeout_ms,
+                                ),
                             };
                             tokio::spawn(async move {
                                 dispatch_peer_streams(connection, sender, stream_context).await;
@@ -607,9 +635,13 @@ fn spawn_quic_accept_loop(
                 }
             }
         }
+        for worker in workers {
+            worker.abort();
+        }
     })
 }
 
+#[derive(Clone)]
 struct PeerStreamContext {
     dht: Arc<DhtNode>,
     gossip: Arc<GossipNode>,
@@ -617,6 +649,9 @@ struct PeerStreamContext {
     content_store: Arc<MemoryContentStore>,
     event_bus: SharedEventBus,
     session: Arc<ConnectionSession>,
+    quic: Arc<QuicManager>,
+    max_concurrent_streams: usize,
+    stream_body_timeout: Duration,
 }
 
 /// 1 つの QUIC コネクションから bidi ストリームをループで受け、先頭 magic で
@@ -626,105 +661,124 @@ async fn dispatch_peer_streams(
     sender: PeerId,
     context: PeerStreamContext,
 ) {
-    /// 拡張 magic ストリームの payload 上限 (1 MiB)。 IPC transport の
-    /// MAX_MESSAGE_SIZE と整合。 これ以上来たら drop する。
-    const MAX_EXTENSION_PAYLOAD: usize = 1024 * 1024;
+    let stream_slots = Arc::new(tokio::sync::Semaphore::new(
+        context.max_concurrent_streams.max(1),
+    ));
 
     loop {
-        let (send, mut recv) = match connection.accept_bi().await {
+        let (send, recv) = match connection.accept_bi().await {
             Ok(pair) => pair,
             Err(e) => {
                 tracing::debug!("connection {} closed: {e}", sender.short());
+                break;
+            }
+        };
+        let permit = match stream_slots.clone().acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => break,
+        };
+        let stream_context = context.clone();
+        let stream_sender = sender.clone();
+        let body_timeout = context.stream_body_timeout;
+        tokio::spawn(async move {
+            let _permit = permit;
+            if tokio::time::timeout(
+                body_timeout,
+                handle_peer_stream(send, recv, stream_sender.clone(), stream_context),
+            )
+            .await
+            .is_err()
+            {
+                tracing::warn!(
+                    "stream body deadline exceeded from {}",
+                    stream_sender.short()
+                );
+            }
+        });
+    }
+    context.quic.disconnect(&sender, "connection closed").await;
+}
+
+async fn handle_peer_stream(
+    send: quinn::SendStream,
+    mut recv: quinn::RecvStream,
+    sender: PeerId,
+    context: PeerStreamContext,
+) {
+    const MAX_EXTENSION_PAYLOAD: usize = 1024 * 1024;
+
+    let mut magic = [0u8; 4];
+    if let Err(e) = recv.read_exact(&mut magic).await {
+        tracing::debug!("stream magic read failed from {}: {e}", sender.short());
+        return;
+    }
+
+    let known_protocol = &magic == DHT_STREAM_MAGIC
+        || &magic == TRANSFER_STREAM_MAGIC
+        || &magic == GOSSIP_STREAM_MAGIC
+        || &magic == BITSWAP_STREAM_MAGIC;
+    let project_id = if known_protocol {
+        let project_id = match read_project_id(&mut recv).await {
+            Ok(project_id) => project_id,
+            Err(e) => {
+                tracing::debug!("project scope read failed from {}: {e}", sender.short());
                 return;
             }
         };
-
-        let mut magic = [0u8; 4];
-        if let Err(e) = recv.read_exact(&mut magic).await {
-            tracing::debug!("stream magic read failed from {}: {e}", sender.short());
-            continue;
+        if !context.session.is_authorized(&project_id) {
+            tracing::warn!(
+                "rejected unauthorized project stream from {}",
+                sender.short()
+            );
+            return;
         }
+        Some(project_id)
+    } else {
+        None
+    };
 
-        let known_protocol = &magic == DHT_STREAM_MAGIC
-            || &magic == TRANSFER_STREAM_MAGIC
-            || &magic == GOSSIP_STREAM_MAGIC
-            || &magic == BITSWAP_STREAM_MAGIC;
-        let project_id = if known_protocol {
-            let project_id = match read_project_id(&mut recv).await {
-                Ok(project_id) => project_id,
-                Err(e) => {
-                    tracing::debug!("project scope read failed from {}: {e}", sender.short());
-                    continue;
-                }
-            };
-            if !context.session.is_authorized(&project_id) {
-                tracing::warn!(
-                    "rejected unauthorized project stream from {}",
-                    sender.short()
-                );
-                continue;
+    if &magic == DHT_STREAM_MAGIC {
+        let project_id = project_id.expect("known protocol has project scope");
+        if let Err(e) = handle_dht_stream(context.dht, send, recv, &project_id).await {
+            tracing::debug!("DHT stream handler error: {e}");
+        }
+    } else if &magic == TRANSFER_STREAM_MAGIC {
+        let project_id = project_id.expect("known protocol has project scope");
+        if let Err(e) = context
+            .exchange
+            .handle_incoming_transfer(recv, sender, &project_id)
+            .await
+        {
+            tracing::debug!("Transfer stream handler error: {e}");
+        }
+    } else if &magic == GOSSIP_STREAM_MAGIC {
+        let project_id = project_id.expect("known protocol has project scope");
+        drop(send);
+        if let Err(e) = handle_gossip_stream(context.gossip, recv, sender, &project_id).await {
+            tracing::debug!("Gossip stream handler error: {e}");
+        }
+    } else if &magic == BITSWAP_STREAM_MAGIC {
+        let project_id = project_id.expect("known protocol has project scope");
+        if let Err(e) = handle_bitswap_stream(context.content_store, send, recv, &project_id).await
+        {
+            tracing::debug!("Bitswap stream handler error: {e}");
+        }
+    } else {
+        drop(send);
+        let payload = match recv.read_to_end(MAX_EXTENSION_PAYLOAD).await {
+            Ok(payload) => payload,
+            Err(e) => {
+                tracing::debug!("extension stream {:?} payload read failed: {e}", magic);
+                return;
             }
-            Some(project_id)
-        } else {
-            None
         };
-
-        let dht = context.dht.clone();
-        let gossip = context.gossip.clone();
-        let exchange = context.exchange.clone();
-        let content_store = context.content_store.clone();
-        let sender_cloned = sender.clone();
-        let event_bus_cloned = context.event_bus.clone();
-        tokio::spawn(async move {
-            if &magic == DHT_STREAM_MAGIC {
-                let project_id = project_id.expect("known protocol has project scope");
-                if let Err(e) = handle_dht_stream(dht, send, recv, &project_id).await {
-                    tracing::debug!("DHT stream handler error: {e}");
-                }
-            } else if &magic == TRANSFER_STREAM_MAGIC {
-                let project_id = project_id.expect("known protocol has project scope");
-                if let Err(e) = exchange
-                    .handle_incoming_transfer(recv, sender_cloned, &project_id)
-                    .await
-                {
-                    tracing::debug!("Transfer stream handler error: {e}");
-                }
-            } else if &magic == GOSSIP_STREAM_MAGIC {
-                let project_id = project_id.expect("known protocol has project scope");
-                drop(send); // gossip は片方向相当 (応答なし)
-                if let Err(e) = handle_gossip_stream(gossip, recv, sender_cloned, &project_id).await
-                {
-                    tracing::debug!("Gossip stream handler error: {e}");
-                }
-            } else if &magic == BITSWAP_STREAM_MAGIC {
-                let project_id = project_id.expect("known protocol has project scope");
-                if let Err(e) = handle_bitswap_stream(content_store, send, recv, &project_id).await
-                {
-                    tracing::debug!("Bitswap stream handler error: {e}");
-                }
-            } else {
-                // 拡張 magic: 残バイトを (上限付きで) 読み出して PeerStreamReceivedEvent emit。
-                drop(send);
-                let payload = match recv.read_to_end(MAX_EXTENSION_PAYLOAD).await {
-                    Ok(p) => p,
-                    Err(e) => {
-                        tracing::debug!("extension stream {:?} payload read failed: {e}", magic);
-                        return;
-                    }
-                };
-                tracing::trace!(
-                    "extension stream magic {:?} from {}: {} bytes",
-                    magic,
-                    sender_cloned.short(),
-                    payload.len()
-                );
-                event_bus_cloned.emit(crate::event_bus::PeerStreamReceivedEvent {
-                    peer_id: sender_cloned.to_string(),
-                    magic,
-                    payload,
-                });
-            }
-        });
+        context
+            .event_bus
+            .emit(crate::event_bus::PeerStreamReceivedEvent {
+                peer_id: sender.to_string(),
+                magic,
+                payload,
+            });
     }
 }
 

--- a/synergos-core/src/daemon.rs
+++ b/synergos-core/src/daemon.rs
@@ -19,7 +19,7 @@ use synergos_net::{
     identity::Identity,
     mesh::Mesh,
     promotion::{NetCapabilities, PromotionMode},
-    quic::{QuicManager, StreamType},
+    quic::{read_project_id, ConnectionSession, QuicManager, StreamType},
     transfer::TRANSFER_STREAM_MAGIC,
     tunnel::TunnelManager,
     types::{FileId, PeerId},
@@ -30,7 +30,7 @@ use crate::event_bus::{CoreEventBus, SharedEventBus};
 use crate::exchange::{Exchange, FetchRequest, FileSharing, TransferPriority};
 use crate::ipc_server::{IpcServer, ServiceContext};
 use crate::presence::{NodeRegistry, PresenceService};
-use crate::project::ProjectManager;
+use crate::project::{ProjectConfiguration, ProjectManager};
 
 /// デーモン設定
 #[derive(Debug, Clone, Default)]
@@ -575,24 +575,24 @@ fn spawn_quic_accept_loop(
                 accepted = net.quic.accept() => {
                     match accepted {
                         Ok(Some(acc)) => {
-                            let dht = net.dht.clone();
-                            let gossip = net.gossip.clone();
-                            let exchange = ctx.exchange.clone();
-                            let content_store = ctx.content_store.clone();
+                            acc.session.authorize_projects(
+                                ctx.project_manager
+                                    .list_projects()
+                                    .into_iter()
+                                    .map(|project| project.project_id),
+                            );
                             let sender = acc.peer_id.clone();
                             let connection = acc.connection;
-                            let event_bus = ctx.event_bus.clone();
+                            let stream_context = PeerStreamContext {
+                                dht: net.dht.clone(),
+                                gossip: net.gossip.clone(),
+                                exchange: ctx.exchange.clone(),
+                                content_store: ctx.content_store.clone(),
+                                event_bus: ctx.event_bus.clone(),
+                                session: acc.session,
+                            };
                             tokio::spawn(async move {
-                                dispatch_peer_streams(
-                                    connection,
-                                    sender,
-                                    dht,
-                                    gossip,
-                                    exchange,
-                                    content_store,
-                                    event_bus,
-                                )
-                                .await;
+                                dispatch_peer_streams(connection, sender, stream_context).await;
                             });
                         }
                         Ok(None) => {
@@ -610,16 +610,21 @@ fn spawn_quic_accept_loop(
     })
 }
 
-/// 1 つの QUIC コネクションから bidi ストリームをループで受け、先頭 magic で
-/// DHT / Gossip / Transfer / Bitswap に振り分ける。コネクションが閉じられたらループを抜ける。
-async fn dispatch_peer_streams(
-    connection: quinn::Connection,
-    sender: PeerId,
+struct PeerStreamContext {
     dht: Arc<DhtNode>,
     gossip: Arc<GossipNode>,
     exchange: Arc<crate::exchange::Exchange>,
     content_store: Arc<MemoryContentStore>,
     event_bus: SharedEventBus,
+    session: Arc<ConnectionSession>,
+}
+
+/// 1 つの QUIC コネクションから bidi ストリームをループで受け、先頭 magic で
+/// DHT / Gossip / Transfer / Bitswap に振り分ける。コネクションが閉じられたらループを抜ける。
+async fn dispatch_peer_streams(
+    connection: quinn::Connection,
+    sender: PeerId,
+    context: PeerStreamContext,
 ) {
     /// 拡張 magic ストリームの payload 上限 (1 MiB)。 IPC transport の
     /// MAX_MESSAGE_SIZE と整合。 これ以上来たら drop する。
@@ -640,28 +645,61 @@ async fn dispatch_peer_streams(
             continue;
         }
 
-        let dht = dht.clone();
-        let gossip = gossip.clone();
-        let exchange = exchange.clone();
-        let content_store = content_store.clone();
+        let known_protocol = &magic == DHT_STREAM_MAGIC
+            || &magic == TRANSFER_STREAM_MAGIC
+            || &magic == GOSSIP_STREAM_MAGIC
+            || &magic == BITSWAP_STREAM_MAGIC;
+        let project_id = if known_protocol {
+            let project_id = match read_project_id(&mut recv).await {
+                Ok(project_id) => project_id,
+                Err(e) => {
+                    tracing::debug!("project scope read failed from {}: {e}", sender.short());
+                    continue;
+                }
+            };
+            if !context.session.is_authorized(&project_id) {
+                tracing::warn!(
+                    "rejected unauthorized project stream from {}",
+                    sender.short()
+                );
+                continue;
+            }
+            Some(project_id)
+        } else {
+            None
+        };
+
+        let dht = context.dht.clone();
+        let gossip = context.gossip.clone();
+        let exchange = context.exchange.clone();
+        let content_store = context.content_store.clone();
         let sender_cloned = sender.clone();
-        let event_bus_cloned = event_bus.clone();
+        let event_bus_cloned = context.event_bus.clone();
         tokio::spawn(async move {
             if &magic == DHT_STREAM_MAGIC {
-                if let Err(e) = handle_dht_stream(dht, send, recv).await {
+                let project_id = project_id.expect("known protocol has project scope");
+                if let Err(e) = handle_dht_stream(dht, send, recv, &project_id).await {
                     tracing::debug!("DHT stream handler error: {e}");
                 }
             } else if &magic == TRANSFER_STREAM_MAGIC {
-                if let Err(e) = exchange.handle_incoming_transfer(recv, sender_cloned).await {
+                let project_id = project_id.expect("known protocol has project scope");
+                if let Err(e) = exchange
+                    .handle_incoming_transfer(recv, sender_cloned, &project_id)
+                    .await
+                {
                     tracing::debug!("Transfer stream handler error: {e}");
                 }
             } else if &magic == GOSSIP_STREAM_MAGIC {
+                let project_id = project_id.expect("known protocol has project scope");
                 drop(send); // gossip は片方向相当 (応答なし)
-                if let Err(e) = handle_gossip_stream(gossip, recv, sender_cloned).await {
+                if let Err(e) = handle_gossip_stream(gossip, recv, sender_cloned, &project_id).await
+                {
                     tracing::debug!("Gossip stream handler error: {e}");
                 }
             } else if &magic == BITSWAP_STREAM_MAGIC {
-                if let Err(e) = handle_bitswap_stream(content_store, send, recv).await {
+                let project_id = project_id.expect("known protocol has project scope");
+                if let Err(e) = handle_bitswap_stream(content_store, send, recv, &project_id).await
+                {
                     tracing::debug!("Bitswap stream handler error: {e}");
                 }
             } else {
@@ -720,6 +758,7 @@ fn spawn_gossip_fanout(
                             };
                             for peer in peers {
                                 let wire = GossipWireMessage {
+                                    project_id: outbound.signed.project_id.clone(),
                                     topic: outbound.topic.clone(),
                                     signed: outbound.signed.clone(),
                                 };

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -7,17 +7,19 @@
 //!
 //! 旧 ars-plugin-synergos から synergos-core に移植。Ars 依存を除去。
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
+use serde::Deserialize;
 use synergos_net::chain::{LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry};
 use synergos_net::content::{Block, ContentStore, MemoryContentStore};
 use synergos_net::gossip::{GossipMessage, GossipNode};
 use synergos_net::quic::{QuicManager, StreamType};
-use synergos_net::transfer::{receive_over_quic, send_over_quic, TransferHeader};
+use synergos_net::transfer::{receive_stream, send_over_quic, TransferHeader, CHUNK_SIZE};
 use synergos_net::types::{Blake3Hash, Cid, FileId, PeerId, TopicId, TransferId};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::event_bus::{SharedEventBus, TransferCompletedEvent, TransferProgressEvent};
 
@@ -25,6 +27,181 @@ use crate::event_bus::{SharedEventBus, TransferCompletedEvent, TransferProgressE
 /// 最終的な書き込み先 `PathBuf` を返す。通常は ProjectManager 経由で
 /// プロジェクトルート + 相対パスを組み立てる想定。
 pub type OutPathResolver = Arc<dyn Fn(&str, &FileId) -> Option<PathBuf> + Send + Sync + 'static>;
+
+#[derive(Deserialize)]
+enum IncomingTransferFrame {
+    Header(TransferHeader),
+}
+
+/// 受信先を確定するため、既存 transfer frame の先頭 Header だけを読む。
+/// 返した prefix は同じバイト列のまま `receive_stream` に再入力する。
+async fn peek_transfer_header<R>(
+    reader: &mut R,
+) -> Result<(TransferHeader, Vec<u8>), FileSharingError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    const MAX_FRAME: usize = CHUNK_SIZE + 1024;
+    if len > MAX_FRAME {
+        return Err(FileSharingError::NetworkError(format!(
+            "transfer frame too large: {len} bytes"
+        )));
+    }
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload).await?;
+    let IncomingTransferFrame::Header(header) = rmp_serde::from_slice(&payload)
+        .map_err(|e| FileSharingError::NetworkError(format!("transfer header decode: {e}")))?;
+
+    let mut prefix = Vec::with_capacity(4 + len);
+    prefix.extend_from_slice(&len_buf);
+    prefix.extend_from_slice(&payload);
+    Ok((header, prefix))
+}
+
+/// Drop を含む全終了経路で未完成の一時ファイルを除去する。
+struct IncomingTempFile {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl IncomingTempFile {
+    fn adjacent_to(final_path: &Path) -> Option<Self> {
+        let parent = final_path.parent()?;
+        Some(Self {
+            path: parent.join(format!(".synergos-incoming-{}", uuid::Uuid::new_v4())),
+            armed: true,
+        })
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for IncomingTempFile {
+    fn drop(&mut self) {
+        if self.armed {
+            match std::fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => tracing::warn!("failed to remove incoming temp file: {error}"),
+            }
+        }
+    }
+}
+
+async fn receive_into_registered_path<R>(
+    mut reader: R,
+    resolver: &OutPathResolver,
+) -> Result<(TransferHeader, PathBuf), FileSharingError>
+where
+    R: AsyncRead + Unpin,
+{
+    let (offered_header, prefix) = peek_transfer_header(&mut reader).await?;
+    let file_id = FileId(offered_header.file_id.clone());
+    let final_path = resolver(&offered_header.project_id, &file_id)
+        .ok_or_else(|| FileSharingError::FileNotFound(offered_header.file_id.clone()))?;
+    let parent = final_path
+        .parent()
+        .ok_or_else(|| FileSharingError::FileNotFound(offered_header.file_id.clone()))?;
+    tokio::fs::create_dir_all(parent).await?;
+
+    let mut temp = IncomingTempFile::adjacent_to(&final_path)
+        .ok_or_else(|| FileSharingError::FileNotFound(offered_header.file_id.clone()))?;
+    let replay = std::io::Cursor::new(prefix).chain(reader);
+    let received_header = receive_stream(replay, &temp.path)
+        .await
+        .map_err(|e| FileSharingError::NetworkError(format!("{e}")))?;
+    tokio::fs::rename(&temp.path, &final_path).await?;
+    temp.disarm();
+    Ok((received_header, final_path))
+}
+
+#[cfg(test)]
+mod incoming_path_tests {
+    use super::*;
+    use synergos_net::transfer::send_stream;
+
+    fn header(file_id: &str, payload: &[u8]) -> TransferHeader {
+        TransferHeader {
+            transfer_id: "transfer-1".into(),
+            project_id: "project-1".into(),
+            file_id: file_id.into(),
+            total_size: payload.len() as u64,
+            chunk_count: u64::from(!payload.is_empty()),
+            total_hash: Blake3Hash(*blake3::hash(payload).as_bytes()),
+        }
+    }
+
+    #[tokio::test]
+    async fn registered_file_lands_inside_project_root() {
+        let root = tempfile::tempdir().unwrap();
+        let final_path = root.path().join("nested/file.bin");
+        let resolved = final_path.clone();
+        let resolver: OutPathResolver = Arc::new(move |project_id, file_id| {
+            (project_id == "project-1" && file_id.0 == "registered-id").then(|| resolved.clone())
+        });
+        let payload = b"registered payload".to_vec();
+        let offered = header("registered-id", &payload);
+        let (writer, reader) = tokio::io::duplex(4096);
+        let send = tokio::spawn({
+            let payload = payload.clone();
+            async move { send_stream(std::io::Cursor::new(payload), writer, offered).await }
+        });
+
+        let (_, received_path) = receive_into_registered_path(reader, &resolver)
+            .await
+            .unwrap();
+        send.await.unwrap().unwrap();
+
+        assert_eq!(received_path, final_path);
+        assert_eq!(tokio::fs::read(final_path).await.unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn unregistered_file_is_rejected_before_body_write() {
+        let resolver: OutPathResolver = Arc::new(|_, _| None);
+        let payload = b"must not be written".to_vec();
+        let offered = header("unknown-id", &payload);
+        let (writer, reader) = tokio::io::duplex(4096);
+        let send = tokio::spawn(async move {
+            let _ = send_stream(std::io::Cursor::new(payload), writer, offered).await;
+        });
+
+        let error = receive_into_registered_path(reader, &resolver)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, FileSharingError::FileNotFound(id) if id == "unknown-id"));
+        send.abort();
+    }
+
+    #[tokio::test]
+    async fn interrupted_receive_removes_project_local_temp_file() {
+        let root = tempfile::tempdir().unwrap();
+        let final_path = root.path().join("file.bin");
+        let resolved = final_path.clone();
+        let resolver: OutPathResolver = Arc::new(move |_, _| Some(resolved.clone()));
+        let mut offered = header("registered-id", b"x");
+        offered.total_size = 2;
+        let (writer, reader) = tokio::io::duplex(4096);
+        let send = tokio::spawn(async move {
+            let result = send_stream(std::io::Cursor::new(b"x".to_vec()), writer, offered).await;
+            assert!(result.is_err());
+        });
+
+        assert!(receive_into_registered_path(reader, &resolver)
+            .await
+            .is_err());
+        send.await.unwrap();
+        assert!(!final_path.exists());
+
+        let mut entries = tokio::fs::read_dir(root.path()).await.unwrap();
+        assert!(entries.next_entry().await.unwrap().is_none());
+    }
+}
 
 /// QUIC 送信を進行しつつ 128KiB ごとに読み込んだ累積バイトを
 /// `tokio::sync::mpsc` で投げ出す `AsyncRead` ラッパ。
@@ -533,23 +710,8 @@ impl Exchange {
             FileSharingError::NetworkError("out_path_resolver not attached".into())
         })?;
 
-        // 先にヘッダを覗き見するため、一時バッファに受信せず receive_over_quic を
-        // 呼んで Header → Body → Footer を完結させる。保存先はヘッダから決める。
-        // 保存先を決めるために「ヘッダだけ先読み」したいが、receive_stream が
-        // 内部で一気通貫するので、tmp ファイルに書いたあと移動する。
-        let tmp_path =
-            std::env::temp_dir().join(format!("synergos-incoming-{}", uuid::Uuid::new_v4()));
-        let header = receive_over_quic(recv, &tmp_path)
-            .await
-            .map_err(|e| FileSharingError::NetworkError(format!("{e}")))?;
-
+        let (header, final_path) = receive_into_registered_path(recv, &resolver).await?;
         let file_id = FileId(header.file_id.clone());
-        let final_path = resolver(&header.project_id, &file_id)
-            .ok_or_else(|| FileSharingError::FileNotFound(header.file_id.clone()))?;
-        if let Some(parent) = final_path.parent() {
-            tokio::fs::create_dir_all(parent).await.ok();
-        }
-        tokio::fs::rename(&tmp_path, &final_path).await?;
 
         // 受信完了したファイルを shared_files にも登録する。これで:
         //   1. 後続の自身に届く同一 FileOffer を has_shared_file で skip できる

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -12,12 +12,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use synergos_net::chain::{LedgerAction, LedgerEntryState, OfferEntry, TransferLedger, WantEntry};
 use synergos_net::content::{Block, ContentStore, MemoryContentStore};
 use synergos_net::gossip::{GossipMessage, GossipNode};
 use synergos_net::quic::{QuicManager, StreamType};
-use synergos_net::transfer::{receive_stream, send_over_quic, TransferHeader, CHUNK_SIZE};
+use synergos_net::transfer::{
+    receive_stream, send_over_quic, TransferHeader, TransferLimits, CHUNK_SIZE,
+};
 use synergos_net::types::{Blake3Hash, Cid, FileId, PeerId, TopicId, TransferId};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
@@ -28,7 +30,7 @@ use crate::event_bus::{SharedEventBus, TransferCompletedEvent, TransferProgressE
 /// プロジェクトルート + 相対パスを組み立てる想定。
 pub type OutPathResolver = Arc<dyn Fn(&str, &FileId) -> Option<PathBuf> + Send + Sync + 'static>;
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 enum IncomingTransferFrame {
     Header(TransferHeader),
 }
@@ -97,6 +99,7 @@ async fn receive_into_registered_path<R>(
     mut reader: R,
     resolver: &OutPathResolver,
     authorized_project_id: &str,
+    limits: TransferLimits,
 ) -> Result<(TransferHeader, PathBuf), FileSharingError>
 where
     R: AsyncRead + Unpin,
@@ -118,7 +121,7 @@ where
     let mut temp = IncomingTempFile::adjacent_to(&final_path)
         .ok_or_else(|| FileSharingError::FileNotFound(offered_header.file_id.clone()))?;
     let replay = std::io::Cursor::new(prefix).chain(reader);
-    let received_header = receive_stream(replay, &temp.path)
+    let received_header = receive_stream(replay, &temp.path, limits)
         .await
         .map_err(|e| FileSharingError::NetworkError(format!("{e}")))?;
     tokio::fs::rename(&temp.path, &final_path).await?;
@@ -130,6 +133,13 @@ where
 mod incoming_path_tests {
     use super::*;
     use synergos_net::transfer::send_stream;
+
+    fn limits() -> TransferLimits {
+        TransferLimits {
+            max_file_size_bytes: 1024 * 1024,
+            transfer_timeout: std::time::Duration::from_secs(1),
+        }
+    }
 
     fn header(file_id: &str, payload: &[u8]) -> TransferHeader {
         TransferHeader {
@@ -158,9 +168,10 @@ mod incoming_path_tests {
             async move { send_stream(std::io::Cursor::new(payload), writer, offered).await }
         });
 
-        let (_, received_path) = receive_into_registered_path(reader, &resolver, "project-1")
-            .await
-            .unwrap();
+        let (_, received_path) =
+            receive_into_registered_path(reader, &resolver, "project-1", limits())
+                .await
+                .unwrap();
         send.await.unwrap().unwrap();
 
         assert_eq!(received_path, final_path);
@@ -177,7 +188,7 @@ mod incoming_path_tests {
             let _ = send_stream(std::io::Cursor::new(payload), writer, offered).await;
         });
 
-        let error = receive_into_registered_path(reader, &resolver, "project-1")
+        let error = receive_into_registered_path(reader, &resolver, "project-1", limits())
             .await
             .unwrap_err();
         assert!(matches!(error, FileSharingError::FileNotFound(id) if id == "unknown-id"));
@@ -195,7 +206,7 @@ mod incoming_path_tests {
             let _ = send_stream(std::io::Cursor::new(payload), writer, offered).await;
         });
 
-        let error = receive_into_registered_path(reader, &resolver, "project-2")
+        let error = receive_into_registered_path(reader, &resolver, "project-2", limits())
             .await
             .unwrap_err();
         assert!(matches!(error, FileSharingError::NetworkError(_)));
@@ -216,14 +227,50 @@ mod incoming_path_tests {
             assert!(result.is_err());
         });
 
-        assert!(receive_into_registered_path(reader, &resolver, "project-1")
-            .await
-            .is_err());
+        assert!(
+            receive_into_registered_path(reader, &resolver, "project-1", limits())
+                .await
+                .is_err()
+        );
         send.await.unwrap();
         assert!(!final_path.exists());
 
         let mut entries = tokio::fs::read_dir(root.path()).await.unwrap();
         assert!(entries.next_entry().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn deadline_removes_project_local_temp_file() {
+        use tokio::io::AsyncWriteExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let final_path = root.path().join("file.bin");
+        let resolved = final_path.clone();
+        let resolver: OutPathResolver = Arc::new(move |_, _| Some(resolved.clone()));
+        let offered = header("registered-id", b"x");
+        let payload = rmp_serde::to_vec(&IncomingTransferFrame::Header(offered)).unwrap();
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        writer
+            .write_all(&(payload.len() as u32).to_le_bytes())
+            .await
+            .unwrap();
+        writer.write_all(&payload).await.unwrap();
+
+        let result = receive_into_registered_path(
+            reader,
+            &resolver,
+            "project-1",
+            TransferLimits {
+                max_file_size_bytes: 1024,
+                transfer_timeout: std::time::Duration::from_millis(10),
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(!final_path.exists());
+        let mut entries = tokio::fs::read_dir(root.path()).await.unwrap();
+        assert!(entries.next_entry().await.unwrap().is_none());
+        drop(writer);
     }
 }
 
@@ -734,9 +781,14 @@ impl Exchange {
         let resolver = self.out_path_resolver.clone().ok_or_else(|| {
             FileSharingError::NetworkError("out_path_resolver not attached".into())
         })?;
+        let limits = self
+            .quic
+            .as_ref()
+            .ok_or_else(|| FileSharingError::NetworkError("QUIC not attached".into()))?
+            .transfer_limits();
 
         let (header, final_path) =
-            receive_into_registered_path(recv, &resolver, authorized_project_id).await?;
+            receive_into_registered_path(recv, &resolver, authorized_project_id, limits).await?;
         let file_id = FileId(header.file_id.clone());
 
         // 受信完了したファイルを shared_files にも登録する。これで:

--- a/synergos-core/src/exchange/mod.rs
+++ b/synergos-core/src/exchange/mod.rs
@@ -96,11 +96,17 @@ impl Drop for IncomingTempFile {
 async fn receive_into_registered_path<R>(
     mut reader: R,
     resolver: &OutPathResolver,
+    authorized_project_id: &str,
 ) -> Result<(TransferHeader, PathBuf), FileSharingError>
 where
     R: AsyncRead + Unpin,
 {
     let (offered_header, prefix) = peek_transfer_header(&mut reader).await?;
+    if offered_header.project_id != authorized_project_id {
+        return Err(FileSharingError::NetworkError(
+            "transfer project_id does not match authorized stream scope".into(),
+        ));
+    }
     let file_id = FileId(offered_header.file_id.clone());
     let final_path = resolver(&offered_header.project_id, &file_id)
         .ok_or_else(|| FileSharingError::FileNotFound(offered_header.file_id.clone()))?;
@@ -152,7 +158,7 @@ mod incoming_path_tests {
             async move { send_stream(std::io::Cursor::new(payload), writer, offered).await }
         });
 
-        let (_, received_path) = receive_into_registered_path(reader, &resolver)
+        let (_, received_path) = receive_into_registered_path(reader, &resolver, "project-1")
             .await
             .unwrap();
         send.await.unwrap().unwrap();
@@ -171,10 +177,28 @@ mod incoming_path_tests {
             let _ = send_stream(std::io::Cursor::new(payload), writer, offered).await;
         });
 
-        let error = receive_into_registered_path(reader, &resolver)
+        let error = receive_into_registered_path(reader, &resolver, "project-1")
             .await
             .unwrap_err();
         assert!(matches!(error, FileSharingError::FileNotFound(id) if id == "unknown-id"));
+        send.abort();
+    }
+
+    #[tokio::test]
+    async fn transfer_project_mismatch_is_rejected_before_path_resolution() {
+        let resolver: OutPathResolver =
+            Arc::new(|_, _| panic!("resolver must not run for an unauthorized transfer"));
+        let payload = b"unauthorized".to_vec();
+        let offered = header("registered-id", &payload);
+        let (writer, reader) = tokio::io::duplex(4096);
+        let send = tokio::spawn(async move {
+            let _ = send_stream(std::io::Cursor::new(payload), writer, offered).await;
+        });
+
+        let error = receive_into_registered_path(reader, &resolver, "project-2")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, FileSharingError::NetworkError(_)));
         send.abort();
     }
 
@@ -192,7 +216,7 @@ mod incoming_path_tests {
             assert!(result.is_err());
         });
 
-        assert!(receive_into_registered_path(reader, &resolver)
+        assert!(receive_into_registered_path(reader, &resolver, "project-1")
             .await
             .is_err());
         send.await.unwrap();
@@ -705,12 +729,14 @@ impl Exchange {
         self: &Arc<Self>,
         recv: quinn::RecvStream,
         sender: PeerId,
+        authorized_project_id: &str,
     ) -> Result<(), FileSharingError> {
         let resolver = self.out_path_resolver.clone().ok_or_else(|| {
             FileSharingError::NetworkError("out_path_resolver not attached".into())
         })?;
 
-        let (header, final_path) = receive_into_registered_path(recv, &resolver).await?;
+        let (header, final_path) =
+            receive_into_registered_path(recv, &resolver, authorized_project_id).await?;
         let file_id = FileId(header.file_id.clone());
 
         // 受信完了したファイルを shared_files にも登録する。これで:

--- a/synergos-core/src/project.rs
+++ b/synergos-core/src/project.rs
@@ -3,7 +3,7 @@
 //! Core デーモンが管理するプロジェクトのライフサイクルを制御する。
 //! ノード（ピア）はプロジェクトに紐づいて管理される。
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -314,20 +314,16 @@ impl ProjectManager {
             .insert((project_id.to_string(), file_id), relative);
     }
 
-    /// `project_id` + `file_id` から絶対保存先パスを解決する。
-    /// - 事前に `register_file` で明示的に紐付けられていればそれを優先
-    /// - 無ければ FileId の文字列をプロジェクト相対パスとして扱う (publish
-    ///   経由で登録した場合の既定動作との互換性を保つ)
+    /// `project_id` + `file_id` から、プロジェクトルート配下の登録済み保存先を解決する。
+    /// 未登録の ID と portable path として危険な ID / 登録パスは拒否する。
     pub fn resolve_file_path(&self, project_id: &str, file_id: &FileId) -> Option<PathBuf> {
+        portable_relative_path(Path::new(&file_id.0))?;
         let root = self.project_root(project_id)?;
-        if let Some(rel) = self
+        let rel = self
             .file_paths
             .get(&(project_id.to_string(), file_id.clone()))
-        {
-            return Some(root.join(&*rel));
-        }
-        // fallback: FileId をそのまま相対パスとして扱う
-        Some(root.join(&file_id.0))
+            .map(|entry| entry.clone())?;
+        resolve_under_project_root(&root, &rel)
     }
 
     /// 期限切れ招待トークンを除去
@@ -360,6 +356,57 @@ impl ProjectManager {
             .get(project_id)
             .map(|entry| entry.root_path.clone())
     }
+}
+
+/// Unix/Windows のどちらで受け取っても同じ判定になる相対パス検証。
+/// `std::path` が Unix 上で区切りとみなさない `\` も `/` として検査する。
+fn portable_relative_path(path: &Path) -> Option<PathBuf> {
+    let raw = path.to_str()?;
+    if raw.is_empty()
+        || raw.starts_with('/')
+        || raw.starts_with('\\')
+        || raw
+            .as_bytes()
+            .get(1)
+            .is_some_and(|second| *second == b':' && raw.as_bytes()[0].is_ascii_alphabetic())
+    {
+        return None;
+    }
+
+    let normalized = raw.replace('\\', "/");
+    let mut relative = PathBuf::new();
+    for component in Path::new(&normalized).components() {
+        match component {
+            Component::Normal(part) => relative.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    (!relative.as_os_str().is_empty()).then_some(relative)
+}
+
+/// 最深の既存 ancestor を canonicalize し、symlink を含めても root 外へ出ない
+/// 論理パスだけを返す。まだ存在しない末尾成分は検証済みのまま付け直す。
+fn resolve_under_project_root(root: &Path, relative: &Path) -> Option<PathBuf> {
+    let root = root.canonicalize().ok()?;
+    let relative = portable_relative_path(relative)?;
+    let candidate = root.join(relative);
+
+    let mut existing = candidate.as_path();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        missing.push(existing.file_name()?.to_os_string());
+        existing = existing.parent()?;
+    }
+
+    let mut resolved = existing.canonicalize().ok()?;
+    if !resolved.starts_with(&root) {
+        return None;
+    }
+    for component in missing.iter().rev() {
+        resolved.push(component);
+    }
+    resolved.starts_with(&root).then_some(resolved)
 }
 
 fn now_epoch_secs() -> u64 {
@@ -585,5 +632,71 @@ impl ProjectConfiguration for ProjectManager {
 
     fn count(&self) -> usize {
         self.projects.len()
+    }
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::*;
+    use crate::event_bus::CoreEventBus;
+
+    fn manager() -> ProjectManager {
+        ProjectManager::new(Arc::new(CoreEventBus::new()))
+    }
+
+    #[tokio::test]
+    async fn resolve_file_path_requires_safe_registered_mapping() {
+        let root = tempfile::tempdir().unwrap();
+        let manager = manager();
+        manager
+            .open_project("p".into(), root.path().to_path_buf(), None)
+            .await
+            .unwrap();
+
+        let valid = FileId::new("nested/file.bin");
+        manager.register_file("p", valid.clone(), PathBuf::from("nested/file.bin"));
+        assert_eq!(
+            manager.resolve_file_path("p", &valid),
+            Some(root.path().canonicalize().unwrap().join("nested/file.bin"))
+        );
+
+        assert!(manager
+            .resolve_file_path("p", &FileId::new("unregistered.bin"))
+            .is_none());
+
+        for malicious in [
+            "../../../x",
+            "..\\..\\x",
+            "/etc/passwd",
+            "C:\\Windows\\system.ini",
+            "\\\\server\\share\\x",
+        ] {
+            let file_id = FileId::new(malicious);
+            manager.register_file("p", file_id.clone(), PathBuf::from("safe.bin"));
+            assert!(
+                manager.resolve_file_path("p", &file_id).is_none(),
+                "accepted malicious file id: {malicious}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_file_path_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join("escape")).unwrap();
+
+        let manager = manager();
+        manager
+            .open_project("p".into(), root.path().to_path_buf(), None)
+            .await
+            .unwrap();
+        let file_id = FileId::new("safe-id");
+        manager.register_file("p", file_id.clone(), PathBuf::from("escape/file.bin"));
+
+        assert!(manager.resolve_file_path("p", &file_id).is_none());
     }
 }

--- a/synergos-core/tests/auto_pull_e2e.rs
+++ b/synergos-core/tests/auto_pull_e2e.rs
@@ -123,11 +123,20 @@ impl Node {
                         let exchange = exchange.clone();
                         let sender_clone = sender.clone();
                         tokio::spawn(async move {
+                            let Ok(project_id) =
+                                synergos_net::quic::read_project_id(&mut recv).await
+                            else {
+                                return;
+                            };
                             if &magic == GOSSIP_STREAM_MAGIC {
                                 drop(send);
-                                let _ = handle_gossip_stream(gossip, recv, sender_clone).await;
+                                let _ =
+                                    handle_gossip_stream(gossip, recv, sender_clone, &project_id)
+                                        .await;
                             } else if &magic == TRANSFER_STREAM_MAGIC {
-                                let _ = exchange.handle_incoming_transfer(recv, sender_clone).await;
+                                let _ = exchange
+                                    .handle_incoming_transfer(recv, sender_clone, &project_id)
+                                    .await;
                             }
                         });
                     }
@@ -213,6 +222,7 @@ impl Node {
                 };
                 for peer in peers {
                     let wire = GossipWireMessage {
+                        project_id: out.signed.project_id.clone(),
                         topic: out.topic.clone(),
                         signed: out.signed.clone(),
                     };
@@ -295,11 +305,17 @@ async fn b_auto_pulls_file_after_receiving_offer() {
                 let exchange = exchange.clone();
                 let sender = b_peer.clone();
                 tokio::spawn(async move {
+                    let Ok(project_id) = synergos_net::quic::read_project_id(&mut recv).await
+                    else {
+                        return;
+                    };
                     if &magic == GOSSIP_STREAM_MAGIC {
                         drop(send);
-                        let _ = handle_gossip_stream(gossip, recv, sender).await;
+                        let _ = handle_gossip_stream(gossip, recv, sender, &project_id).await;
                     } else if &magic == TRANSFER_STREAM_MAGIC {
-                        let _ = exchange.handle_incoming_transfer(recv, sender).await;
+                        let _ = exchange
+                            .handle_incoming_transfer(recv, sender, &project_id)
+                            .await;
                     }
                 });
             }

--- a/synergos-core/tests/auto_transfer_e2e.rs
+++ b/synergos-core/tests/auto_transfer_e2e.rs
@@ -73,8 +73,11 @@ async fn file_want_auto_triggers_share_and_send_over_quic() {
                     continue;
                 }
                 if &magic == TRANSFER_STREAM_MAGIC {
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
                     let _ = ex_b_for_task
-                        .handle_incoming_transfer(recv, sender.clone())
+                        .handle_incoming_transfer(recv, sender.clone(), &project_id)
                         .await;
                 }
                 break;

--- a/synergos-core/tests/catalog_sync_e2e.rs
+++ b/synergos-core/tests/catalog_sync_e2e.rs
@@ -72,9 +72,12 @@ fn spawn_bitswap_server(
                     continue;
                 }
                 if &magic == BITSWAP_STREAM_MAGIC {
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
                     let s = store.clone();
                     tokio::spawn(async move {
-                        let _ = handle_bitswap_stream(s, send, recv).await;
+                        let _ = handle_bitswap_stream(s, send, recv, &project_id).await;
                     });
                 }
             }

--- a/synergos-core/tests/gossip_mesh_e2e.rs
+++ b/synergos-core/tests/gossip_mesh_e2e.rs
@@ -72,7 +72,16 @@ async fn publish_flows_through_quic_gossip_stream_to_remote_subscriber() {
                     continue;
                 }
                 if &magic == GOSSIP_STREAM_MAGIC {
-                    let _ = handle_gossip_stream(gb_clone.clone(), recv, id_a_peer.clone()).await;
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
+                    let _ = handle_gossip_stream(
+                        gb_clone.clone(),
+                        recv,
+                        id_a_peer.clone(),
+                        &project_id,
+                    )
+                    .await;
                     break; // 1 メッセージ受けたらテスト用に抜ける
                 }
             }
@@ -110,6 +119,7 @@ async fn publish_flows_through_quic_gossip_stream_to_remote_subscriber() {
         .expect("outbound must arrive quickly")
         .expect("outbound channel open");
     let wire = GossipWireMessage {
+        project_id: outbound.signed.project_id.clone(),
         topic: outbound.topic.clone(),
         signed: outbound.signed.clone(),
     };

--- a/synergos-core/tests/transfer_e2e.rs
+++ b/synergos-core/tests/transfer_e2e.rs
@@ -70,7 +70,12 @@ async fn execute_send_and_handle_incoming_roundtrip() {
                     continue;
                 }
                 if &magic == TRANSFER_STREAM_MAGIC {
-                    let _ = ex.handle_incoming_transfer(recv, sender.clone()).await;
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
+                    let _ = ex
+                        .handle_incoming_transfer(recv, sender.clone(), &project_id)
+                        .await;
                 }
                 break;
             }

--- a/synergos-core/tests/two_node_full_e2e.rs
+++ b/synergos-core/tests/two_node_full_e2e.rs
@@ -121,11 +121,20 @@ impl Node {
                         let exchange = exchange.clone();
                         let sender_clone = sender.clone();
                         tokio::spawn(async move {
+                            let Ok(project_id) =
+                                synergos_net::quic::read_project_id(&mut recv).await
+                            else {
+                                return;
+                            };
                             if &magic == GOSSIP_STREAM_MAGIC {
                                 drop(send);
-                                let _ = handle_gossip_stream(gossip, recv, sender_clone).await;
+                                let _ =
+                                    handle_gossip_stream(gossip, recv, sender_clone, &project_id)
+                                        .await;
                             } else if &magic == TRANSFER_STREAM_MAGIC {
-                                let _ = exchange.handle_incoming_transfer(recv, sender_clone).await;
+                                let _ = exchange
+                                    .handle_incoming_transfer(recv, sender_clone, &project_id)
+                                    .await;
                             }
                         });
                     }
@@ -182,6 +191,7 @@ impl Node {
                 };
                 for peer in peers {
                     let wire = GossipWireMessage {
+                        project_id: out.signed.project_id.clone(),
                         topic: out.topic.clone(),
                         signed: out.signed.clone(),
                     };
@@ -263,11 +273,17 @@ async fn two_nodes_auto_transfer_via_gossip_and_quic() {
                 let exchange = exchange.clone();
                 let sender = b_peer.clone();
                 tokio::spawn(async move {
+                    let Ok(project_id) = synergos_net::quic::read_project_id(&mut recv).await
+                    else {
+                        return;
+                    };
                     if &magic == GOSSIP_STREAM_MAGIC {
                         drop(send);
-                        let _ = handle_gossip_stream(gossip, recv, sender).await;
+                        let _ = handle_gossip_stream(gossip, recv, sender, &project_id).await;
                     } else if &magic == TRANSFER_STREAM_MAGIC {
-                        let _ = exchange.handle_incoming_transfer(recv, sender).await;
+                        let _ = exchange
+                            .handle_incoming_transfer(recv, sender, &project_id)
+                            .await;
                     }
                 });
             }

--- a/synergos-net/src/config.rs
+++ b/synergos-net/src/config.rs
@@ -14,6 +14,9 @@ pub struct NetConfig {
     pub speed_test: SpeedTestConfig,
     pub peer_selection: PeerSelectionConfig,
     pub monitor: MonitorConfig,
+    /// 接続・stream・transferのDoS耐性上限。
+    #[serde(default)]
+    pub resource_limits: QuicResourceLimits,
     /// CatalogManager のチューニング (マジックナンバー解消、後方互換のため
     /// `#[serde(default)]` で旧 config からも読める)。
     #[serde(default)]
@@ -168,6 +171,53 @@ pub struct QuicConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuicResourceLimits {
+    pub max_file_size_bytes: u64,
+    pub transfer_timeout_ms: u64,
+    pub hello_concurrency: usize,
+    pub max_connections_global: usize,
+    pub max_connections_per_ip: usize,
+    pub max_connections_per_peer: usize,
+    pub stream_body_timeout_ms: u64,
+}
+
+impl Default for QuicResourceLimits {
+    fn default() -> Self {
+        Self {
+            max_file_size_bytes: 1024 * 1024 * 1024,
+            transfer_timeout_ms: 5 * 60 * 1000,
+            hello_concurrency: 32,
+            max_connections_global: 1024,
+            max_connections_per_ip: 32,
+            max_connections_per_peer: 1,
+            stream_body_timeout_ms: 30_000,
+        }
+    }
+}
+
+impl QuicResourceLimits {
+    fn validate(&self) -> Result<(), String> {
+        if self.max_file_size_bytes == 0
+            || self.transfer_timeout_ms == 0
+            || self.hello_concurrency == 0
+            || self.max_connections_global == 0
+            || self.max_connections_per_ip == 0
+            || self.max_connections_per_peer == 0
+            || self.stream_body_timeout_ms == 0
+        {
+            return Err("QUIC resource limits must all be greater than zero".into());
+        }
+        if self.max_connections_per_ip > self.max_connections_global {
+            return Err("max_connections_per_ip must not exceed global limit".into());
+        }
+        if self.max_connections_per_peer != 1 {
+            return Err("current QUIC session map requires max_connections_per_peer = 1".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DhtConfig {
     /// Kademlia k-bucket サイズ
     pub k_bucket_size: usize,
@@ -305,6 +355,7 @@ impl Default for NetConfig {
                 history_size: 3600,
                 graph_sample_interval_secs: 1,
             },
+            resource_limits: QuicResourceLimits::default(),
             catalog: CatalogConfig::default(),
             peer_info_listen_addr: None,
             quic_advertised_addr: None,
@@ -320,6 +371,7 @@ impl NetConfig {
     /// 個別の知識は各サブ struct の `validate()` に委譲する。
     pub fn validate(&self) -> Result<(), String> {
         self.stream_allocation.validate()?;
+        self.resource_limits.validate()?;
         Ok(())
     }
 }

--- a/synergos-net/src/content/bitswap.rs
+++ b/synergos-net/src/content/bitswap.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SynergosNetError};
+use crate::quic::write_project_id;
 use crate::types::Cid;
 
 use super::block::Block;
@@ -41,18 +42,29 @@ pub const MAX_WANTLIST_LEN: usize = 1024;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BitswapRequest {
     /// 単一 CID を要求。v1 互換。サーバは `Block` か `NotFound` を 1 フレーム返す。
-    Want { cid: Cid },
+    Want { project_id: String, cid: Cid },
     /// 複数 CID をまとめて要求。
     /// `want_have=false` なら `Block`/`NotFound`、`want_have=true` なら `Have`/`DontHave`
     /// をリクエスト順に 1 フレームずつ返す。
     WantList {
+        project_id: String,
         cids: Vec<Cid>,
         /// true にすると Block 本体ではなくメタ情報 (Have / DontHave) だけ返す。
         #[serde(default)]
         want_have: bool,
     },
     /// 以前送った WANT をキャンセル。応答は返らない (ストリームは即クローズ)。
-    Cancel { cids: Vec<Cid> },
+    Cancel { project_id: String, cids: Vec<Cid> },
+}
+
+impl BitswapRequest {
+    pub fn project_id(&self) -> &str {
+        match self {
+            Self::Want { project_id, .. }
+            | Self::WantList { project_id, .. }
+            | Self::Cancel { project_id, .. } => project_id,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,9 +145,11 @@ async fn read_frame_body(recv: &mut quinn::RecvStream, what: &str) -> Result<Opt
 pub async fn request_block(
     send: quinn::SendStream,
     recv: quinn::RecvStream,
+    project_id: &str,
     cid: &Cid,
 ) -> Result<BitswapResponse> {
-    let mut results = request_many(send, recv, std::slice::from_ref(cid), false).await?;
+    let mut results =
+        request_many(send, recv, project_id, std::slice::from_ref(cid), false).await?;
     results
         .pop()
         .ok_or_else(|| SynergosNetError::Serialization("bitswap empty response".into()))
@@ -149,6 +163,7 @@ pub async fn request_block(
 pub async fn request_many(
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
+    project_id: &str,
     cids: &[Cid],
     want_have: bool,
 ) -> Result<Vec<BitswapResponse>> {
@@ -166,13 +181,16 @@ pub async fn request_many(
     send.write_all(BITSWAP_STREAM_MAGIC)
         .await
         .map_err(|e| SynergosNetError::Quic(format!("bitswap write magic: {e}")))?;
+    write_project_id(&mut send, project_id).await?;
     let req = if cids.len() == 1 && !want_have {
         // v1 互換のため単発は Want で送る (旧サーバとも会話できる)。
         BitswapRequest::Want {
+            project_id: project_id.to_string(),
             cid: cids[0].clone(),
         }
     } else {
         BitswapRequest::WantList {
+            project_id: project_id.to_string(),
             cids: cids.to_vec(),
             want_have,
         }
@@ -205,11 +223,17 @@ pub async fn request_many(
 
 /// Cancel リクエストを送るだけの片道呼び出し。サーバは応答を返さずに close する。
 /// 呼び出し側は `recv` を drop すればよい。
-pub async fn send_cancel(mut send: quinn::SendStream, cids: &[Cid]) -> Result<()> {
+pub async fn send_cancel(
+    mut send: quinn::SendStream,
+    project_id: &str,
+    cids: &[Cid],
+) -> Result<()> {
     send.write_all(BITSWAP_STREAM_MAGIC)
         .await
         .map_err(|e| SynergosNetError::Quic(format!("bitswap write magic: {e}")))?;
+    write_project_id(&mut send, project_id).await?;
     let req = BitswapRequest::Cancel {
+        project_id: project_id.to_string(),
         cids: cids.to_vec(),
     };
     let body = rmp_serde::to_vec(&req)
@@ -229,6 +253,7 @@ pub async fn handle_bitswap_stream<S: ContentStore + ?Sized>(
     store: Arc<S>,
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
+    authorized_project_id: &str,
 ) -> Result<()> {
     let body = read_frame_body(&mut recv, "request")
         .await?
@@ -236,6 +261,11 @@ pub async fn handle_bitswap_stream<S: ContentStore + ?Sized>(
 
     let req: BitswapRequest = rmp_serde::from_slice(&body)
         .map_err(|e| SynergosNetError::Serialization(format!("bitswap req decode: {e}")))?;
+    if req.project_id() != authorized_project_id {
+        return Err(SynergosNetError::Identity(
+            "bitswap request project_id does not match authorized stream scope".into(),
+        ));
+    }
 
     // Cancel は応答無し
     if matches!(req, BitswapRequest::Cancel { .. }) {
@@ -252,8 +282,10 @@ pub async fn handle_bitswap_stream<S: ContentStore + ?Sized>(
 
     // リクエスト → フレーム列へ展開
     let (cids, want_have): (Vec<Cid>, bool) = match req {
-        BitswapRequest::Want { cid } => (vec![cid], false),
-        BitswapRequest::WantList { cids, want_have } => (cids, want_have),
+        BitswapRequest::Want { cid, .. } => (vec![cid], false),
+        BitswapRequest::WantList {
+            cids, want_have, ..
+        } => (cids, want_have),
         BitswapRequest::Cancel { .. } => unreachable!(),
     };
 
@@ -294,12 +326,13 @@ mod tests {
     #[test]
     fn request_want_roundtrip_serde() {
         let r = BitswapRequest::Want {
+            project_id: "p".into(),
             cid: Cid("blake3-abc".into()),
         };
         let b = rmp_serde::to_vec(&r).unwrap();
         let back: BitswapRequest = rmp_serde::from_slice(&b).unwrap();
         match back {
-            BitswapRequest::Want { cid } => assert_eq!(cid.0, "blake3-abc"),
+            BitswapRequest::Want { cid, .. } => assert_eq!(cid.0, "blake3-abc"),
             _ => panic!("wrong variant"),
         }
     }
@@ -307,13 +340,16 @@ mod tests {
     #[test]
     fn request_wantlist_roundtrip_serde() {
         let r = BitswapRequest::WantList {
+            project_id: "p".into(),
             cids: vec![Cid("blake3-a".into()), Cid("blake3-b".into())],
             want_have: true,
         };
         let b = rmp_serde::to_vec(&r).unwrap();
         let back: BitswapRequest = rmp_serde::from_slice(&b).unwrap();
         match back {
-            BitswapRequest::WantList { cids, want_have } => {
+            BitswapRequest::WantList {
+                cids, want_have, ..
+            } => {
                 assert_eq!(cids.len(), 2);
                 assert_eq!(cids[0].0, "blake3-a");
                 assert!(want_have);
@@ -325,6 +361,7 @@ mod tests {
     #[test]
     fn request_cancel_roundtrip_serde() {
         let r = BitswapRequest::Cancel {
+            project_id: "p".into(),
             cids: vec![Cid("blake3-x".into())],
         };
         let b = rmp_serde::to_vec(&r).unwrap();

--- a/synergos-net/src/content/session.rs
+++ b/synergos-net/src/content/session.rs
@@ -45,6 +45,7 @@ where
 {
     quic: Arc<QuicManager>,
     peer: PeerId,
+    project_id: String,
     store: Arc<S>,
     /// fetch_blocks / fetch_dag で同時に張る bidi stream の上限。
     max_inflight_streams: usize,
@@ -54,10 +55,11 @@ impl<S> BitswapSession<S>
 where
     S: ContentStore + ?Sized + 'static,
 {
-    pub fn new(quic: Arc<QuicManager>, peer: PeerId, store: Arc<S>) -> Self {
+    pub fn new(quic: Arc<QuicManager>, peer: PeerId, project_id: String, store: Arc<S>) -> Self {
         Self {
             quic,
             peer,
+            project_id,
             store,
             max_inflight_streams: 4,
         }
@@ -84,7 +86,7 @@ where
                 .quic
                 .open_stream(&self.peer, StreamType::Control)
                 .await?;
-            let resps = request_many(send, recv, batch, true).await?;
+            let resps = request_many(send, recv, &self.project_id, batch, true).await?;
             if resps.len() != batch.len() {
                 return Err(SynergosNetError::Serialization(format!(
                     "bitswap have_query: expected {} responses, got {}",
@@ -152,7 +154,7 @@ where
             .quic
             .open_stream(&self.peer, StreamType::Control)
             .await?;
-        let resps = request_many(send, recv, &cids, false).await?;
+        let resps = request_many(send, recv, &self.project_id, &cids, false).await?;
         if resps.len() != cids.len() {
             return Err(SynergosNetError::Serialization(format!(
                 "bitswap fetch_batch: expected {} responses, got {}",
@@ -261,7 +263,7 @@ mod tests {
         ));
         let _ = quic.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
         let store: Arc<MemoryContentStore> = Arc::new(MemoryContentStore::new());
-        let session = BitswapSession::new(quic, PeerId::new("nobody"), store);
+        let session = BitswapSession::new(quic, PeerId::new("nobody"), "p".into(), store);
         let out = session.have_query(&[]).await.unwrap();
         assert!(out.is_empty());
     }
@@ -288,7 +290,7 @@ mod tests {
         let cid = block.cid.clone();
         store.put(block).await.unwrap();
 
-        let session = BitswapSession::new(quic, PeerId::new("nobody"), store);
+        let session = BitswapSession::new(quic, PeerId::new("nobody"), "p".into(), store);
         let out = session
             .fetch_blocks(std::slice::from_ref(&cid))
             .await

--- a/synergos-net/src/dht/node.rs
+++ b/synergos-net/src/dht/node.rs
@@ -133,6 +133,7 @@ impl DhtNode {
     /// `alpha`, `max_hops`, `per_request_timeout` で暴走を防止する。
     pub async fn find_peer_iterative(
         &self,
+        project_id: &str,
         target: &PeerId,
         transport: &dyn DhtTransport,
         opts: FindNodeOptions,
@@ -174,6 +175,7 @@ impl DhtNode {
             for peer in &round {
                 let peer = peer.clone();
                 let req = DhtRequest::FindNode {
+                    project_id: project_id.to_string(),
                     target: target.clone(),
                 };
                 let timeout = opts.per_request_timeout;
@@ -244,8 +246,8 @@ impl DhtNode {
     /// 受信する型を既に判別済みの前提 — トランスポート層から呼ばれる。
     pub async fn handle_request(&self, req: DhtRequest) -> DhtResponse {
         match req {
-            DhtRequest::Ping => DhtResponse::Pong,
-            DhtRequest::FindNode { target } => {
+            DhtRequest::Ping { .. } => DhtResponse::Pong,
+            DhtRequest::FindNode { target, .. } => {
                 let target_node_id = NodeId::from_peer_id(&target);
                 let exact = self.find_peer_local(&target).await.map(|r| r.to_dto());
                 let closest_ids = self.closest_peers(&target_node_id, 20).await;
@@ -267,7 +269,7 @@ impl DhtNode {
                     .collect();
                 DhtResponse::ProjectPeers { peers }
             }
-            DhtRequest::Announce { record } => {
+            DhtRequest::Announce { record, .. } => {
                 let peer_id = record.peer_id.clone();
                 let endpoints = record.endpoints.iter().map(Into::into).collect::<Vec<_>>();
                 self.announce(PeerRecord::from_dto(record)).await;

--- a/synergos-net/src/dht/rpc.rs
+++ b/synergos-net/src/dht/rpc.rs
@@ -102,13 +102,27 @@ impl From<&RouteDto> for Route {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DhtRequest {
     /// 近接ノードの返却を要求
-    FindNode { target: PeerId },
+    FindNode { project_id: String, target: PeerId },
     /// プロジェクトに参加しているピアを要求
     FindProjectPeers { project_id: String },
     /// 自分のレコードを announce
-    Announce { record: PeerRecordDto },
+    Announce {
+        project_id: String,
+        record: PeerRecordDto,
+    },
     /// ヘルスチェック
-    Ping,
+    Ping { project_id: String },
+}
+
+impl DhtRequest {
+    pub fn project_id(&self) -> &str {
+        match self {
+            Self::FindNode { project_id, .. }
+            | Self::FindProjectPeers { project_id }
+            | Self::Announce { project_id, .. }
+            | Self::Ping { project_id } => project_id,
+        }
+    }
 }
 
 /// DHT RPC レスポンス
@@ -184,12 +198,13 @@ mod tests {
     #[test]
     fn encode_decode_request_roundtrip() {
         let req = DhtRequest::FindNode {
+            project_id: "p".into(),
             target: PeerId::new("abc"),
         };
         let bytes = encode(&req).unwrap();
         let back: DhtRequest = decode(&bytes).unwrap();
         match back {
-            DhtRequest::FindNode { target } => assert_eq!(target.0, "abc"),
+            DhtRequest::FindNode { target, .. } => assert_eq!(target.0, "abc"),
             _ => panic!("wrong variant"),
         }
     }

--- a/synergos-net/src/dht/transport.rs
+++ b/synergos-net/src/dht/transport.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::error::{Result, SynergosNetError};
-use crate::quic::{QuicManager, StreamType};
+use crate::quic::{write_project_id, QuicManager, StreamType};
 use crate::types::PeerId;
 
 use super::node::DhtNode;
@@ -39,6 +39,7 @@ impl DhtTransport for QuicDhtTransport {
 
         // ヘッダ + フレーム
         send.write_all(DHT_STREAM_MAGIC).await.map_err(to_err)?;
+        write_project_id(&mut send, req.project_id()).await?;
         let payload = rpc::encode(req)?;
         send.write_all(&payload).await.map_err(to_err)?;
         send.finish()
@@ -82,6 +83,7 @@ pub async fn handle_dht_stream(
     dht: Arc<DhtNode>,
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
+    authorized_project_id: &str,
 ) -> Result<()> {
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf).await.map_err(to_err)?;
@@ -98,6 +100,11 @@ pub async fn handle_dht_stream(
     full.extend_from_slice(&len_buf);
     full.extend_from_slice(&body);
     let req: DhtRequest = rpc::decode(&full)?;
+    if req.project_id() != authorized_project_id {
+        return Err(SynergosNetError::Identity(
+            "DHT request project_id does not match authorized stream scope".into(),
+        ));
+    }
 
     let resp = dht.handle_request(req).await;
 

--- a/synergos-net/src/gossip/message.rs
+++ b/synergos-net/src/gossip/message.rs
@@ -12,6 +12,8 @@ use crate::types::{Blake3Hash, ChunkId, Cid, FileId, MessageId, PeerId};
 /// 避けるため、wire 上は `Vec<u8>` で保持する。`verify` 時に長さを検証する。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedGossipMessage {
+    /// 署名対象に含めるproject scope。
+    pub project_id: String,
     pub message: GossipMessage,
     /// 送信者の ed25519 公開鍵 (32 bytes expected)
     pub sender_public_key: Vec<u8>,
@@ -21,10 +23,11 @@ pub struct SignedGossipMessage {
 
 impl SignedGossipMessage {
     /// 自分の Identity でメッセージを署名する。
-    pub fn sign(message: GossipMessage, identity: &Identity) -> Self {
-        let bytes = signing_bytes(&message);
+    pub fn sign(project_id: String, message: GossipMessage, identity: &Identity) -> Self {
+        let bytes = scoped_signing_bytes(&project_id, &message);
         let signature = identity.sign(&bytes);
         Self {
+            project_id,
             message,
             sender_public_key: identity.public_key_bytes().to_vec(),
             signature: signature.to_vec(),
@@ -85,9 +88,21 @@ impl SignedGossipMessage {
             // ConflictAlert は project 全体向けなので送信者の明示フィールドは無い。
             GossipMessage::ConflictAlert { .. } => {}
         }
-        identity::verify(&pub_bytes, &signing_bytes(&self.message), &sig_bytes)
-            .map_err(|_| SynergosNetError::Identity("gossip signature invalid".into()))
+        identity::verify(
+            &pub_bytes,
+            &scoped_signing_bytes(&self.project_id, &self.message),
+            &sig_bytes,
+        )
+        .map_err(|_| SynergosNetError::Identity("gossip signature invalid".into()))
     }
+}
+
+fn scoped_signing_bytes(project_id: &str, message: &GossipMessage) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(project_id.len() + 1 + 128);
+    bytes.extend_from_slice(project_id.as_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(&signing_bytes(message));
+    bytes
 }
 
 /// Gossip メッセージの正規バイト列化。

--- a/synergos-net/src/gossip/node.rs
+++ b/synergos-net/src/gossip/node.rs
@@ -151,15 +151,27 @@ impl GossipNode {
 
     /// 署名付き送信用に現在のメッセージを封筒化する。
     /// Identity が未設定の場合は `None` を返し、呼び出し側は送信をスキップする。
-    pub fn envelope(&self, message: GossipMessage) -> Option<SignedGossipMessage> {
+    pub fn envelope(
+        &self,
+        project_id: &str,
+        message: GossipMessage,
+    ) -> Option<SignedGossipMessage> {
         self.identity
             .as_ref()
-            .map(|id| SignedGossipMessage::sign(message, id))
+            .map(|id| SignedGossipMessage::sign(project_id.to_string(), message, id))
     }
 
     /// 受信した SignedGossipMessage を検証し、内側の GossipMessage を取り出す。
     /// 検証失敗 / 未署名は `None`。
-    pub fn verify_envelope(&self, signed: SignedGossipMessage) -> Option<GossipMessage> {
+    pub fn verify_envelope(
+        &self,
+        expected_project_id: &str,
+        signed: SignedGossipMessage,
+    ) -> Option<GossipMessage> {
+        if signed.project_id != expected_project_id {
+            tracing::warn!("dropped gossip message: project_id scope mismatch");
+            return None;
+        }
         if let Err(e) = signed.verify() {
             tracing::warn!("dropped gossip message: {e}");
             return None;
@@ -200,7 +212,11 @@ impl GossipNode {
 
         // Identity を持っていれば署名して outbound にも流す。
         // Daemon の送信タスクがこれを拾って QUIC で各メッシュピアに配る。
-        if let Some(signed) = self.envelope(message) {
+        let Some(project_id) = topic.0.strip_prefix("project/") else {
+            tracing::warn!("skipped outbound gossip for non-project topic");
+            return peers;
+        };
+        if let Some(signed) = self.envelope(project_id, message) {
             let _ = self.outbound_tx.send(OutboundGossip {
                 topic: topic.clone(),
                 signed,
@@ -215,10 +231,11 @@ impl GossipNode {
     pub fn on_signed_message_received(
         &self,
         topic: &TopicId,
+        expected_project_id: &str,
         signed: SignedGossipMessage,
         _from: &PeerId,
     ) -> bool {
-        match self.verify_envelope(signed) {
+        match self.verify_envelope(expected_project_id, signed) {
             Some(msg) => self.deliver(topic, msg),
             None => false,
         }
@@ -365,5 +382,37 @@ mod tests {
         // Second publish returns empty (duplicate)
         let targets = node.publish(&topic, msg);
         assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn file_want_from_different_project_scope_is_rejected() {
+        let identity = Arc::new(Identity::generate());
+        let mut node = GossipNode::new(
+            identity.peer_id().clone(),
+            GossipsubConfig {
+                mesh_n: 6,
+                mesh_n_low: 4,
+                mesh_n_high: 12,
+                heartbeat_interval_ms: 1000,
+                message_cache_size: 100,
+            },
+        );
+        node.set_identity(identity.clone());
+        let signed = SignedGossipMessage::sign(
+            "project-a".into(),
+            GossipMessage::FileWant {
+                requester: identity.peer_id().clone(),
+                file_id: crate::types::FileId::new("f1"),
+                version: 1,
+            },
+            &identity,
+        );
+
+        assert!(!node.on_signed_message_received(
+            &TopicId::project("project-b"),
+            "project-b",
+            signed,
+            identity.peer_id(),
+        ));
     }
 }

--- a/synergos-net/src/gossip/transport.rs
+++ b/synergos-net/src/gossip/transport.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SynergosNetError};
 use crate::gossip::{GossipNode, SignedGossipMessage};
+use crate::quic::write_project_id;
 use crate::types::{PeerId, TopicId};
 
 /// Gossip ストリーム識別マジック。Daemon のディスパッチャが先頭 4 byte を
@@ -32,6 +33,7 @@ pub const MAX_GOSSIP_FRAME: usize = 256 * 1024;
 /// QUIC 上で送る gossip メッセージの wire 形式。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GossipWireMessage {
+    pub project_id: String,
     pub topic: TopicId,
     pub signed: SignedGossipMessage,
 }
@@ -61,6 +63,7 @@ pub async fn send_gossip(mut send: quinn::SendStream, msg: &GossipWireMessage) -
     send.write_all(GOSSIP_STREAM_MAGIC)
         .await
         .map_err(|e| SynergosNetError::Quic(format!("gossip magic: {e}")))?;
+    write_project_id(&mut send, &msg.project_id).await?;
     let len = (body.len() as u32).to_be_bytes();
     send.write_all(&len)
         .await
@@ -79,6 +82,7 @@ pub async fn handle_gossip_stream(
     gossip: Arc<GossipNode>,
     mut recv: quinn::RecvStream,
     from: PeerId,
+    authorized_project_id: &str,
 ) -> Result<()> {
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf)
@@ -98,9 +102,17 @@ pub async fn handle_gossip_stream(
 
     let wire: GossipWireMessage = rmp_serde::from_slice(&body)
         .map_err(|e| SynergosNetError::Serialization(format!("gossip decode: {e}")))?;
+    if wire.project_id != authorized_project_id
+        || wire.signed.project_id != authorized_project_id
+        || wire.topic != TopicId::project(authorized_project_id)
+    {
+        return Err(SynergosNetError::Identity(
+            "gossip project_id does not match authorized stream scope".into(),
+        ));
+    }
 
     // 署名検証 + ローカル deliver。deliver の後で broadcast channel 経由で
     // 購読者 (Exchange, Presence 等) に届く。
-    gossip.on_signed_message_received(&wire.topic, wire.signed, &from);
+    gossip.on_signed_message_received(&wire.topic, authorized_project_id, wire.signed, &from);
     Ok(())
 }

--- a/synergos-net/src/quic/hello.rs
+++ b/synergos-net/src/quic/hello.rs
@@ -1,22 +1,12 @@
-//! アプリケーション層のピア認識 Hello (HLO1)。
+//! アプリケーション層の相互ピア認証 Hello。
 //!
-//! S1 QUIC 認証は「クライアントがサーバ (expected) を特定する」一方向の
-//! 真性検証。サーバ側は `no_client_auth` で動くので、相手クライアントの
-//! PeerId は cert から取れない (pending-{addr} になる)。本プロトコルで
-//! 相手も ed25519 署名付き Hello を送ることで、サーバは相手を確定できる。
-//!
-//! プロトコル:
-//!   1. クライアントは connect 直後に QUIC bidi `HLO1` ストリームを開き、
-//!      `SignedHello { peer_id, public_key, ts_ms }` を送る。
-//!   2. サーバは accept_bi 後に magic `HLO1` を確認し、署名を検証して
-//!      `blake3(public_key)[:20] == peer_id` を照合する。
-//!   3. サーバ側はそれを以降の全ての認識に使い、DHT / Transfer / Gossip の
-//!      ストリームディスパッチもこの peer_id で紐付ける。
-//!
-//! 失敗時はコネクションを close する (なりすましを受け入れない)。
+//! HLO1 の wire 型は互換のため残すが、server は replay 耐性のない HLO1 を
+//! 受理しない。実接続は HLO2 の server nonce challenge と TLS exporter の
+//! channel binding を使う。
 
 use std::time::Duration;
 
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 
@@ -24,17 +14,24 @@ use crate::error::{Result, SynergosNetError};
 use crate::identity::{self, Identity};
 use crate::types::PeerId;
 
-/// Hello ストリーム識別マジック。
-pub const HELLO_STREAM_MAGIC: &[u8; 4] = b"HLO1";
-
-/// Hello 往復のタイムアウト。サーバ側 accept 後ここでブロックする。
+/// replay 耐性のない旧 magic。server は明示的に拒否する。
+pub const HELLO1_STREAM_MAGIC: &[u8; 4] = b"HLO1";
+/// server nonce challenge を使う現行 magic。
+pub const HELLO2_STREAM_MAGIC: &[u8; 4] = b"HLO2";
 pub const HELLO_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// 送信される `Hello` 本体。`signing_bytes` でバイト列に落として署名する。
+const SERVER_NONCE_LEN: usize = 32;
+const TLS_EXPORTER_LEN: usize = 32;
+const TLS_EXPORTER_LABEL: &[u8] = b"synergos-hlo2";
+const TLS_EXPORTER_CONTEXT: &[u8] = b"";
+const MAX_HELLO_BODY: usize = 4096;
+const MAX_CLOCK_SKEW_MS: u64 = 60_000;
+
+/// HLO1 本体。wire decode 互換のためのみ残す。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Hello {
     pub peer_id: PeerId,
-    pub public_key: Vec<u8>, // 32 bytes
+    pub public_key: Vec<u8>,
     pub ts_ms: u64,
 }
 
@@ -49,155 +46,344 @@ impl Hello {
     }
 }
 
+/// HLO1 署名 envelope。server 検証経路からは使用しない。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedHello {
     pub hello: Hello,
-    pub signature: Vec<u8>, // 64 bytes
+    pub signature: Vec<u8>,
 }
 
 impl SignedHello {
     pub fn new(identity: &Identity) -> Self {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
         let hello = Hello {
             peer_id: identity.peer_id().clone(),
             public_key: identity.public_key_bytes().to_vec(),
-            ts_ms: now_ms,
+            ts_ms: now_ms(),
         };
-        let sig = identity.sign(&hello.signing_bytes());
-        Self {
-            hello,
-            signature: sig.to_vec(),
-        }
+        let signature = identity.sign(&hello.signing_bytes()).to_vec();
+        Self { hello, signature }
+    }
+}
+
+/// HLO2 の署名対象と署名を一体化した wire 型。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedHello2 {
+    pub peer_id: PeerId,
+    pub public_key: Vec<u8>,
+    pub server_nonce: [u8; SERVER_NONCE_LEN],
+    pub tls_exporter: [u8; TLS_EXPORTER_LEN],
+    pub ts_ms: u64,
+    pub signature: Vec<u8>,
+}
+
+impl SignedHello2 {
+    pub fn new(
+        identity: &Identity,
+        server_nonce: [u8; SERVER_NONCE_LEN],
+        tls_exporter: [u8; TLS_EXPORTER_LEN],
+    ) -> Self {
+        Self::new_at(identity, server_nonce, tls_exporter, now_ms())
     }
 
-    /// 署名と peer_id = blake3(public_key) を検証する。成功時は中の PeerId を返す。
-    pub fn verify(&self) -> Result<PeerId> {
-        if self.hello.public_key.len() != 32 {
+    fn new_at(
+        identity: &Identity,
+        server_nonce: [u8; SERVER_NONCE_LEN],
+        tls_exporter: [u8; TLS_EXPORTER_LEN],
+        ts_ms: u64,
+    ) -> Self {
+        let mut signed = Self {
+            peer_id: identity.peer_id().clone(),
+            public_key: identity.public_key_bytes().to_vec(),
+            server_nonce,
+            tls_exporter,
+            ts_ms,
+            signature: Vec::new(),
+        };
+        signed.signature = identity.sign(&signed.signing_bytes()).to_vec();
+        signed
+    }
+
+    fn signing_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(160 + self.public_key.len());
+        out.extend_from_slice(HELLO2_STREAM_MAGIC);
+        out.extend_from_slice(self.peer_id.0.as_bytes());
+        out.push(0);
+        out.extend_from_slice(&self.public_key);
+        out.extend_from_slice(&self.server_nonce);
+        out.extend_from_slice(&self.tls_exporter);
+        out.extend_from_slice(&self.ts_ms.to_le_bytes());
+        out
+    }
+
+    fn verify_fields(
+        &self,
+        expected_nonce: &[u8; SERVER_NONCE_LEN],
+        expected_exporter: &[u8; TLS_EXPORTER_LEN],
+        current_ms: u64,
+    ) -> Result<PeerId> {
+        if self.public_key.len() != 32 {
             return Err(SynergosNetError::Identity(
-                "hello public_key length != 32".into(),
+                "HLO2 public_key length != 32".into(),
             ));
         }
         if self.signature.len() != 64 {
             return Err(SynergosNetError::Identity(
-                "hello signature length != 64".into(),
+                "HLO2 signature length != 64".into(),
             ));
         }
-        let mut pk = [0u8; 32];
-        pk.copy_from_slice(&self.hello.public_key);
-        let mut sig = [0u8; 64];
-        sig.copy_from_slice(&self.signature);
-
-        let derived = identity::peer_id_from_public_bytes(&pk);
-        if derived != self.hello.peer_id {
+        if &self.server_nonce != expected_nonce {
             return Err(SynergosNetError::Identity(
-                "hello peer_id does not match public_key".into(),
+                "HLO2 server nonce mismatch".into(),
             ));
         }
-        identity::verify(&pk, &self.hello.signing_bytes(), &sig)
-            .map_err(|_| SynergosNetError::Identity("hello signature invalid".into()))?;
+        if &self.tls_exporter != expected_exporter {
+            return Err(SynergosNetError::Identity(
+                "HLO2 TLS exporter mismatch".into(),
+            ));
+        }
+        if self.ts_ms.abs_diff(current_ms) > MAX_CLOCK_SKEW_MS {
+            return Err(SynergosNetError::Identity(
+                "HLO2 timestamp outside allowed skew".into(),
+            ));
+        }
 
+        let mut public_key = [0u8; 32];
+        public_key.copy_from_slice(&self.public_key);
+        let derived = identity::peer_id_from_public_bytes(&public_key);
+        if derived != self.peer_id {
+            return Err(SynergosNetError::Identity(
+                "HLO2 peer_id does not match public_key".into(),
+            ));
+        }
+
+        let mut signature = [0u8; 64];
+        signature.copy_from_slice(&self.signature);
+        identity::verify(&public_key, &self.signing_bytes(), &signature)
+            .map_err(|_| SynergosNetError::Identity("HLO2 signature invalid".into()))?;
         Ok(derived)
     }
 }
 
-/// クライアント側: connect 成功直後に呼ぶ。`HLO1` bidi ストリームを 1 本開き、
-/// 自分の SignedHello を送る。サーバ側からの応答 (ack) は任意扱いで待たない。
-pub async fn send_hello(connection: &quinn::Connection, identity: &Identity) -> Result<()> {
-    let signed = SignedHello::new(identity);
-    let payload = rmp_serde::to_vec(&signed)
-        .map_err(|e| SynergosNetError::Serialization(format!("hello encode: {e}")))?;
-
-    let (mut send, _recv) = connection
-        .open_bi()
-        .await
-        .map_err(|e| SynergosNetError::Quic(format!("hello open_bi: {e}")))?;
-    send.write_all(HELLO_STREAM_MAGIC)
-        .await
-        .map_err(|e| SynergosNetError::Quic(format!("hello magic: {e}")))?;
-    let len = (payload.len() as u32).to_be_bytes();
-    send.write_all(&len)
-        .await
-        .map_err(|e| SynergosNetError::Quic(format!("hello len: {e}")))?;
-    send.write_all(&payload)
-        .await
-        .map_err(|e| SynergosNetError::Quic(format!("hello body: {e}")))?;
-    send.finish()
-        .map_err(|e| SynergosNetError::Quic(format!("hello finish: {e}")))?;
-    Ok(())
+/// 1 接続専用の server challenge。一度検証を試みた nonce は再使用できない。
+struct ServerChallenge {
+    nonce: [u8; SERVER_NONCE_LEN],
+    consumed: bool,
 }
 
-/// サーバ側: QUIC 接続確立直後、最初の bidi ストリームから HLO1 を読んで
-/// 相手の PeerId を返す。タイムアウトまでに届かなければエラー。
-pub async fn recv_hello(connection: &quinn::Connection) -> Result<PeerId> {
-    let accept_fut = async {
-        let (_send, mut recv) = connection
+impl ServerChallenge {
+    fn random() -> Self {
+        let mut nonce = [0u8; SERVER_NONCE_LEN];
+        rand::rngs::OsRng.fill_bytes(&mut nonce);
+        Self {
+            nonce,
+            consumed: false,
+        }
+    }
+
+    #[cfg(test)]
+    fn fixed(nonce: [u8; SERVER_NONCE_LEN]) -> Self {
+        Self {
+            nonce,
+            consumed: false,
+        }
+    }
+
+    fn verify_once(
+        &mut self,
+        signed: &SignedHello2,
+        expected_exporter: &[u8; TLS_EXPORTER_LEN],
+        current_ms: u64,
+    ) -> Result<PeerId> {
+        if self.consumed {
+            return Err(SynergosNetError::Identity(
+                "HLO2 server nonce already consumed".into(),
+            ));
+        }
+        self.consumed = true;
+        signed.verify_fields(&self.nonce, expected_exporter, current_ms)
+    }
+}
+
+fn tls_exporter(connection: &quinn::Connection) -> Result<[u8; TLS_EXPORTER_LEN]> {
+    let mut output = [0u8; TLS_EXPORTER_LEN];
+    connection
+        .export_keying_material(&mut output, TLS_EXPORTER_LABEL, TLS_EXPORTER_CONTEXT)
+        .map_err(|e| SynergosNetError::Identity(format!("HLO2 TLS exporter failed: {e:?}")))?;
+    Ok(output)
+}
+
+/// client: HLO2 stream を開き、server nonce を受け取って channel-bound Hello を返す。
+pub async fn send_hello2(connection: &quinn::Connection, identity: &Identity) -> Result<()> {
+    let exchange = async {
+        let (mut send, mut recv) = connection
+            .open_bi()
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 open_bi: {e}")))?;
+        send.write_all(HELLO2_STREAM_MAGIC)
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 magic: {e}")))?;
+
+        let mut server_nonce = [0u8; SERVER_NONCE_LEN];
+        recv.read_exact(&mut server_nonce)
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 server nonce: {e}")))?;
+        let signed = SignedHello2::new(identity, server_nonce, tls_exporter(connection)?);
+        let payload = rmp_serde::to_vec(&signed)
+            .map_err(|e| SynergosNetError::Serialization(format!("HLO2 encode: {e}")))?;
+        send.write_all(&(payload.len() as u32).to_be_bytes())
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 len: {e}")))?;
+        send.write_all(&payload)
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 body: {e}")))?;
+        send.finish()
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 finish: {e}")))?;
+        Ok(())
+    };
+
+    timeout(HELLO_TIMEOUT, exchange)
+        .await
+        .map_err(|_| SynergosNetError::Identity("HLO2 send timed out".into()))?
+}
+
+/// server: 最初の bidi stream で HLO2 challenge を実行し、認証済み PeerId を返す。
+pub async fn recv_hello2(connection: &quinn::Connection) -> Result<PeerId> {
+    let exchange = async {
+        let (mut send, mut recv) = connection
             .accept_bi()
             .await
-            .map_err(|e| SynergosNetError::Quic(format!("hello accept_bi: {e}")))?;
-
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 accept_bi: {e}")))?;
         let mut magic = [0u8; 4];
         recv.read_exact(&mut magic)
             .await
-            .map_err(|e| SynergosNetError::Quic(format!("hello magic: {e}")))?;
-        if &magic != HELLO_STREAM_MAGIC {
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 magic: {e}")))?;
+        if &magic == HELLO1_STREAM_MAGIC {
+            return Err(SynergosNetError::Identity(
+                "HLO1 rejected: replay-resistant HLO2 required".into(),
+            ));
+        }
+        if &magic != HELLO2_STREAM_MAGIC {
             return Err(SynergosNetError::Identity(format!(
-                "unexpected first-stream magic: expected HLO1, got {magic:?}"
+                "unexpected first-stream magic: expected HLO2, got {magic:?}"
             )));
         }
+
+        let mut challenge = ServerChallenge::random();
+        send.write_all(&challenge.nonce)
+            .await
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 server nonce: {e}")))?;
+        send.finish()
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 nonce finish: {e}")))?;
+
         let mut len_buf = [0u8; 4];
         recv.read_exact(&mut len_buf)
             .await
-            .map_err(|e| SynergosNetError::Quic(format!("hello len: {e}")))?;
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 len: {e}")))?;
         let len = u32::from_be_bytes(len_buf) as usize;
-        if len > 4096 {
-            return Err(SynergosNetError::Identity(format!(
-                "hello too large: {len}"
-            )));
+        if len > MAX_HELLO_BODY {
+            return Err(SynergosNetError::Identity(format!("HLO2 too large: {len}")));
         }
         let mut body = vec![0u8; len];
         recv.read_exact(&mut body)
             .await
-            .map_err(|e| SynergosNetError::Quic(format!("hello body: {e}")))?;
-
-        let signed: SignedHello = rmp_serde::from_slice(&body)
-            .map_err(|e| SynergosNetError::Serialization(format!("hello decode: {e}")))?;
-        signed.verify()
+            .map_err(|e| SynergosNetError::Quic(format!("HLO2 body: {e}")))?;
+        let signed: SignedHello2 = rmp_serde::from_slice(&body)
+            .map_err(|e| SynergosNetError::Serialization(format!("HLO2 decode: {e}")))?;
+        challenge.verify_once(&signed, &tls_exporter(connection)?, now_ms())
     };
 
-    timeout(HELLO_TIMEOUT, accept_fut)
+    timeout(HELLO_TIMEOUT, exchange)
         .await
-        .map_err(|_| SynergosNetError::Identity("hello timed out".into()))?
+        .map_err(|_| SynergosNetError::Identity("HLO2 receive timed out".into()))?
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const NONCE_A: [u8; SERVER_NONCE_LEN] = [0xA5; SERVER_NONCE_LEN];
+    const NONCE_B: [u8; SERVER_NONCE_LEN] = [0xB6; SERVER_NONCE_LEN];
+    const EXPORTER_A: [u8; TLS_EXPORTER_LEN] = [0x11; TLS_EXPORTER_LEN];
+    const EXPORTER_B: [u8; TLS_EXPORTER_LEN] = [0x22; TLS_EXPORTER_LEN];
+
     #[test]
-    fn signed_hello_roundtrip() {
-        let id = Identity::generate();
-        let signed = SignedHello::new(&id);
-        let peer_id = signed.verify().unwrap();
-        assert_eq!(&peer_id, id.peer_id());
+    fn signed_hello2_roundtrip() {
+        let identity = Identity::generate();
+        let signed = SignedHello2::new(&identity, NONCE_A, EXPORTER_A);
+        let mut challenge = ServerChallenge::fixed(NONCE_A);
+        assert_eq!(
+            challenge
+                .verify_once(&signed, &EXPORTER_A, signed.ts_ms)
+                .unwrap(),
+            *identity.peer_id()
+        );
     }
 
     #[test]
     fn tampered_public_key_rejected() {
-        let id = Identity::generate();
-        let mut signed = SignedHello::new(&id);
-        // 公開鍵の 1 バイトをフリップ → derived != peer_id もしくは署名検証失敗
-        signed.hello.public_key[0] ^= 0xFF;
-        assert!(signed.verify().is_err());
+        let identity = Identity::generate();
+        let mut signed = SignedHello2::new(&identity, NONCE_A, EXPORTER_A);
+        signed.public_key[0] ^= 0xFF;
+        let mut challenge = ServerChallenge::fixed(NONCE_A);
+        assert!(challenge
+            .verify_once(&signed, &EXPORTER_A, signed.ts_ms)
+            .is_err());
     }
 
     #[test]
     fn tampered_signature_rejected() {
-        let id = Identity::generate();
-        let mut signed = SignedHello::new(&id);
+        let identity = Identity::generate();
+        let mut signed = SignedHello2::new(&identity, NONCE_A, EXPORTER_A);
         signed.signature[0] ^= 0xFF;
-        assert!(signed.verify().is_err());
+        let mut challenge = ServerChallenge::fixed(NONCE_A);
+        assert!(challenge
+            .verify_once(&signed, &EXPORTER_A, signed.ts_ms)
+            .is_err());
+    }
+
+    #[test]
+    fn replayed_hello_rejected() {
+        let identity = Identity::generate();
+        let signed = SignedHello2::new(&identity, NONCE_A, EXPORTER_A);
+
+        let mut different_nonce = ServerChallenge::fixed(NONCE_B);
+        assert!(different_nonce
+            .verify_once(&signed, &EXPORTER_A, signed.ts_ms)
+            .is_err());
+        let mut different_connection = ServerChallenge::fixed(NONCE_A);
+        assert!(different_connection
+            .verify_once(&signed, &EXPORTER_B, signed.ts_ms)
+            .is_err());
+    }
+
+    #[test]
+    fn stale_timestamp_rejected() {
+        let identity = Identity::generate();
+        let current = now_ms();
+        let signed = SignedHello2::new_at(&identity, NONCE_A, EXPORTER_A, current - 61_000);
+        let mut challenge = ServerChallenge::fixed(NONCE_A);
+        assert!(challenge
+            .verify_once(&signed, &EXPORTER_A, current)
+            .is_err());
+    }
+
+    #[test]
+    fn nonce_reuse_rejected() {
+        let identity = Identity::generate();
+        let signed = SignedHello2::new(&identity, NONCE_A, EXPORTER_A);
+        let mut challenge = ServerChallenge::fixed(NONCE_A);
+        assert!(challenge
+            .verify_once(&signed, &EXPORTER_A, signed.ts_ms)
+            .is_ok());
+        assert!(challenge
+            .verify_once(&signed, &EXPORTER_A, signed.ts_ms)
+            .is_err());
     }
 }

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -22,16 +22,18 @@ pub mod hello;
 mod session;
 mod verifier;
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
 use tokio::sync::RwLock;
 
-use crate::config::QuicConfig;
+use crate::config::{QuicConfig, QuicResourceLimits};
 use crate::error::{Result, SynergosNetError};
 use crate::identity::Identity;
+use crate::transfer::TransferLimits;
 use crate::types::{PeerId, TransferId};
 
 pub use session::{read_project_id, write_project_id, ConnectionSession, ProjectId};
@@ -139,6 +141,7 @@ impl ConnectionCalibrator {
 /// サーバー（着信接続の受付）とクライアント（発信接続の確立）の両方を担当する。
 pub struct QuicManager {
     config: QuicConfig,
+    resource_limits: QuicResourceLimits,
     /// 自ノードの暗号アイデンティティ (S1 の真性認証で使う)
     identity: Arc<Identity>,
     /// アクティブなコネクション（PeerId → QuicConnection）
@@ -149,19 +152,85 @@ pub struct QuicManager {
     local_addr: RwLock<Option<SocketAddr>>,
     /// コネクションごとの帯域推定値
     bandwidth_estimates: DashMap<PeerId, u64>,
+    pending_connections: Arc<AtomicUsize>,
+    pending_by_ip: Arc<DashMap<IpAddr, usize>>,
 }
 
 impl QuicManager {
     pub fn new(config: QuicConfig, identity: Arc<Identity>) -> Self {
+        Self::with_resource_limits(config, QuicResourceLimits::default(), identity)
+    }
+
+    pub fn with_resource_limits(
+        config: QuicConfig,
+        resource_limits: QuicResourceLimits,
+        identity: Arc<Identity>,
+    ) -> Self {
         install_default_crypto_provider();
         Self {
             config,
+            resource_limits,
             identity,
             connections: DashMap::new(),
             endpoint: RwLock::new(None),
             local_addr: RwLock::new(None),
             bandwidth_estimates: DashMap::new(),
+            pending_connections: Arc::new(AtomicUsize::new(0)),
+            pending_by_ip: Arc::new(DashMap::new()),
         }
+    }
+
+    pub fn resource_limits(&self) -> &QuicResourceLimits {
+        &self.resource_limits
+    }
+
+    pub fn transfer_limits(&self) -> TransferLimits {
+        TransferLimits {
+            max_file_size_bytes: self.resource_limits.max_file_size_bytes,
+            transfer_timeout: Duration::from_millis(self.resource_limits.transfer_timeout_ms),
+        }
+    }
+
+    fn acquire_pending_connection(&self, ip: IpAddr) -> Result<PendingConnectionGuard> {
+        let pending_before = self.pending_connections.fetch_add(1, Ordering::AcqRel);
+        if self.connections.len() + pending_before >= self.resource_limits.max_connections_global {
+            self.pending_connections.fetch_sub(1, Ordering::AcqRel);
+            return Err(SynergosNetError::Quic(
+                "global connection limit exceeded".into(),
+            ));
+        }
+
+        let active_for_ip = self
+            .connections
+            .iter()
+            .filter(|entry| entry.remote_addr.ip() == ip)
+            .count();
+        let mut pending_for_ip = self.pending_by_ip.entry(ip).or_insert(0);
+        if active_for_ip + *pending_for_ip >= self.resource_limits.max_connections_per_ip {
+            drop(pending_for_ip);
+            self.pending_connections.fetch_sub(1, Ordering::AcqRel);
+            return Err(SynergosNetError::Quic(
+                "per-IP connection limit exceeded".into(),
+            ));
+        }
+        *pending_for_ip += 1;
+        drop(pending_for_ip);
+
+        Ok(PendingConnectionGuard {
+            global: self.pending_connections.clone(),
+            by_ip: self.pending_by_ip.clone(),
+            ip,
+        })
+    }
+
+    fn ensure_peer_capacity(&self, peer_id: &PeerId) -> Result<()> {
+        let active = usize::from(self.connections.contains_key(peer_id));
+        if active >= self.resource_limits.max_connections_per_peer {
+            return Err(SynergosNetError::Quic(
+                "per-peer connection limit exceeded".into(),
+            ));
+        }
+        Ok(())
     }
 
     /// QUIC エンドポイントを初期化し、リスンを開始する。
@@ -205,6 +274,8 @@ impl QuicManager {
         addr: SocketAddr,
         server_name: &str,
     ) -> Result<()> {
+        let _pending = self.acquire_pending_connection(addr.ip())?;
+        self.ensure_peer_capacity(&expected_peer_id)?;
         let endpoint = self.endpoint.read().await;
         let endpoint = endpoint
             .as_ref()
@@ -384,12 +455,13 @@ impl QuicManager {
             Some(inc) => inc,
             None => return Ok(None),
         };
+        let remote_addr = incoming.remote_address();
+        let _pending = self.acquire_pending_connection(remote_addr.ip())?;
 
         let connection = incoming
             .await
             .map_err(|e| SynergosNetError::Quic(format!("Incoming handshake failed: {e}")))?;
 
-        let remote_addr = connection.remote_address();
         let rtt = connection.rtt().as_millis() as u32;
 
         // クライアントと HLO2 challenge を行い peer_id を確定させる。
@@ -401,6 +473,10 @@ impl QuicManager {
                 return Err(e);
             }
         };
+        if let Err(error) = self.ensure_peer_capacity(&peer_id) {
+            connection.close(0u32.into(), b"connection limit exceeded");
+            return Err(error);
+        }
 
         let session = Arc::new(ConnectionSession::new(peer_id.clone()));
         let quic_conn = QuicConnection {
@@ -527,6 +603,26 @@ impl QuicManager {
     }
 }
 
+struct PendingConnectionGuard {
+    global: Arc<AtomicUsize>,
+    by_ip: Arc<DashMap<IpAddr, usize>>,
+    ip: IpAddr,
+}
+
+impl Drop for PendingConnectionGuard {
+    fn drop(&mut self) {
+        self.global.fetch_sub(1, Ordering::AcqRel);
+        if let Some(mut count) = self.by_ip.get_mut(&self.ip) {
+            *count = count.saturating_sub(1);
+            let remove = *count == 0;
+            drop(count);
+            if remove {
+                self.by_ip.remove(&self.ip);
+            }
+        }
+    }
+}
+
 /// rustls 0.23 は `ServerConfig::builder()` / `ClientConfig::builder()` が
 /// 既定の `CryptoProvider` を要求する。`rustls` の feature `ring` 有効化と
 /// `aws-lc-rs` 未有効の条件でのみ auto-detect が働くが、依存グラフの都合で
@@ -589,4 +685,76 @@ pub struct QuicConnectionInfo {
     pub active_streams: u32,
     pub state: QuicConnectionState,
     pub rtt_ms: u32,
+}
+
+#[cfg(test)]
+mod resource_limit_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn config() -> QuicConfig {
+        QuicConfig {
+            max_concurrent_streams: 8,
+            idle_timeout_ms: 5_000,
+            max_udp_payload_size: 1350,
+            enable_0rtt: false,
+            listen_addr: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn slow_hello_does_not_block_another_accept_worker() {
+        let server_identity = Arc::new(Identity::generate());
+        let slow_identity = Arc::new(Identity::generate());
+        let fast_identity = Arc::new(Identity::generate());
+        let server = Arc::new(QuicManager::new(config(), server_identity.clone()));
+        let slow = Arc::new(QuicManager::new(config(), slow_identity));
+        let fast = Arc::new(QuicManager::new(config(), fast_identity));
+        let server_addr = server.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+        slow.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+        fast.bind((Ipv4Addr::LOCALHOST, 0).into()).await.unwrap();
+
+        let slow_accept = tokio::spawn({
+            let server = server.clone();
+            async move { server.accept().await }
+        });
+        tokio::task::yield_now().await;
+
+        let slow_endpoint = slow.endpoint.read().await.as_ref().unwrap().clone();
+        let slow_config = slow
+            .build_client_config_for(server_identity.peer_id().clone())
+            .unwrap();
+        let slow_connection = slow_endpoint
+            .connect_with(slow_config, server_addr, "synergos")
+            .unwrap()
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let fast_accept = tokio::spawn({
+            let server = server.clone();
+            async move { server.accept().await }
+        });
+        let fast_connect = tokio::spawn({
+            let fast = fast.clone();
+            let server_peer = server_identity.peer_id().clone();
+            async move { fast.connect(server_peer, server_addr, "synergos").await }
+        });
+
+        let accepted = tokio::time::timeout(Duration::from_secs(1), fast_accept)
+            .await
+            .expect("second accept must not wait for slow HLO")
+            .unwrap()
+            .unwrap()
+            .expect("connection accepted");
+        fast_connect.await.unwrap().unwrap();
+        assert_eq!(accepted.peer_id, *fast.identity.peer_id());
+        assert!(!slow_accept.is_finished());
+
+        slow_connection.close(0u32.into(), b"test complete");
+        slow_accept.abort();
+        server.shutdown().await;
+        slow.shutdown().await;
+        fast.shutdown().await;
+    }
 }

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -230,9 +230,9 @@ impl QuicManager {
 
         let rtt = connection.rtt().as_millis() as u32;
 
-        // 相互認識のため HLO1 ストリームで自分の署名 Hello を送る。
+        // 相互認識のため HLO2 の server nonce + channel-bound Hello を送る。
         // 失敗しても接続は閉じる (相手にこちらの PeerId を確信させられない)。
-        if let Err(e) = hello::send_hello(&connection, &self.identity).await {
+        if let Err(e) = hello::send_hello2(&connection, &self.identity).await {
             connection.close(0u32.into(), b"hello failed");
             return Err(SynergosNetError::Identity(format!(
                 "hello send failed: {e}"
@@ -372,9 +372,9 @@ impl QuicManager {
         let remote_addr = connection.remote_address();
         let rtt = connection.rtt().as_millis() as u32;
 
-        // クライアントからの HLO1 Hello を待って peer_id を確定させる。
+        // クライアントと HLO2 challenge を行い peer_id を確定させる。
         // タイムアウト / 不正 Hello ならコネクションを閉じて拒否する。
-        let peer_id = match hello::recv_hello(&connection).await {
+        let peer_id = match hello::recv_hello2(&connection).await {
             Ok(pid) => pid,
             Err(e) => {
                 connection.close(0u32.into(), b"hello rejected");

--- a/synergos-net/src/quic/mod.rs
+++ b/synergos-net/src/quic/mod.rs
@@ -19,6 +19,7 @@
 //!    拒否する。緩和パス (旧 `DevOnlySkipVerify`) は完全に削除した。
 
 pub mod hello;
+mod session;
 mod verifier;
 
 use std::net::SocketAddr;
@@ -33,6 +34,7 @@ use crate::error::{Result, SynergosNetError};
 use crate::identity::Identity;
 use crate::types::{PeerId, TransferId};
 
+pub use session::{read_project_id, write_project_id, ConnectionSession, ProjectId};
 pub use verifier::PeerPinningVerifier;
 
 /// QUIC ストリーム種別
@@ -59,6 +61,8 @@ pub struct QuicConnection {
     pub rtt_ms: u32,
     /// quinn コネクションハンドル
     connection: Option<quinn::Connection>,
+    /// この接続で利用を許可された project の集合。
+    session: Arc<ConnectionSession>,
 }
 
 /// QUIC 接続状態
@@ -246,6 +250,7 @@ impl QuicManager {
             state: QuicConnectionState::Connected,
             rtt_ms: rtt,
             connection: Some(connection),
+            session: Arc::new(ConnectionSession::new(expected_peer_id.clone())),
         };
 
         self.connections.insert(expected_peer_id, quic_conn);
@@ -335,6 +340,21 @@ impl QuicManager {
             .and_then(|e| e.connection.clone())
     }
 
+    /// 認証済み接続の認可sessionを取得する。T6 redeem 成功時の登録先でもある。
+    pub fn connection_session(&self, peer_id: &PeerId) -> Option<Arc<ConnectionSession>> {
+        self.connections
+            .get(peer_id)
+            .map(|entry| entry.session.clone())
+    }
+
+    pub fn authorize_project(&self, peer_id: &PeerId, project_id: ProjectId) -> Result<()> {
+        let session = self
+            .connection_session(peer_id)
+            .ok_or_else(|| SynergosNetError::PeerNotFound(peer_id.to_string()))?;
+        session.authorize_project(project_id);
+        Ok(())
+    }
+
     /// 全接続の情報を取得
     pub fn list_connections(&self) -> Vec<QuicConnectionInfo> {
         self.connections
@@ -382,6 +402,7 @@ impl QuicManager {
             }
         };
 
+        let session = Arc::new(ConnectionSession::new(peer_id.clone()));
         let quic_conn = QuicConnection {
             peer_id: peer_id.clone(),
             remote_addr,
@@ -389,6 +410,7 @@ impl QuicManager {
             state: QuicConnectionState::Connected,
             rtt_ms: rtt,
             connection: Some(connection.clone()),
+            session: session.clone(),
         };
         self.connections.insert(peer_id.clone(), quic_conn);
 
@@ -396,6 +418,7 @@ impl QuicManager {
             peer_id,
             remote_addr,
             connection,
+            session,
         }))
     }
 
@@ -522,6 +545,7 @@ pub struct AcceptedConnection {
     pub peer_id: PeerId,
     pub remote_addr: SocketAddr,
     pub connection: quinn::Connection,
+    pub session: Arc<ConnectionSession>,
 }
 
 /// rcgen で ed25519 keypair から自己署名証明書を作り、rustls が受け取れる

--- a/synergos-net/src/quic/session.rs
+++ b/synergos-net/src/quic/session.rs
@@ -1,0 +1,98 @@
+use std::collections::HashSet;
+use std::sync::RwLock;
+
+use crate::error::{Result, SynergosNetError};
+use crate::types::PeerId;
+
+pub type ProjectId = String;
+
+const MAX_PROJECT_ID_LEN: usize = 1024;
+
+/// 認証済みconnectionに紐づくproject membership認可状態。
+#[derive(Debug)]
+pub struct ConnectionSession {
+    peer_id: PeerId,
+    authorized_projects: RwLock<HashSet<ProjectId>>,
+}
+
+impl ConnectionSession {
+    pub fn new(peer_id: PeerId) -> Self {
+        Self {
+            peer_id,
+            authorized_projects: RwLock::new(HashSet::new()),
+        }
+    }
+
+    pub fn peer_id(&self) -> &PeerId {
+        &self.peer_id
+    }
+
+    pub fn authorize_project(&self, project_id: ProjectId) {
+        if let Ok(mut projects) = self.authorized_projects.write() {
+            projects.insert(project_id);
+        }
+    }
+
+    pub fn authorize_projects(&self, projects: impl IntoIterator<Item = ProjectId>) {
+        if let Ok(mut authorized) = self.authorized_projects.write() {
+            authorized.extend(projects);
+        }
+    }
+
+    pub fn is_authorized(&self, project_id: &str) -> bool {
+        self.authorized_projects
+            .read()
+            .map(|projects| projects.contains(project_id))
+            .unwrap_or(false)
+    }
+}
+
+/// protocol magic直後に置くproject scope。payload側のproject_idと必ず二重照合する。
+pub async fn write_project_id(send: &mut quinn::SendStream, project_id: &str) -> Result<()> {
+    let bytes = project_id.as_bytes();
+    if bytes.is_empty() || bytes.len() > MAX_PROJECT_ID_LEN {
+        return Err(SynergosNetError::Serialization(
+            "project_id length outside allowed range".into(),
+        ));
+    }
+    send.write_all(&(bytes.len() as u16).to_be_bytes())
+        .await
+        .map_err(|e| SynergosNetError::Quic(format!("project_id len write: {e}")))?;
+    send.write_all(bytes)
+        .await
+        .map_err(|e| SynergosNetError::Quic(format!("project_id write: {e}")))?;
+    Ok(())
+}
+
+pub async fn read_project_id(recv: &mut quinn::RecvStream) -> Result<ProjectId> {
+    let mut len = [0u8; 2];
+    recv.read_exact(&mut len)
+        .await
+        .map_err(|e| SynergosNetError::Quic(format!("project_id len read: {e}")))?;
+    let len = u16::from_be_bytes(len) as usize;
+    if len == 0 || len > MAX_PROJECT_ID_LEN {
+        return Err(SynergosNetError::Serialization(
+            "project_id length outside allowed range".into(),
+        ));
+    }
+    let mut bytes = vec![0u8; len];
+    recv.read_exact(&mut bytes)
+        .await
+        .map_err(|e| SynergosNetError::Quic(format!("project_id read: {e}")))?;
+    String::from_utf8(bytes)
+        .map_err(|_| SynergosNetError::Serialization("project_id is not UTF-8".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_denies_until_project_is_authorized() {
+        let session = ConnectionSession::new(PeerId::new("peer"));
+        assert!(!session.is_authorized("project-a"));
+        session.authorize_project("project-a".into());
+        assert!(session.is_authorized("project-a"));
+        assert!(!session.is_authorized("project-b"));
+    }
+}

--- a/synergos-net/src/transfer/mod.rs
+++ b/synergos-net/src/transfer/mod.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::error::{Result, SynergosNetError};
+use crate::quic::write_project_id;
 use crate::types::Blake3Hash;
 
 /// 1 チャンクあたりのバイト数 (64 KiB)。
@@ -200,6 +201,7 @@ where
     send.write_all(TRANSFER_STREAM_MAGIC)
         .await
         .map_err(|e| SynergosNetError::Quic(format!("write magic: {e}")))?;
+    write_project_id(&mut send, &header.project_id).await?;
     send_stream(reader, send, header).await
 }
 

--- a/synergos-net/src/transfer/mod.rs
+++ b/synergos-net/src/transfer/mod.rs
@@ -12,6 +12,7 @@
 //!   順次送る最小仕様。
 
 use std::path::Path;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -24,6 +25,12 @@ use crate::types::Blake3Hash;
 /// QUIC の congestion window を越えない範囲で十分大きく、かつ
 /// メモリ確保の一度あたりのサイズを抑える値。
 pub const CHUNK_SIZE: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TransferLimits {
+    pub max_file_size_bytes: u64,
+    pub transfer_timeout: Duration,
+}
 
 /// 転送ヘッダ (ストリームの先頭に 1 回だけ送る)。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,7 +117,27 @@ where
 
 /// 受信側: `reader` (QUIC bidi の recv side) から読み、検証しながら `out_path`
 /// へ書く。完了時にヘッダと一致する全体ハッシュを返す。
-pub async fn receive_stream<R>(mut reader: R, out_path: &Path) -> Result<TransferHeader>
+pub async fn receive_stream<R>(
+    reader: R,
+    out_path: &Path,
+    limits: TransferLimits,
+) -> Result<TransferHeader>
+where
+    R: AsyncRead + Unpin,
+{
+    tokio::time::timeout(
+        limits.transfer_timeout,
+        receive_stream_inner(reader, out_path, limits.max_file_size_bytes),
+    )
+    .await
+    .map_err(|_| SynergosNetError::Transfer("whole transfer deadline exceeded".into()))?
+}
+
+async fn receive_stream_inner<R>(
+    mut reader: R,
+    out_path: &Path,
+    max_file_size_bytes: u64,
+) -> Result<TransferHeader>
 where
     R: AsyncRead + Unpin,
 {
@@ -122,6 +149,12 @@ where
             ));
         }
     };
+    if header.total_size > max_file_size_bytes {
+        return Err(SynergosNetError::Transfer(format!(
+            "file size {} exceeds configured maximum {}",
+            header.total_size, max_file_size_bytes
+        )));
+    }
 
     // 親ディレクトリが無ければ作成
     if let Some(parent) = out_path.parent() {
@@ -132,11 +165,23 @@ where
     let mut file = tokio::fs::File::create(out_path).await?;
     let mut hasher = blake3::Hasher::new();
     let mut received_chunks: u64 = 0;
+    let mut received_bytes: u64 = 0;
 
     loop {
         let frame = read_frame(&mut reader).await?;
         match frame {
             FrameKind::Chunk(c) => {
+                received_bytes =
+                    received_bytes
+                        .checked_add(c.data.len() as u64)
+                        .ok_or_else(|| {
+                            SynergosNetError::Transfer("received byte count overflow".into())
+                        })?;
+                if received_bytes > header.total_size || received_bytes > max_file_size_bytes {
+                    return Err(SynergosNetError::Transfer(format!(
+                        "received bytes exceed declared/configured size: {received_bytes}"
+                    )));
+                }
                 let expected_hash = Blake3Hash(*blake3::hash(&c.data).as_bytes());
                 if expected_hash != c.hash {
                     return Err(SynergosNetError::Transfer(format!(
@@ -170,6 +215,12 @@ where
                     return Err(SynergosNetError::Transfer(format!(
                         "chunk count mismatch: expected {} got {}",
                         header.chunk_count, received_chunks
+                    )));
+                }
+                if received_bytes != header.total_size {
+                    return Err(SynergosNetError::Transfer(format!(
+                        "total size mismatch: expected {} got {}",
+                        header.total_size, received_bytes
                     )));
                 }
                 file.flush().await?;
@@ -207,8 +258,12 @@ where
 
 /// 受信ラッパ: magic は呼び出し側で既に消費済みの前提。QUIC recv half を
 /// そのまま `receive_stream` に渡す。
-pub async fn receive_over_quic(recv: quinn::RecvStream, out_path: &Path) -> Result<TransferHeader> {
-    receive_stream(recv, out_path).await
+pub async fn receive_over_quic(
+    recv: quinn::RecvStream,
+    out_path: &Path,
+    limits: TransferLimits,
+) -> Result<TransferHeader> {
+    receive_stream(recv, out_path, limits).await
 }
 
 /// ディスク上のファイルの全体 Blake3 ハッシュとサイズ + チャンク数を計算する。
@@ -279,6 +334,13 @@ mod tests {
     use super::*;
     use tokio::io::duplex;
 
+    fn limits() -> TransferLimits {
+        TransferLimits {
+            max_file_size_bytes: 1024 * 1024,
+            transfer_timeout: Duration::from_secs(1),
+        }
+    }
+
     #[tokio::test]
     async fn roundtrip_small_file() {
         // 10 KiB のランダムデータをメモリ上の双方向パイプで送受信する。
@@ -307,7 +369,7 @@ mod tests {
         let send_task =
             tokio::spawn(async move { send_stream(src_reader, tx, header.clone()).await });
         let dst_path = tmp_dst.clone();
-        let recv_task = tokio::spawn(async move { receive_stream(rx, &dst_path).await });
+        let recv_task = tokio::spawn(async move { receive_stream(rx, &dst_path, limits()).await });
 
         send_task.await.unwrap().unwrap();
         let recv_header = recv_task.await.unwrap().unwrap();
@@ -328,6 +390,7 @@ mod tests {
             receive_stream(
                 rx,
                 &std::env::temp_dir().join(format!("synergos-tx-tamper-{}", uuid::Uuid::new_v4())),
+                limits(),
             )
             .await
         });
@@ -356,5 +419,106 @@ mod tests {
 
         let err = recv.await.unwrap();
         assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn received_bytes_cannot_exceed_declared_total_size() {
+        let (mut tx, rx) = duplex(64 * 1024);
+        let out =
+            std::env::temp_dir().join(format!("synergos-tx-overrun-{}", uuid::Uuid::new_v4()));
+        let recv = tokio::spawn({
+            let out = out.clone();
+            async move { receive_stream(rx, &out, limits()).await }
+        });
+        let header = TransferHeader {
+            transfer_id: "t".into(),
+            project_id: "p".into(),
+            file_id: "f".into(),
+            total_size: 4,
+            chunk_count: 1,
+            total_hash: Blake3Hash(*blake3::hash(b"hello").as_bytes()),
+        };
+        write_frame(&mut tx, &FrameKind::Header(header))
+            .await
+            .unwrap();
+        write_frame(
+            &mut tx,
+            &FrameKind::Chunk(ChunkFrame {
+                index: 0,
+                hash: Blake3Hash(*blake3::hash(b"hello").as_bytes()),
+                data: b"hello".to_vec(),
+            }),
+        )
+        .await
+        .unwrap();
+        drop(tx);
+
+        assert!(recv.await.unwrap().is_err());
+        let _ = tokio::fs::remove_file(out).await;
+    }
+
+    #[tokio::test]
+    async fn configured_file_size_limit_is_enforced_before_create() {
+        let (mut tx, rx) = duplex(1024);
+        let out =
+            std::env::temp_dir().join(format!("synergos-tx-too-large-{}", uuid::Uuid::new_v4()));
+        write_frame(
+            &mut tx,
+            &FrameKind::Header(TransferHeader {
+                transfer_id: "t".into(),
+                project_id: "p".into(),
+                file_id: "f".into(),
+                total_size: 2,
+                chunk_count: 1,
+                total_hash: Blake3Hash::default(),
+            }),
+        )
+        .await
+        .unwrap();
+        let result = receive_stream(
+            rx,
+            &out,
+            TransferLimits {
+                max_file_size_bytes: 1,
+                transfer_timeout: Duration::from_secs(1),
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(!out.exists());
+    }
+
+    #[tokio::test]
+    async fn whole_transfer_deadline_is_enforced() {
+        let (mut tx, rx) = duplex(1024);
+        let out =
+            std::env::temp_dir().join(format!("synergos-tx-timeout-{}", uuid::Uuid::new_v4()));
+        write_frame(
+            &mut tx,
+            &FrameKind::Header(TransferHeader {
+                transfer_id: "t".into(),
+                project_id: "p".into(),
+                file_id: "f".into(),
+                total_size: 1,
+                chunk_count: 1,
+                total_hash: Blake3Hash::default(),
+            }),
+        )
+        .await
+        .unwrap();
+        let result = receive_stream(
+            rx,
+            &out,
+            TransferLimits {
+                max_file_size_bytes: 1024,
+                transfer_timeout: Duration::from_millis(10),
+            },
+        )
+        .await;
+        assert!(
+            matches!(result, Err(SynergosNetError::Transfer(message)) if message.contains("deadline"))
+        );
+        drop(tx);
+        let _ = tokio::fs::remove_file(out).await;
     }
 }

--- a/synergos-net/tests/bitswap_e2e.rs
+++ b/synergos-net/tests/bitswap_e2e.rs
@@ -51,7 +51,10 @@ async fn bitswap_fetch_single_block_over_quic() {
                     continue;
                 }
                 if &magic == BITSWAP_STREAM_MAGIC {
-                    let _ = handle_bitswap_stream(store_s.clone(), send, recv).await;
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
+                    let _ = handle_bitswap_stream(store_s.clone(), send, recv, &project_id).await;
                     break;
                 }
             }
@@ -68,7 +71,7 @@ async fn bitswap_fetch_single_block_over_quic() {
         .await
         .unwrap();
 
-    let resp = request_block(send, recv, &cid).await.unwrap();
+    let resp = request_block(send, recv, "p", &cid).await.unwrap();
     match resp {
         BitswapResponse::Block {
             cid: got_cid,
@@ -106,7 +109,10 @@ async fn bitswap_not_found_for_unknown_cid() {
                     continue;
                 }
                 if &magic == BITSWAP_STREAM_MAGIC {
-                    let _ = handle_bitswap_stream(store_s.clone(), send, recv).await;
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
+                    let _ = handle_bitswap_stream(store_s.clone(), send, recv, &project_id).await;
                     break;
                 }
             }
@@ -123,7 +129,7 @@ async fn bitswap_not_found_for_unknown_cid() {
         .unwrap();
 
     let cid = synergos_net::types::Cid("blake3-unknown".into());
-    let resp = request_block(send, recv, &cid).await.unwrap();
+    let resp = request_block(send, recv, "p", &cid).await.unwrap();
     matches!(resp, BitswapResponse::NotFound { .. });
 
     tokio::time::timeout(Duration::from_millis(200), server_task)
@@ -173,9 +179,12 @@ async fn chunker_plus_bitswap_reassembles_file() {
                     continue;
                 }
                 if &magic == BITSWAP_STREAM_MAGIC {
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
                     let s = store_s.clone();
                     tokio::spawn(async move {
-                        let _ = handle_bitswap_stream(s, send, recv).await;
+                        let _ = handle_bitswap_stream(s, send, recv, &project_id).await;
                     });
                 }
             }
@@ -195,7 +204,7 @@ async fn chunker_plus_bitswap_reassembles_file() {
         .open_stream(server_id.peer_id(), StreamType::Control)
         .await
         .unwrap();
-    match request_block(send, recv, &root).await.unwrap() {
+    match request_block(send, recv, "p", &root).await.unwrap() {
         BitswapResponse::Block { cid, bytes } => {
             client_store.put(Block { cid, bytes }).await.unwrap();
         }
@@ -210,7 +219,7 @@ async fn chunker_plus_bitswap_reassembles_file() {
             .open_stream(server_id.peer_id(), StreamType::Control)
             .await
             .unwrap();
-        match request_block(send, recv, chunk_cid).await.unwrap() {
+        match request_block(send, recv, "p", chunk_cid).await.unwrap() {
             BitswapResponse::Block { cid, bytes } => {
                 client_store.put(Block { cid, bytes }).await.unwrap();
             }

--- a/synergos-net/tests/bitswap_v2.rs
+++ b/synergos-net/tests/bitswap_v2.rs
@@ -37,9 +37,12 @@ fn spawn_bitswap_server(
                     continue;
                 }
                 if &magic == BITSWAP_STREAM_MAGIC {
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
                     let s = store.clone();
                     tokio::spawn(async move {
-                        let _ = handle_bitswap_stream(s, send, recv).await;
+                        let _ = handle_bitswap_stream(s, send, recv, &project_id).await;
                     });
                 }
             }
@@ -78,7 +81,7 @@ async fn wantlist_fetches_multiple_cids_in_one_stream() {
         .unwrap();
 
     let cids = vec![c1.clone(), c2.clone(), c3.clone()];
-    let resps = request_many(send, recv, &cids, false).await.unwrap();
+    let resps = request_many(send, recv, "p", &cids, false).await.unwrap();
     assert_eq!(resps.len(), 3);
     for (cid, r) in cids.iter().zip(resps.iter()) {
         match r {
@@ -124,7 +127,7 @@ async fn wantlist_mixes_block_and_notfound_in_request_order() {
         .unwrap();
 
     let cids = vec![c1.clone(), missing.clone(), c1.clone()];
-    let resps = request_many(send, recv, &cids, false).await.unwrap();
+    let resps = request_many(send, recv, "p", &cids, false).await.unwrap();
     assert_eq!(resps.len(), 3);
     matches!(resps[0], BitswapResponse::Block { .. });
     matches!(resps[1], BitswapResponse::NotFound { .. });
@@ -163,6 +166,7 @@ async fn have_query_returns_have_and_donthave() {
     let session = BitswapSession::new(
         quic_c.clone(),
         server_id.peer_id().clone(),
+        "p".into(),
         Arc::new(MemoryContentStore::new()),
     );
     let res = session
@@ -202,9 +206,13 @@ async fn cancel_closes_stream_without_error() {
         .open_stream(server_id.peer_id(), StreamType::Control)
         .await
         .unwrap();
-    send_cancel(send, &[synergos_net::types::Cid("blake3-whatever".into())])
-        .await
-        .unwrap();
+    send_cancel(
+        send,
+        "p",
+        &[synergos_net::types::Cid("blake3-whatever".into())],
+    )
+    .await
+    .unwrap();
 
     drop(quic_c);
     tokio::time::timeout(Duration::from_millis(300), server_task)
@@ -252,6 +260,7 @@ async fn session_fetch_dag_pulls_root_and_all_chunks() {
     let session = BitswapSession::new(
         quic_c.clone(),
         server_id.peer_id().clone(),
+        "p".into(),
         client_store.clone(),
     )
     .with_max_inflight(4);

--- a/synergos-net/tests/dht_find_node.rs
+++ b/synergos-net/tests/dht_find_node.rs
@@ -121,7 +121,7 @@ async fn find_peer_local_hit_short_circuits() {
     let transport = MockTransport::new();
     let opts = FindNodeOptions::default();
     let found = node
-        .find_peer_iterative(&target, &transport, opts)
+        .find_peer_iterative("project", &target, &transport, opts)
         .await
         .unwrap();
     assert_eq!(found.peer_id, target);
@@ -155,7 +155,7 @@ async fn find_peer_iterative_returns_exact_hit_from_neighbor() {
         ..Default::default()
     };
     let found = node
-        .find_peer_iterative(&target, &transport, opts)
+        .find_peer_iterative("project", &target, &transport, opts)
         .await
         .expect("target should be resolved via neighbor");
     assert_eq!(found.peer_id, target);
@@ -184,7 +184,7 @@ async fn find_peer_iterative_follows_closest_chain() {
     transport.set_response(n2.clone(), Some(dto(&target)), vec![]);
 
     let found = node
-        .find_peer_iterative(&target, &transport, FindNodeOptions::default())
+        .find_peer_iterative("project", &target, &transport, FindNodeOptions::default())
         .await
         .expect("target should be resolved after 2 hops");
     assert_eq!(found.peer_id, target);
@@ -219,7 +219,9 @@ async fn find_peer_iterative_respects_hop_limit() {
         alpha: 1,
         ..Default::default()
     };
-    let found = node.find_peer_iterative(&target, &transport, opts).await;
+    let found = node
+        .find_peer_iterative("project", &target, &transport, opts)
+        .await;
     assert!(
         found.is_none(),
         "hop limit must prevent resolving target at depth 3"
@@ -253,7 +255,9 @@ async fn find_peer_iterative_timeout_on_slow_peer() {
         ..Default::default()
     };
     let start = Instant::now();
-    let found = node.find_peer_iterative(&target, &transport, opts).await;
+    let found = node
+        .find_peer_iterative("project", &target, &transport, opts)
+        .await;
     assert!(found.is_none(), "slow peer should be timed-out");
     // 500ms 待たずに早期脱出していること
     assert!(start.elapsed() < Duration::from_millis(300));
@@ -267,6 +271,7 @@ async fn handle_request_find_node_returns_local_exact() {
 
     let resp = node
         .handle_request(DhtRequest::FindNode {
+            project_id: "project".into(),
             target: target.clone(),
         })
         .await;
@@ -282,6 +287,10 @@ async fn handle_request_find_node_returns_local_exact() {
 #[tokio::test]
 async fn handle_request_ping_pong() {
     let node = DhtNode::new(PeerId::new("self"), cfg());
-    let resp = node.handle_request(DhtRequest::Ping).await;
+    let resp = node
+        .handle_request(DhtRequest::Ping {
+            project_id: "project".into(),
+        })
+        .await;
     matches!(resp, DhtResponse::Pong);
 }

--- a/synergos-net/tests/dht_over_quic.rs
+++ b/synergos-net/tests/dht_over_quic.rs
@@ -71,7 +71,10 @@ async fn find_node_over_quic_resolves_target_via_server_announce() {
             while let Ok((send, mut recv)) = connection.accept_bi().await {
                 let mut magic = [0u8; 4];
                 if recv.read_exact(&mut magic).await.is_ok() && &magic == b"DHT1" {
-                    let _ = handle_dht_stream(sdht.clone(), send, recv).await;
+                    let project_id = synergos_net::quic::read_project_id(&mut recv)
+                        .await
+                        .unwrap();
+                    let _ = handle_dht_stream(sdht.clone(), send, recv, &project_id).await;
                 }
             }
         }
@@ -98,7 +101,7 @@ async fn find_node_over_quic_resolves_target_via_server_announce() {
         k: 20,
     };
     let found = client_dht
-        .find_peer_iterative(&target, transport.as_ref(), opts)
+        .find_peer_iterative("p", &target, transport.as_ref(), opts)
         .await;
     assert!(found.is_some(), "target must be resolvable via server");
     assert_eq!(found.unwrap().peer_id, target);


### PR DESCRIPTION
## What changed

- T1: registered project pathsだけを受信先として許可し、path traversal・absolute path・symlink escapeを拒否。project内tmpをRAIIでcleanupする。
- T7: HLO2 server nonce challengeとTLS exporter channel bindingを導入し、replay・stale timestamp・nonce reuseを拒否する。
- T8: connection sessionに`authorized_projects`を保持し、DHT/Gossip/Transfer/Bitswapをdispatcher入口で認可する。wire payload側の`project_id`も二重照合する。
- T9: config由来のfile size・deadline・connection・stream上限を導入し、slow Helloとunbounded spawnを防ぐ。

## Why

任意ファイル書込、HLO replay、project membership認可欠如、無制限resource消費を、2ノード疎通テスト再開前にsecurity boundaryとして閉じるため。

本件はsecurity boundaryの作り直しで1PRではレビュー不能になるため、承認済み計画に従いフェーズ単位で3PRへ分割した第1段です。

## Impact

- HLO1 clientはserver側で拒否され、HLO2が必須になる。
- 各protocol streamは明示的なproject scopeを持ち、認可外projectへ到達できない。
- 旧configはserde defaultでresource limit既定値へ移行する。

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked --offline -j 1 -- -D warnings`
- `cargo test --workspace --all-targets --locked --offline -j 1`

## 発見メモ

- T8着手時、DHT/Bitswap wireに`project_id`が存在しないことを確認。計画者判断で`project_id`追加方針を確定後、本PR内で対応した。
- その他のスコープ外問題に対するコード変更なし。
